### PR TITLE
Clean up the codecov PR comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ jobs:
           path: /tmp/test-results
       - codecov/upload:
           file: /tmp/test-results/jest/*
-          flags: frontend
           conf: codecov.yml
 
   publish:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,5 @@ codecov:
 comment:
   # Must be the # of parallel test builds in CircleCI
   after_n_builds: 4
+  layout: "diff, files"
+  require_changes: yes


### PR DESCRIPTION
I've been noticing that the graph on the codecov comment usually doesn't reflect the actual coverage status, so I'm removing it from the comment.