### PR TITLE
fix: Add missing blockquote styles to markdown

### DIFF
--- a/packages/gamut/src/Markdown/styles/_mixins.scss
+++ b/packages/gamut/src/Markdown/styles/_mixins.scss
@@ -125,4 +125,20 @@
   .iframe {
     width: 100%;
   }
+
+  .blockquote {
+    display: block;
+    font-family: $font-family-base;
+    padding-left: $base-margin;
+    border-left: ($base-margin / 2) solid $color-gray-200;
+    margin: 0;
+    margin-bottom: $base-margin;
+    font-style: italic;
+    // The Markdown processor combines multiple lines
+    // into a single tag if the same tag repeats line to line
+    // this is mainly for `<p>` tags since that's the default
+    > * {
+      white-space: pre-wrap;
+    }
+  }
 }

--- a/packages/styleguide/stories/Markdown/Markdown.stories.js
+++ b/packages/styleguide/stories/Markdown/Markdown.stories.js
@@ -20,7 +20,7 @@ This is markdown
 
     `
     )}
-    theme={select('theme', ['tight', 'loose', 'none'])}
+    spacing={select('spacing', ['tight', 'loose'])}
   />
 );
 
@@ -37,7 +37,7 @@ basics.story = {
 export const fullExample = () => (
   <Markdown
     text={text('markdown', exampleMarkdown)}
-    theme={select('theme', ['tight', 'loose', 'none'])}
+    spacing={select('spacing', ['tight', 'loose'])}
   />
 );
 
@@ -63,7 +63,7 @@ This is a custom markdown component
 <CustomElement title="A Custom Component" />
     `
     )}
-    theme={select('theme', ['tight', 'loose', 'none'])}
+    spacing={select('spacing', ['tight', 'loose'])}
     overrides={{
       CodeBlock: {
         component: props => <span style={{ color: 'blue' }} {...props} />,
@@ -110,7 +110,7 @@ export const inlineMarkdown = () => (
     tempor incididunt ut labore et dolore magna aliqua.
     <Markdown
       text={text('markdown', '`this is an inline markdown component`')}
-      theme={select('theme', ['tight', 'loose', 'none'])}
+      spacing={select('spacing', ['tight', 'loose'])}
       inline
     />
     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut


### PR DESCRIPTION
Previously these just looked like normal paragraphs.

![Screenshot 2020-02-11 18 02 07](https://user-images.githubusercontent.com/238023/74288276-02290880-4cfa-11ea-9442-f98d857f40c8.png)
