### PR TITLE
fix: markdown styling: do not override code color

### DIFF
--- a/packages/gamut/src/Markdown/styles/_mixins.scss
+++ b/packages/gamut/src/Markdown/styles/_mixins.scss
@@ -88,7 +88,7 @@
     padding: 0 0.25rem;
     margin: 0 0.0625rem;
     border-radius: 0.125rem;
-    color: inherit;
+    color: $deprecated-gamut-purple-900;
     background-color: mix(
       $deprecated-swatches-grey-200,
       $deprecated-swatches-grey-100
@@ -106,6 +106,7 @@
       white-space: pre-wrap;
       padding: 0;
       margin: 0;
+      color: inherit;
       background-color: transparent;
       font-family: $font-monospace;
     }

--- a/packages/gamut/src/Markdown/styles/_mixins.scss
+++ b/packages/gamut/src/Markdown/styles/_mixins.scss
@@ -88,7 +88,7 @@
     padding: 0 0.25rem;
     margin: 0 0.0625rem;
     border-radius: 0.125rem;
-    color: $deprecated-gamut-purple-900;
+    color: inherit;
     background-color: mix(
       $deprecated-swatches-grey-200,
       $deprecated-swatches-grey-100


### PR DESCRIPTION
## Fix bug

https://codecademy.atlassian.net/browse/LX-3565

where LaTeX is showing up as dark text in quiz answers