### PR TITLE
Bumped typescript-eslint to 2.7; added missing airbnb rules

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -35,7 +35,27 @@ module.exports = {
 
   rules: {
     // These off-by-default or configurable rules are good and we like having them on
+    eqeqeq: 'error',
+    'no-console': 'error',
+    'no-eval': 'error',
+    'no-global-assign': 'error',
+    'no-underscore-dangle': 'error',
     'no-only-tests/no-only-tests': 'error',
+    'prefer-destructuring': [
+      'error',
+      {
+        object: true,
+        array: false,
+      },
+    ],
+    'prefer-promise-reject-errors': 'error',
+    'react-hooks/exhaustive-deps': 'error',
+    'react-hooks/rules-of-hooks': 'error',
+    'react/button-has-type': 'error',
+    'react/no-access-state-in-setstate': 'error',
+    'react/no-array-index-key': 'error',
+    'react/no-danger': 'error',
+    'react/no-unused-state': 'error',
     'react/prop-types': [
       'error',
       {
@@ -43,8 +63,6 @@ module.exports = {
         skipUndeclared: true,
       },
     ],
-    'react-hooks/exhaustive-deps': 'error',
-    'react-hooks/rules-of-hooks': 'error',
 
     // These rules could be useful, but we haven't gotten around to trying them out
     '@typescript-eslint/array-type': 'off',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -20,8 +20,8 @@
     "eslint": "^6.5.1"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.6.1-alpha.0",
-    "@typescript-eslint/parser": "2.6.1-alpha.0",
+    "@typescript-eslint/eslint-plugin": "2.7.0",
+    "@typescript-eslint/parser": "2.7.0",
     "eslint-config-prettier": "6.4.0",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jsx-a11y": "6.2.3",

--- a/packages/gamut/src/ButtonBase/index.tsx
+++ b/packages/gamut/src/ButtonBase/index.tsx
@@ -59,6 +59,7 @@ export const ButtonBase = (props: ButtonBaseProps) => {
     return <a {...defaultProps} href={href} />;
   }
 
+  // eslint-disable-next-line react/button-has-type
   return <button {...defaultProps} />;
 };
 

--- a/packages/gamut/src/DeprecatedTabs/index.tsx
+++ b/packages/gamut/src/DeprecatedTabs/index.tsx
@@ -110,6 +110,7 @@ export class Tabs extends Component<TabsProps, TabsState> {
     let activeTabId;
     // which tab should be shown right now?
     if (this.state.activeTabId) {
+      // eslint-disable-next-line prefer-destructuring
       activeTabId = this.state.activeTabId;
     } else if (this.props.config.findIndex(c => c.default) !== -1) {
       activeTabId = this.createId(this.props.config.findIndex(c => c.default));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3829,46 +3829,47 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@2.6.1-alpha.0":
-  version "2.6.1-alpha.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1-alpha.0.tgz#1f443a4b420bd3718db5ebaf7c8a8f473c186cda"
-  integrity sha512-iUU4Qsv0Dg5ZG5zu/YkLa8aBt+OpGf94+y4MF0PTli3CnKYK1ARtQmH0wj72KawE8hc+bmLdRZnhxKWiT+WmtQ==
+"@typescript-eslint/eslint-plugin@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.7.0.tgz#dff176bdb73dfd7e2e43062452189bd1b9db6021"
+  integrity sha512-H5G7yi0b0FgmqaEUpzyBlVh0d9lq4cWG2ap0RKa6BkF3rpBb6IrAoubt1NWh9R2kRs/f0k6XwRDiDz3X/FqXhQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.6.1-alpha.0+5338955f"
+    "@typescript-eslint/experimental-utils" "2.7.0"
     eslint-utils "^1.4.2"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.6.1-alpha.0+5338955f":
-  version "2.6.1-alpha.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1-alpha.0.tgz#ee52ac6e330bc4994e2dd973b1124f97f3efdd7d"
-  integrity sha512-AO1kRwPM6Yk0J1/wt36rTZk1aISXXV/ggLMAeBO11SiF1Sp+FQ3KtXESzJ3ywk7g6alq9SztkO4byq7K4mcMWw==
+"@typescript-eslint/experimental-utils@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.7.0.tgz#58d790a3884df3041b5a5e08f9e5e6b7c41864b5"
+  integrity sha512-9/L/OJh2a5G2ltgBWJpHRfGnt61AgDeH6rsdg59BH0naQseSwR7abwHq3D5/op0KYD/zFT4LS5gGvWcMmegTEg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.6.1-alpha.0+5338955f"
+    "@typescript-eslint/typescript-estree" "2.7.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@2.6.1-alpha.0":
-  version "2.6.1-alpha.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.6.1-alpha.0.tgz#171c7b3279a4ab7c3bc0270a939abb76e661e034"
-  integrity sha512-luPQTohX8fQNyramat8I9n2z2l49INacVizkdkZIR5AsnR7C8fRCMf+iHEWzznr2dt0/us3bdYRl3nAVNRgqGg==
+"@typescript-eslint/parser@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.7.0.tgz#b5e6a4944e2b68dba1e7fbfd5242e09ff552fd12"
+  integrity sha512-ctC0g0ZvYclxMh/xI+tyqP0EC2fAo6KicN9Wm2EIao+8OppLfxji7KAGJosQHSGBj3TcqUrA96AjgXuKa5ob2g==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.6.1-alpha.0+5338955f"
-    "@typescript-eslint/typescript-estree" "2.6.1-alpha.0+5338955f"
+    "@typescript-eslint/experimental-utils" "2.7.0"
+    "@typescript-eslint/typescript-estree" "2.7.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.6.1-alpha.0+5338955f":
-  version "2.6.1-alpha.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1-alpha.0.tgz#11c93e6bb779eaaae6621291a959b1eb416075b7"
-  integrity sha512-zEKCecLG9vqcL175mDxI8JDTRtfI1Hij5wAvBkioiwFgwICnnkyfyiw0MXRIvTOJQlyHn0W3SORyDVTlWJNL8g==
+"@typescript-eslint/typescript-estree@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.7.0.tgz#34fd98c77a07b40d04d5b4203eddd3abeab909f4"
+  integrity sha512-vVCE/DY72N4RiJ/2f10PTyYekX2OLaltuSIBqeHYI44GQ940VCYioInIb8jKMrK9u855OEJdFC+HmWAZTnC+Ag==
   dependencies:
     debug "^4.1.1"
     glob "^7.1.4"
     is-glob "^4.0.1"
     lodash.unescape "4.0.1"
     semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"


### PR DESCRIPTION
I tested out the new version on the monolith in https://github.com/codecademy-engineering/Codecademy/pull/15093. You were right @jakemhiller, there were a few rules we like and used to have from the airbnb presets that we no longer do. They're mostly esoteric ones from the React rulesets that aren't enabled by default in their recommended config. I manually added them here.

This also bumps the typescript-eslint packages to 2.7.0 to get us that sweet performance improvement in https://github.com/typescript-eslint/typescript-eslint/pull/1179. It brings our monolith's prospective new lint time down from _10 minutes_ (!!) to _2_. Phew!