### PR TITLE
Used gray-500 for toggle unchecked state

### DIFF
--- a/packages/gamut/src/Toggle/styles/index.module.scss
+++ b/packages/gamut/src/Toggle/styles/index.module.scss
@@ -20,7 +20,7 @@
   height: 1.8rem;
   padding: 0;
   border-radius: 99rem;
-  background-color: $deprecated-swatches-grey-200;
+  background-color: $color-gray-500;
   transition: all 0.2s ease;
 }
 
@@ -35,7 +35,7 @@
   width: 1.38rem;
   height: 1.38rem;
   border-radius: 99rem;
-  background-color: $deprecated-gamut-white;
+  background-color: $color-white;
   transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1);
 }
 


### PR DESCRIPTION
Per Sarah's request to fix the accessibility issue.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img alt="After state screenshot" src="https://user-images.githubusercontent.com/3335181/71272590-a2c60200-2321-11ea-9b9a-bacf39213f28.png" />
</td>
<td>
<img alt="Before state screenshot" src="https://user-images.githubusercontent.com/3335181/71272343-917cf580-2321-11ea-9ad3-da5df75768c1.png" />
</td>
</tr>
</tbody>
</table>

https://codecademy.atlassian.net/browse/A11Y-208