### PR TITLE
ci: Move test coverage upload to a separate task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,11 @@ jobs:
           command: |
             TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
             yarn test --ci --runInBand ${TESTFILES} --coverage
-      - attach_workspace:
-          at: /tmp
       - run:
           name: Copy coverage files
           command: |
             mkdir -p /tmp/test-results/jest
-            cp ./coverage/clover.xml /tmp/test-results/jest/clover-${CIRCLE_NODE_INDEX}.xml
+            cp ./coverage/clover.xml /tmp/test-results/jest/${CIRCLE_NODE_INDEX}/clover.xml
       - store_artifacts:
           path: /tmp/test-results
       - store_test_results:
@@ -123,7 +121,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - codecov/upload:
-          file: /tmp/test-results/jest/*.xml
+          file: /tmp/test-results/jest
           flags: frontend
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
       - persist_to_workspace:
-          root: .
+          root: repo
           paths:
             - /tmp/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
     environment:
       GITHUB_BOT_USERNAME: codecademydev
       NODE_OPTIONS: "--max_old_space_size=4096"
-      JEST_JUNIT_OUTPUT_DIR: /tmp/test-results/jest
+
 
   repo_cache_key_1: &repo_cache_key_1 v1-repo-{{ arch}}-{{ .Branch }}-{{ .Revision }}
   repo_cache_key_2: &repo_cache_key_2 v1-repo-{{ arch}}-{{ .Branch }}
@@ -100,6 +100,11 @@ jobs:
           command: |
             TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
             yarn test --ci --runInBand ${TESTFILES} --coverage
+      - run:
+          name: Copy coverage files
+          command: |
+            mkdir /tmp/test-results/jest
+            cp ./coverage/clover.xml /tmp/test-results/jest/clover-${CIRCLE_NODE_INDEX}.xml
       - store_artifacts:
           path: /tmp/test-results
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,12 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - run:
+          name: Merge coverage
+          command: |
+            npx istanbul-merge --out /tmp/test-results/jest/coverage.all.json /tmp/test-results/jest/*
       - codecov/upload:
-          file: /tmp/test-results/jest/*
+          file: /tmp/test-results/jest/coverage.all.json
           flags: frontend
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
 
   tests:
     <<: *default_env
+    parallelism: 4
     resource_class: large
     steps:
       - *restore_repo
@@ -97,16 +98,42 @@ jobs:
       - run:
           name: Run test suite
           command: |
-            yarn test --ci --runInBand --coverage
+            TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
+            yarn test --ci --runInBand ${TESTFILES} --coverage
       - run:
           name: Copy coverage files
           command: |
             mkdir -p /tmp/test-results/jest
-            mv ./coverage/* /tmp/test-results/jest
+            cp ./coverage/coverage-final.json /tmp/test-results/jest/coverage-${CIRCLE_NODE_INDEX}.json
+      - store_artifacts:
+          path: /tmp/test-results
       - store_test_results:
           path: /tmp/test-results
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - test-results
+
+  upload_test_coverage:
+    <<: *default_env
+    steps:
+      - attach_workspace:
+          at: /tmp
+      # The codecov orb does not handle merging multiple files
+      # so the number of codecov upload steps should match the
+      # parallelism # of the tests job
       - codecov/upload:
-          file: /tmp/test-results/jest/*
+          file: /tmp/test-results/jest/coverage-0.json
+          upload_name: ${CIRCLE_BUILD_NUM}-0
+      - codecov/upload:
+          file: /tmp/test-results/jest/coverage-1.json
+          upload_name: ${CIRCLE_BUILD_NUM}-1
+      - codecov/upload:
+          file: /tmp/test-results/jest/coverage-2.json
+          upload_name: ${CIRCLE_BUILD_NUM}-2
+      - codecov/upload:
+          file: /tmp/test-results/jest/coverage-3.json
+          upload_name: ${CIRCLE_BUILD_NUM}-3
 
   publish:
     <<: *default_env
@@ -168,6 +195,9 @@ workflows:
       - tests:
           requires:
             - checkout_code
+      - upload_test_coverage:
+          requires:
+            - tests
       - verify_linting:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
     environment:
       GITHUB_BOT_USERNAME: codecademydev
       NODE_OPTIONS: "--max_old_space_size=4096"
-      CIRCLE_TEST_REPORTS: /tmp/test-results
+      JEST_JUNIT_OUTPUT_DIR: /tmp/test-results/jest
 
   repo_cache_key_1: &repo_cache_key_1 v1-repo-{{ arch}}-{{ .Branch }}-{{ .Revision }}
   repo_cache_key_2: &repo_cache_key_2 v1-repo-{{ arch}}-{{ .Branch }}
@@ -99,7 +99,7 @@ jobs:
           name: Run test suite
           command: |
             TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
-            JEST_JUNIT_OUTPUT_DIR="$CIRCLE_TEST_REPORTS/jest" yarn test --ci --runInBand ${TESTFILES} --coverage
+            yarn test --ci --runInBand ${TESTFILES} --coverage
       - store_artifacts:
           path: /tmp/test-results
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - codecov/upload:
-          file: /tmp/test-results/jest
+          file: /tmp/test-results/jest/**/*
           flags: frontend
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           name: Copy coverage files
           command: |
             mkdir -p /tmp/test-results/jest
-            cp ./coverage/coverage-final.json /tmp/test-results/jest/coverage-${CIRCLE_NODE_INDEX}.json
+            cp ./coverage/clover.xml /tmp/test-results/jest/clover.${CIRCLE_NODE_INDEX}.xml
       - store_artifacts:
           path: /tmp/test-results
       - store_test_results:
@@ -123,13 +123,13 @@ jobs:
       # so the number of codecov upload steps should match the
       # parallelism # of the tests job
       - codecov/upload:
-          file: /tmp/test-results/jest/coverage-0.json
+          file: /tmp/test-results/jest/clover.0.xml
       - codecov/upload:
-          file: /tmp/test-results/jest/coverage-1.json
+          file: /tmp/test-results/jest/clover.1.xml
       - codecov/upload:
-          file: /tmp/test-results/jest/coverage-2.json
+          file: /tmp/test-results/jest/clover.2.xml
       - codecov/upload:
-          file: /tmp/test-results/jest/coverage-3.json
+          file: /tmp/test-results/jest/clover.3.xml
 
   publish:
     <<: *default_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,13 +119,17 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
-      - run:
-          name: Merge coverage
-          command: |
-            npx istanbul-merge --out /tmp/test-results/jest/coverage.all.json /tmp/test-results/jest/*
+      # The codecov orb does not handle merging multiple files
+      # so the number of codecov upload steps should match the
+      # parallelism # of the tests job
       - codecov/upload:
-          file: /tmp/test-results/jest/coverage.all.json
-          flags: frontend
+          file: /tmp/test-results/jest/coverage-0.json
+      - codecov/upload:
+          file: /tmp/test-results/jest/coverage-1.json
+      - codecov/upload:
+          file: /tmp/test-results/jest/coverage-2.json
+      - codecov/upload:
+          file: /tmp/test-results/jest/coverage-3.json
 
   publish:
     <<: *default_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Copy coverage files
           command: |
-            mkdir -p /tmp/test-results/jest
+            mkdir -p /tmp/test-results/jest/${CIRCLE_NODE_INDEX}
             cp ./coverage/clover.xml /tmp/test-results/jest/${CIRCLE_NODE_INDEX}/clover.xml
       - store_artifacts:
           path: /tmp/test-results
@@ -117,7 +117,6 @@ jobs:
   upload_test_coverage:
     <<: *default_env
     steps:
-      - *restore_repo
       - attach_workspace:
           at: /tmp
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           name: Copy coverage files
           command: |
             mkdir -p /tmp/test-results/jest/${CIRCLE_NODE_INDEX}
-            cp ./coverage/clover.xml /tmp/test-results/jest/${CIRCLE_NODE_INDEX}/clover.xml
+            cp ./coverage/coverage-final.json /tmp/test-results/jest/coverage-${CIRCLE_NODE_INDEX}.json
       - store_artifacts:
           path: /tmp/test-results
       - store_test_results:
@@ -120,7 +120,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - codecov/upload:
-          file: /tmp/test-results/jest/**/*
+          file: /tmp/test-results/jest/*
           flags: frontend
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
       - *restore_repo
       - attach_workspace:
-          at: /tmp/test-results
+          at: /tmp
       - codecov/upload:
           file: /tmp/test-results/jest/*
           flags: frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Copy coverage files
           command: |
-            mkdir -p /tmp/test-results/jest/${CIRCLE_NODE_INDEX}
+            mkdir -p /tmp/test-results/jest
             cp ./coverage/coverage-final.json /tmp/test-results/jest/coverage-${CIRCLE_NODE_INDEX}.json
       - store_artifacts:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,9 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
       - persist_to_workspace:
-          root: repo
+          root: /tmp
           paths:
-            - /tmp/test-results
+            - test-results
 
   upload_test_coverage:
     <<: *default_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,8 @@ jobs:
           command: |
             TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
             yarn test --ci --runInBand ${TESTFILES} --coverage
+      - attach_workspace:
+          at: /tmp
       - run:
           name: Copy coverage files
           command: |
@@ -121,7 +123,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - codecov/upload:
-          file: /tmp/test-results/jest/*
+          file: /tmp/test-results/jest/*.xml
           flags: frontend
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ jobs:
 
   tests:
     <<: *default_env
-    parallelism: 4
     resource_class: large
     steps:
       - *restore_repo
@@ -98,38 +97,18 @@ jobs:
       - run:
           name: Run test suite
           command: |
-            TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
-            yarn test --ci --runInBand ${TESTFILES} --coverage
+            yarn test --ci --runInBand --coverage
       - run:
           name: Copy coverage files
           command: |
             mkdir -p /tmp/test-results/jest
-            cp ./coverage/clover.xml /tmp/test-results/jest/clover.${CIRCLE_NODE_INDEX}.xml
+            cp ./coverage/* /tmp/test-results/jest
       - store_artifacts:
           path: /tmp/test-results
       - store_test_results:
           path: /tmp/test-results
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - test-results
-
-  upload_test_coverage:
-    <<: *default_env
-    steps:
-      - attach_workspace:
-          at: /tmp
-      # The codecov orb does not handle merging multiple files
-      # so the number of codecov upload steps should match the
-      # parallelism # of the tests job
       - codecov/upload:
-          file: /tmp/test-results/jest/clover.0.xml
-      - codecov/upload:
-          file: /tmp/test-results/jest/clover.1.xml
-      - codecov/upload:
-          file: /tmp/test-results/jest/clover.2.xml
-      - codecov/upload:
-          file: /tmp/test-results/jest/clover.3.xml
+          file: /tmp/test-results/*
 
   publish:
     <<: *default_env
@@ -191,9 +170,6 @@ workflows:
       - tests:
           requires:
             - checkout_code
-      - upload_test_coverage:
-          requires:
-            - tests
       - verify_linting:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,6 @@ jobs:
           command: |
             mkdir -p /tmp/test-results/jest
             mv ./coverage/* /tmp/test-results/jest
-      - store_artifacts:
-          path: /tmp/test-results
       - store_test_results:
           path: /tmp/test-results
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Copy coverage files
           command: |
-            mkdir /tmp/test-results/jest
+            mkdir -p /tmp/test-results/jest
             cp ./coverage/clover.xml /tmp/test-results/jest/clover-${CIRCLE_NODE_INDEX}.xml
       - store_artifacts:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,8 @@ jobs:
           command: |
             TESTFILES=$(circleci tests glob "**/*-test.{jsx,tsx,js,ts}" | circleci tests split)
             JEST_JUNIT_OUTPUT_DIR="$CIRCLE_TEST_REPORTS/jest" yarn test --ci --runInBand ${TESTFILES} --coverage
+      - store_artifacts:
+          path: /tmp/test-results
       - store_test_results:
           path: /tmp/test-results
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,17 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR="$CIRCLE_TEST_REPORTS/jest" yarn test --ci --runInBand ${TESTFILES} --coverage
       - store_test_results:
           path: /tmp/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - /tmp/test-results
+
+  upload_test_coverage:
+    <<: *default_env
+    steps:
+      - *restore_repo
+      - attach_workspace:
+          at: /tmp/test-results
       - codecov/upload:
           file: /tmp/test-results/jest/*
           flags: frontend
@@ -166,6 +177,9 @@ workflows:
       - tests:
           requires:
             - checkout_code
+      - upload_test_coverage:
+          requires:
+            - tests
       - verify_linting:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           name: Copy coverage files
           command: |
             mkdir -p /tmp/test-results/jest
-            cp ./coverage/* /tmp/test-results/jest
+            mv ./coverage/* /tmp/test-results/jest
       - store_artifacts:
           path: /tmp/test-results
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
       - codecov/upload:
-          file: /tmp/test-results/*
+          file: /tmp/test-results/jest/*
 
   publish:
     <<: *default_env


### PR DESCRIPTION
Currently, if one of the parallel test running containers fails, the others will still upload test coverage, so you'll get a message from codecov saying you dropped coverage by a massive amount.

This moves the test coverage upload after the parallel tests, so it will only run if all tests pass