### PR TITLE
Corrected onChange prop for RadioGroup

### DIFF
--- a/packages/gamut/src/Form/RadioGroup.tsx
+++ b/packages/gamut/src/Form/RadioGroup.tsx
@@ -1,11 +1,15 @@
 import React, { cloneElement, HTMLAttributes } from 'react';
 
-export type RadioGroupProps = HTMLAttributes<HTMLDivElement> & {
-  children: any;
-  htmlForPrefix?: string;
-  name?: string;
-  selected?: string;
-};
+export type RadioGroupProps = Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> &
+  Pick<HTMLAttributes<HTMLInputElement>, 'onChange'> & {
+    /**
+     * @remarks This is meant to be `Radio`s.
+     */
+    children: any[];
+    htmlForPrefix?: string;
+    name?: string;
+    selected?: string;
+  };
 
 export const RadioGroup: React.FC<RadioGroupProps> = ({
   children,


### PR DESCRIPTION
The prop is passed to the children, which are expected to be input elements (from Radios). The typings were wrong.

Related to https://github.com/codecademy-engineering/Codecademy/pull/15076, where there's an unfortunate `as any` on an `e.target`...