### PR TITLE
Left aligned notification button text

### DIFF
--- a/packages/gamut/src/NotificationList/styles/Notification.module.scss
+++ b/packages/gamut/src/NotificationList/styles/Notification.module.scss
@@ -10,6 +10,7 @@
   color: $color-black;
   border: none;
   border-bottom: 1px solid $color-gray-200;
+  text-align: left;
 
   &.unread {
     background-color: rgba($color-blue-500, 0.1);


### PR DESCRIPTION
My change to make those notifications focusable by making them `<button>`s centered the text. Oy.

Before:

![image](https://user-images.githubusercontent.com/3335181/74259480-f3286300-4cc5-11ea-99b8-2d3f25bb0880.png)

After:

![image](https://user-images.githubusercontent.com/3335181/74259533-0b987d80-4cc6-11ea-9cb3-b44e111c6ec9.png)
