### PR TITLE
fix: use safer method to pull out markdown language prop

### DIFF
--- a/packages/gamut-templates/package.json
+++ b/packages/gamut-templates/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "verify": "tsc --noEmit",
     "build:clean": "rm -rf dist",
-    "build:copy": "copyfiles -u 1 -a -e './**/*[!.d].ts' -e './**/*.tsx' './src/**/*' ./dist",
-    "build": "yarn build:clean && yarn build:copy && tsc"
+    "build:copy": "copyfiles -u 1 -a -e './**/*[!.d].ts' -e './**/*.tsx' './src/**/*' ./dist"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
@@ -98,7 +98,7 @@ describe('<Markdown />', () => {
       const text = `
 # Heading
 
-\`\`\`
+\`\`\`js
 var test = true;
 \`\`\`
       `;
@@ -115,6 +115,7 @@ var test = true;
 
       const markdown = mount(<Markdown text={text} overrides={overrides} />);
       expect(markdown.find(CodeBlock).length).toEqual(1);
+      expect((markdown.find(CodeBlock).props() as any).language).toEqual('js');
     });
 
     it('When specifying a <code /> element override with a custom CodeBlock override, the CodeBlock wins', () => {

--- a/packages/gamut/src/Markdown/libs/overrides/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/index.tsx
@@ -109,7 +109,7 @@ export const createCodeBlockOverride = (
     },
 
     processNode(node: HTMLToReactNode, props: any) {
-      const [, language] =
+      const [, language = undefined] =
         (props.className && props.className.match(/language-([^\s]+)/)) || [];
 
       return (

--- a/packages/gamut/src/Markdown/libs/overrides/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/index.tsx
@@ -109,8 +109,8 @@ export const createCodeBlockOverride = (
     },
 
     processNode(node: HTMLToReactNode, props: any) {
-      const language =
-        props.className && props.className.replace('language-', '');
+      const [, language] =
+        (props.className && props.className.match(/language-([^\s]+)/)) || [];
 
       return (
         <Override.component {...props} language={language}>


### PR DESCRIPTION
Because we were using string replacement to pull out the language of code blocks, introducing a new class name broke syntax highlighting.

in this case because we derive the language from the class name, and the class name was `code language-js`, we passed the language down to the code block override as `code js`, instead of `js`.