### PR TITLE
Allowed all notification items to be focusable

### DIFF
--- a/packages/gamut/src/NotificationList/NotificationItem.tsx
+++ b/packages/gamut/src/NotificationList/NotificationItem.tsx
@@ -31,13 +31,15 @@ export const NotificationItem: React.FC<NotificationItemProps> = props => {
     [s.unread]: unread,
   });
 
-  const TagName = link ? 'a' : 'div';
-  const tagProps = link ? { target: '_blank' } : { role: 'presentation' };
+  const [TagName, tagProps] = link
+    ? ([
+        'a',
+        { href: link, rel: 'noopener noreferrer', target: '_blank' },
+      ] as const)
+    : (['button', { type: 'button' }] as const);
 
   return (
     <TagName
-      href={link}
-      rel="noopener noreferrer"
       className={cx(notificationClasses)}
       onClick={onClick}
       {...tagProps}

--- a/packages/gamut/src/NotificationList/__tests__/NotificationItem-test.tsx
+++ b/packages/gamut/src/NotificationList/__tests__/NotificationItem-test.tsx
@@ -26,11 +26,22 @@ describe('NotificationItem', () => {
     expect(renderedNotification.name()).toBe('a');
   });
 
-  it('renders a div if no href is specified', () => {
+  it('renders a button if no href is specified', () => {
     const renderedNotification = shallow(
       <NotificationItem notification={noLinkNotification} />
     );
 
-    expect(renderedNotification.name()).toBe('div');
+    expect(renderedNotification.name()).toBe('button');
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    const renderedNotification = shallow(
+      <NotificationItem notification={noLinkNotification} onClick={onClick} />
+    );
+
+    renderedNotification.find('button').simulate('click');
+
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/gamut/src/NotificationList/styles/Notification.module.scss
+++ b/packages/gamut/src/NotificationList/styles/Notification.module.scss
@@ -1,12 +1,14 @@
 @import "~@codecademy/gamut-styles/utils";
 
 .notification {
+  background: none;
   width: 100%;
   padding: 1rem 1.5rem;
   display: flex;
   align-items: flex-start;
   font-size: 0.875rem;
   color: $color-black;
+  border: none;
   border-bottom: 1px solid $color-gray-200;
 
   &.unread {


### PR DESCRIPTION
We can't have `<div>`s because the notification list needs to contain at least one focusable item. If the only notification is for a streak, it needs to be a `<button>`.

Simulating most of the properties of a notification _(looks like I missed the main text, heh)_ to verify the styles don't look all weird and button-y:

![Screen Shot 2020-02-05 at 9 29 07 AM](https://user-images.githubusercontent.com/3335181/73850707-341e0480-47fa-11ea-8367-9e6f63b63cab.png)
