### PR TITLE
gamut-icons adjustments

### DIFF
--- a/packages/gamut-icons/icon-template.js
+++ b/packages/gamut-icons/icon-template.js
@@ -8,7 +8,7 @@ function iconTemplate(
   return typeScriptTpl.ast`
     import * as React from 'react';
     export interface GamutIconProps extends React.SVGProps<SVGSVGElement> {
-      size?: number;
+      size?: number | string;
       title?: string;
       color?: string;
     }

--- a/packages/gamut-icons/svgr.config.js
+++ b/packages/gamut-icons/svgr.config.js
@@ -5,12 +5,13 @@ module.exports = {
   dimensions: false,
   titleProp: true,
   svgProps: {
-    width: '{size || width || "1em"}',
-    height: '{size || height || "1em"}',
+    width: '{size || width || "16px"}',
+    height: '{size || height || "16px"}',
     fill: '{color || "currentColor"}',
     role: 'img',
   },
   replaceAttrValues: {
+    currentColor: '{color || "currentColor"}',
     '#000': '{color || "currentColor"}',
     '#111': '{color || "currentColor"}',
     '#444': '{color || "currentColor"}',


### PR DESCRIPTION
Sets a default size instead of using `1em` to match the text size. We never used that sizing before so replacing the icons on the site with `gamut-icons` will be more difficult if we do that.

Also adds `currentColor` to the attribute overrides, a few icons authored with `currentColor` were not getting the color prop applied.