### PR TITLE
Used FormHTMLAttributes for Select props

### DIFF
--- a/packages/gamut/src/Form/Select.tsx
+++ b/packages/gamut/src/Form/Select.tsx
@@ -1,13 +1,11 @@
-import React, { ReactNode, HTMLAttributes } from 'react';
+import React, { ReactNode, FormHTMLAttributes } from 'react';
 import { isArray, isObject, each } from 'lodash';
 import cx from 'classnames';
 import s from './styles/Select.module.scss';
 
-export type SelectProps = HTMLAttributes<HTMLSelectElement> & {
-  className?: string;
-  defaultValue?: string;
+export type SelectProps = FormHTMLAttributes<HTMLSelectElement> & {
   htmlFor?: string;
-  options?: string[] | {};
+  options?: string[] | Record<string, string>;
 };
 
 export const Select: React.FC<SelectProps> = props => {

--- a/packages/gamut/src/Form/Select.tsx
+++ b/packages/gamut/src/Form/Select.tsx
@@ -5,7 +5,7 @@ import s from './styles/Select.module.scss';
 
 export type SelectProps = FormHTMLAttributes<HTMLSelectElement> & {
   htmlFor?: string;
-  options?: string[] | Record<string, string>;
+  options?: string[] | Record<string, number | string>;
 };
 
 export const Select: React.FC<SelectProps> = props => {


### PR DESCRIPTION
This is more correct. For https://github.com/codecademy-engineering/Codecademy/pull/15761, I want `onChange` events to have a `target.value`. They don't prior to this change.