### PR TITLE
revert removal of id from default hashes

### DIFF
--- a/packages/webpack-config/src/config/common.js
+++ b/packages/webpack-config/src/config/common.js
@@ -25,8 +25,8 @@ const commonConfig = (options = {}) => {
     entry: path.resolve(options.context, 'src/main.js'),
 
     output: {
-      filename: DEV ? '[name].js' : '[contenthash].js',
-      chunkFilename: DEV ? '[name].chunk.js' : '[contenthash].chunk.js',
+      filename: DEV ? '[name].js' : '[name].[contenthash].js',
+      chunkFilename: DEV ? '[name].chunk.js' : '[name].[contenthash].chunk.js',
       path: path.resolve(options.context, 'dist'),
     },
 
@@ -38,7 +38,7 @@ const commonConfig = (options = {}) => {
               ...loaders.files.default,
               options: {
                 name: DEV
-                  ? '[name]-[contenthash].[ext]'
+                  ? '[name].[contenthash].[ext]'
                   : '[contenthash].[ext]',
               },
             },


### PR DESCRIPTION
Because the output file contains the id, this change wasn't really necessary.

As it's the more standard webpack setup, let's just stick with it until Webpack 5 and reassess.