### PR TITLE
ci: Fix jest memory usage in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           name: Run test suite
           command: |
             TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
-            yarn test --runInBand ${TESTFILES}
+            yarn test --ci --runInBand ${TESTFILES}
 
   publish:
     <<: *default_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           name: Run test suite
           command: |
             TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
-            yarn test ${TESTFILES}
+            yarn test --runInBand ${TESTFILES}
 
   publish:
     <<: *default_env


### PR DESCRIPTION
Using the `runInBand` option prevents jest from parallelizing tests, using more memory.

The `ci` option just causes the tests to fail when there are outdated snapshots, which doesn't affect us much now but it may in the future.