### PR TITLE
Removed prop-types from gamut once and for all

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -36,6 +36,13 @@ module.exports = {
   rules: {
     // These off-by-default or configurable rules are good and we like having them on
     'no-only-tests/no-only-tests': 'error',
+    'react/prop-types': [
+      'error',
+      {
+        ignore: ['children'],
+        skipUndeclared: true,
+      },
+    ],
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -36,13 +36,6 @@ module.exports = {
   rules: {
     // These off-by-default or configurable rules are good and we like having them on
     'no-only-tests/no-only-tests': 'error',
-    'react/prop-types': [
-      'error',
-      {
-        ignore: ['children'],
-        skipUndeclared: true,
-      },
-    ],
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
 

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -32,7 +32,6 @@
     "lodash": "^4.17.5",
     "marked": "^0.6.0",
     "moment": "^2.24.0",
-    "prop-types": "^15.5.10",
     "react-aria-tabpanel": "^4.4.0",
     "react-truncate": "^2.4.0"
   },

--- a/packages/gamut/src/Button/index.tsx
+++ b/packages/gamut/src/Button/index.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, HTMLAttributes } from 'react';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
 import ButtonBase from '../ButtonBase';
 import omitProps from '../utils/omitProps';
@@ -15,23 +14,23 @@ export const presetThemes: { [i: string]: string } = {
   lantern: 'darkmint',
 };
 
-const propTypes = {
-  theme: PropTypes.string,
-  size: PropTypes.oneOf(['large', 'small']),
-  outline: PropTypes.bool,
-  underline: PropTypes.bool,
-  link: PropTypes.bool,
-  caps: PropTypes.bool,
-  go: PropTypes.bool,
-  children: PropTypes.node,
-  block: PropTypes.bool,
-  className: PropTypes.string,
-  round: PropTypes.bool,
-  square: PropTypes.bool,
-  flat: PropTypes.bool,
-  fitText: PropTypes.bool,
-  onClick: PropTypes.func,
-};
+const propKeys = [
+  'theme',
+  'size',
+  'outline',
+  'underline',
+  'link',
+  'caps',
+  'go',
+  'children',
+  'block',
+  'className',
+  'round',
+  'square',
+  'flat',
+  'fitText',
+  'onClick',
+];
 
 export type ButtonProps = HTMLAttributes<HTMLButtonElement> & {
   /**
@@ -93,7 +92,7 @@ export const Button = (props: ButtonProps) => {
     props.className
   );
 
-  const propsToTransfer = omitProps(propTypes, props);
+  const propsToTransfer = omitProps(propKeys, props);
 
   return (
     <ButtonBase
@@ -106,7 +105,5 @@ export const Button = (props: ButtonProps) => {
     </ButtonBase>
   );
 };
-
-Button.propTypes = propTypes;
 
 export default Button;

--- a/packages/gamut/src/ButtonBase/index.tsx
+++ b/packages/gamut/src/ButtonBase/index.tsx
@@ -1,17 +1,10 @@
 import React, { HTMLProps, ReactNode } from 'react';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omitProps from '../utils/omitProps';
 import styles from './styles.scss';
 import { ChildComponentDescriptor } from '../typings/react';
 
-const propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  href: PropTypes.string,
-  link: PropTypes.bool,
-  onClick: PropTypes.func,
-};
+const propKeys = ['children', 'className', 'href', 'link', 'onClick'];
 
 export type ButtonBaseProps = (
   | HTMLProps<HTMLLinkElement>
@@ -36,7 +29,7 @@ export type ButtonBaseProps = (
 export const ButtonBase = (props: ButtonBaseProps) => {
   const { href, className, link, onClick } = props;
   const { as: As, asProps = {}, ...restOfProps } = props;
-  const propsToTransfer = omitProps(propTypes, restOfProps);
+  const propsToTransfer = omitProps(propKeys, restOfProps);
 
   const classes = cx(styles.basicBtn, className, {
     [styles.basicLink]: link,
@@ -61,7 +54,5 @@ export const ButtonBase = (props: ButtonBaseProps) => {
 
   return <button {...defaultProps} />;
 };
-
-ButtonBase.propTypes = propTypes;
 
 export default ButtonBase;

--- a/packages/gamut/src/FlexGrid/Col.tsx
+++ b/packages/gamut/src/FlexGrid/Col.tsx
@@ -1,26 +1,21 @@
-import React, { ReactNode } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
 import omitProps from '../utils/omitProps';
 import style from './styles/index.scss';
 
-const ModificatorType = PropTypes.oneOfType([PropTypes.number, PropTypes.bool]);
-
-const propTypes = {
-  xs: ModificatorType,
-  sm: ModificatorType,
-  md: ModificatorType,
-  lg: ModificatorType,
-  xsOffset: PropTypes.number,
-  smOffset: PropTypes.number,
-  mdOffset: PropTypes.number,
-  lgOffset: PropTypes.number,
-  reverse: PropTypes.bool,
-  className: PropTypes.string,
-  tagName: PropTypes.string,
-  children: PropTypes.node,
-};
-
-const propKeys = Object.keys(propTypes);
+const propKeys = [
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xsOffset',
+  'smOffset',
+  'mdOffset',
+  'lgOffset',
+  'reverse',
+  'className',
+  'tagName',
+  'children',
+];
 
 const classMap = {
   xs: 'col-xs',
@@ -70,7 +65,6 @@ export type ColProps = {
   tagName?: string;
   className?: string;
   reverse?: boolean;
-  children?: ReactNode;
 };
 
 export const Col = (props: ColProps) => {
@@ -81,7 +75,5 @@ export const Col = (props: ColProps) => {
     omitProps(propKeys, { ...props, className })
   );
 };
-
-Col.propTypes = propTypes;
 
 export default Col;

--- a/packages/gamut/src/FlexGrid/Grid.tsx
+++ b/packages/gamut/src/FlexGrid/Grid.tsx
@@ -1,17 +1,9 @@
 import React, { ReactNode } from 'react';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omitProps from '../utils/omitProps';
 import style from './styles/index.scss';
 
-const propTypes = {
-  fluid: PropTypes.bool,
-  className: PropTypes.string,
-  tagName: PropTypes.string,
-  children: PropTypes.node,
-};
-
-const propKeys = Object.keys(propTypes);
+const propKeys = ['fluid', 'className', 'tagName', 'children'];
 
 export type GridProps = {
   children?: ReactNode | ReactNode[];
@@ -29,7 +21,5 @@ export const Grid = (props: GridProps) => {
     omitProps(propKeys, { ...props, className })
   );
 };
-
-Grid.propTypes = propTypes;
 
 export default Grid;

--- a/packages/gamut/src/FlexGrid/Row.tsx
+++ b/packages/gamut/src/FlexGrid/Row.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omitProps from '../utils/omitProps';
 import style from './styles/index.scss';
 
-const ModificatorType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
-const modificatorKeys = [
+const propKeys = [
+  'reverse',
   'start',
   'center',
   'end',
@@ -16,26 +15,10 @@ const modificatorKeys = [
   'between',
   'first',
   'last',
+  'className',
+  'tagName',
+  'children',
 ];
-
-const propTypes = {
-  reverse: PropTypes.bool,
-  start: ModificatorType,
-  center: ModificatorType,
-  end: ModificatorType,
-  top: ModificatorType,
-  middle: ModificatorType,
-  bottom: ModificatorType,
-  around: ModificatorType,
-  between: ModificatorType,
-  first: ModificatorType,
-  last: ModificatorType,
-  className: PropTypes.string,
-  tagName: PropTypes.string,
-  children: PropTypes.node,
-};
-
-const propKeys = Object.keys(propTypes);
 
 function getClassNames(props: RowProps) {
   const modificators = [style.row];
@@ -54,10 +37,35 @@ function getClassNames(props: RowProps) {
   return cx(props.className, modificators);
 }
 
+const modificatorKeys = [
+  'start',
+  'center',
+  'end',
+  'top',
+  'middle',
+  'bottom',
+  'around',
+  'between',
+  'first',
+  'last',
+];
+
+type ModificatorType = 'xs' | 'sm' | 'md' | 'lg';
+
 export type RowProps<TElement extends HTMLElement = HTMLElement> = {
+  around: ModificatorType;
+  between: ModificatorType;
+  bottom: ModificatorType;
+  center: ModificatorType;
   className?: string;
+  end: ModificatorType;
+  first: ModificatorType;
+  last: ModificatorType;
+  middle: ModificatorType;
   reverse?: boolean;
+  start: ModificatorType;
   tagName?: TElement['tagName'];
+  top: ModificatorType;
 };
 
 export const Row = <TElement extends HTMLElement = HTMLDivElement>(
@@ -68,7 +76,5 @@ export const Row = <TElement extends HTMLElement = HTMLDivElement>(
     omitProps(propKeys, { ...props, className: getClassNames(props) })
   );
 };
-
-Row.propTypes = propTypes;
 
 export default Row;

--- a/workspaces/gamut-storybook/package.json
+++ b/workspaces/gamut-storybook/package.json
@@ -52,7 +52,6 @@
     "moment": "2.24.0",
     "node-sass": "4.11.0",
     "postcss-loader": "3.0.0",
-    "prop-types": "15.7.2",
     "react": "16.9.0",
     "react-docgen-typescript-loader": "^3.3.0",
     "react-dom": "16.8.6",


### PR DESCRIPTION
I was in the area and remembered that we still use them... but the only reasons are to get prop key lists to omit. Begone!

Annoyingly, `yarn.lock` didn't update after a `yarn`, because we depend on packages that depend on them... ah well.