### PR TITLE
ci: simplify publishing config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,15 +109,8 @@ jobs:
       - checkout
       - *set_npm_token
       - run:
-          name: lerna version
-          command: yarn lerna version --include-merged-tags --conventional-commits --yes --create-release=github
-      - run:
           name: lerna publish
-          command: yarn lerna publish from-git --yes
-      - run:
-          # Storybook build will fail if there were no changed packages, but we still want to build
-          name: build packages
-          command: yarn build-all
+          command: yarn lerna publish --yes --include-merged-tags --conventional-commits --create-release=github
       - run:
           name: build storybook
           command: yarn build-storybook
@@ -150,11 +143,8 @@ jobs:
       - checkout
       - *set_npm_token
       - run:
-          name: lerna version (alpha)
-          command: yarn lerna version prerelease --include-merged-tags --conventional-commits --yes --no-push --preid=alpha.${CIRCLE_SHA1:0:6}
-      - run:
           name: lerna publish (alpha)
-          command: yarn lerna publish from-git --canary --yes --no-git-reset --preid=prerelease --dist-tag=prerelease
+          command: yarn lerna publish --yes --include-merged-tags --conventional-commits --no-push --canary --preid=alpha.${CIRCLE_SHA1:0:6} --no-git-reset --dist-tag=prerelease
 
 workflows:
   version: 2


### PR DESCRIPTION
Attempting to simplify the CI publishing workflow to just use `lerna publish`.

Our current config has been fragile over the years as lerna has updated, and is now pretty overcomplicated.