### PR TITLE
Allowed skipping tag processing in Markdown

### DIFF
--- a/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
@@ -72,7 +72,7 @@ describe('<Markdown />', () => {
 | col 3 is | right-aligned |    $1 |
     `;
     const markdown = mount(
-      <Markdown skipProcessing={{ table: true }} text={table} />
+      <Markdown skipDefaultOverrides={{ table: true }} text={table} />
     );
     expect(markdown.find('table').length).toEqual(1);
     expect(markdown.find('div.tableWrapper table').length).toEqual(0);

--- a/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
@@ -63,6 +63,21 @@ describe('<Markdown />', () => {
     });
   });
 
+  it('Skips rendering custom tables in markdown when skipProcessing.table is true', () => {
+    const table = `
+| Tables   |      Are      |  Cool |
+|----------|:-------------:|------:|
+| col 1 is |  left-aligned | $1600 |
+| col 2 is |    centered   |   $12 |
+| col 3 is | right-aligned |    $1 |
+    `;
+    const markdown = mount(
+      <Markdown skipProcessing={{ table: true }} text={table} />
+    );
+    expect(markdown.find('table').length).toEqual(1);
+    expect(markdown.find('div.tableWrapper table').length).toEqual(0);
+  });
+
   it('Wraps youtube iframes in a flexible container', () => {
     const markdown = mount(<Markdown text={youtubeMarkdown} />);
     expect(markdown.find('[data-testid="yt-iframe"]').length).toEqual(1);

--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -27,7 +27,7 @@ const isValidNode = function() {
   return true;
 };
 
-export type SkipProcessingSettings = {
+export type SkipDefaultOverridesSettings = {
   a?: boolean;
   iframe?: boolean;
   table?: boolean;
@@ -37,7 +37,7 @@ export type MarkdownProps = {
   className?: string;
   inline?: boolean;
   overrides?: ManyOverrideSettings;
-  skipProcessing?: SkipProcessingSettings;
+  skipDefaultOverrides?: SkipDefaultOverridesSettings;
   spacing?: 'loose' | 'tight' | 'none';
   text?: string;
 };
@@ -49,7 +49,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
       text = '',
       className,
       overrides: userOverrides = {},
-      skipProcessing = {},
+      skipDefaultOverrides = {},
       inline = false,
     } = this.props;
 
@@ -68,15 +68,15 @@ export class Markdown extends PureComponent<MarkdownProps> {
     });
 
     const processingInstructions = [
-      !skipProcessing.iframe &&
+      !skipDefaultOverrides.iframe &&
         createTagOverride('iframe', {
           component: Iframe,
         }),
-      !skipProcessing.a &&
+      !skipDefaultOverrides.a &&
         createTagOverride('a', {
           component: Anchor,
         }),
-      !skipProcessing.table &&
+      !skipDefaultOverrides.table &&
         createTagOverride('table', {
           component: props => (
             <Table maxHeight={spacing === 'tight' ? 180 : 500} {...props} />

--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -27,13 +27,20 @@ const isValidNode = function() {
   return true;
 };
 
-export interface MarkdownProps {
+export type SkipProcessingSettings = {
+  a?: boolean;
+  iframe?: boolean;
+  table?: boolean;
+};
+
+export type MarkdownProps = {
   className?: string;
   inline?: boolean;
   overrides?: ManyOverrideSettings;
+  skipProcessing?: SkipProcessingSettings;
   spacing?: 'loose' | 'tight' | 'none';
   text?: string;
-}
+};
 
 export class Markdown extends PureComponent<MarkdownProps> {
   render() {
@@ -42,6 +49,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
       text = '',
       className,
       overrides: userOverrides = {},
+      skipProcessing = {},
       inline = false,
     } = this.props;
 
@@ -60,21 +68,24 @@ export class Markdown extends PureComponent<MarkdownProps> {
     });
 
     const processingInstructions = [
-      createTagOverride('iframe', {
-        component: Iframe,
-      }),
-      createTagOverride('a', {
-        component: Anchor,
-      }),
-      createTagOverride('table', {
-        component: props => (
-          <Table maxHeight={spacing === 'tight' ? 180 : 500} {...props} />
-        ),
-        allowedAttributes: ['style'],
-      }),
+      !skipProcessing.iframe &&
+        createTagOverride('iframe', {
+          component: Iframe,
+        }),
+      !skipProcessing.a &&
+        createTagOverride('a', {
+          component: Anchor,
+        }),
+      !skipProcessing.table &&
+        createTagOverride('table', {
+          component: props => (
+            <Table maxHeight={spacing === 'tight' ? 180 : 500} {...props} />
+          ),
+          allowedAttributes: ['style'],
+        }),
       ...overrides,
       ...standardOverrides,
-    ];
+    ].filter(Boolean);
 
     const markedOptions = {
       smartypants: true,


### PR DESCRIPTION
The fancy table addition isn't always desirable. On our /policy page, for example, we just want a regular non-sticky table. See https://github.com/codecademy-engineering/Codecademy/pull/15335.
