### PR TITLE
Added HTMLInputElement types to Radio props

### DIFF
--- a/packages/gamut/src/Form/Radio.tsx
+++ b/packages/gamut/src/Form/Radio.tsx
@@ -1,11 +1,10 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, HTMLAttributes } from 'react';
 import cx from 'classnames';
 import s from './styles/Radio.module.scss';
 
-export type RadioProps = {
+export type RadioProps = HTMLAttributes<HTMLInputElement> & {
   checked?: boolean;
   disabled?: boolean;
-  className?: string;
   htmlFor?: string;
   id?: string;
   label?: ReactNode;


### PR DESCRIPTION
They're spread onto the input node, so this was an overly limited props type before.
