### PR TITLE
initialize Brand Component package with Avatar component

### DIFF
--- a/packages/brand-components/CHANGELOG.md
+++ b/packages/brand-components/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/brand-components/README.md
+++ b/packages/brand-components/README.md
@@ -1,0 +1,24 @@
+# Brand Components
+
+## Component Guidelines
+
+1. The Brand Components package will be used for components that are more tied to brand representation and/or marketing purposes. These are components that might be more frequently subject to style updates do their nature, but are not just solely used in the main Codecademy monolith app. (e.g., a brand component might also be used in a Gatsby hosted campaign page)
+
+## When to add a component to Brand Components
+
+When considering whether to add a component to Gamut, answer these questions:
+
+1. Is this component more tied to brand representation/marketing purposes than say a [Button in the Gamut package](https://github.com/Codecademy/client-modules/tree/master/packages/gamut/src/Button).
+2. Is this component or some version of it used across all or most new React based applications at Codecademy?
+
+## box-sizing
+
+Brand Components expect `box-sizing: border-box` to be applied to all elements on the page globally. If it isn't there already, add something like this to your application's global stylesheet:
+
+```css
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+```

--- a/packages/brand-components/README.md
+++ b/packages/brand-components/README.md
@@ -8,7 +8,7 @@
 
 When considering whether to add a component to Gamut, answer these questions:
 
-1. Is this component more tied to brand representation/marketing purposes than say a [Button in the Gamut package](https://github.com/Codecademy/client-modules/tree/master/packages/gamut/src/Button).
+1. Is this component more tied to brand representation/marketing purposes than say a [Button in the Gamut package](../gamut/src/Button).
 2. Is this component or some version of it used across all or most new React based applications at Codecademy?
 
 ## box-sizing

--- a/packages/brand-components/babel.config.js
+++ b/packages/brand-components/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: ['codecademy', '@babel/preset-typescript'],
+  include: ['./src/**/*'],
+  ignore: ['__tests__', './**/*.d.ts'],
+};

--- a/packages/brand-components/package.json
+++ b/packages/brand-components/package.json
@@ -30,8 +30,5 @@
     "build": "yarn build:clean && yarn build:compile && yarn build:types",
     "prepublishOnly": "yarn build"
   },
-  "license": "MIT",
-  "devDependencies": {
-    "copyfiles": "^2.1.1"
-  }
+  "license": "MIT"
 }

--- a/packages/brand-components/package.json
+++ b/packages/brand-components/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@codecademy/brand-components",
+  "description": "Brand component library for Codecademy",
+  "version": "0.0.1",
+  "author": "Codecademy Engineering <dev@codecademy.com>",
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
+  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Codecademy/client-modules.git"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.1",
+    "react-dom": ">=16.8.1"
+  },
+  "dependencies": {
+    "@codecademy/gamut": "^2.4.6",
+    "@codecademy/gamut-styles": "^2.2.11",
+    "classnames": "^2.2.5"
+  },
+  "scripts": {
+    "verify": "tsc --noEmit",
+    "build:compile": "babel ./src --out-dir ./dist --copy-files --copy-ignored --extensions \".ts,.tsx\"",
+    "build:clean": "rm -rf dist",
+    "build:types": "tsc --emitDeclarationOnly",
+    "build": "yarn build:clean && yarn build:compile && yarn build:types",
+    "prepublishOnly": "yarn build"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "copyfiles": "^2.1.1"
+  }
+}

--- a/packages/brand-components/src/Avatar/__tests__/avatar-test.tsx
+++ b/packages/brand-components/src/Avatar/__tests__/avatar-test.tsx
@@ -1,0 +1,52 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { VisualTheme } from '../../../../gamut/src/theming/VisualTheme';
+
+import { Avatar } from '..';
+import styles from '../../styles.module.scss';
+
+describe('Avatar', () => {
+  it('when an "alt" prop is passed, an "alt" attribute is added to the <img/>', () => {
+    const wrapper = mount(<Avatar src="" alt="alt" />);
+
+    expect(wrapper.find('img[alt="alt"]')).toHaveLength(1);
+  });
+
+  it('when an "aria-labelledby" prop is passed, an "aria-labelledby" attribute is added to the <img/>', () => {
+    const wrapper = mount(
+      <>
+        <Avatar src="" aria-labelledby="label" />
+        <h1 id="label">I is label</h1>
+      </>
+    );
+    expect(wrapper.find('img[aria-labelledby="label"]')).toHaveLength(1);
+  });
+
+  it('adds the light class to the container name as a default', () => {
+    const wrapper = mount(<Avatar src="" alt="" />);
+
+    const containerClassName = wrapper.find(`div`).prop('className');
+
+    expect(containerClassName).toContain(styles.lightContainer);
+  });
+
+  it('adds the light class to the container name when its theme is light', () => {
+    const wrapper = mount(
+      <Avatar src="" theme={VisualTheme.LightMode} alt="" />
+    );
+
+    const containerClassName = wrapper.find(`div`).prop('className');
+
+    expect(containerClassName).toContain(styles.lightContainer);
+  });
+
+  it('adds the dark class to the container name when its theme is dark', () => {
+    const wrapper = mount(
+      <Avatar src="" theme={VisualTheme.DarkMode} alt="" />
+    );
+
+    const containerClassName = wrapper.find(`div`).prop('className');
+
+    expect(containerClassName).toContain(styles.darkContainer);
+  });
+});

--- a/packages/brand-components/src/Avatar/index.tsx
+++ b/packages/brand-components/src/Avatar/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import s from './styles.module.scss';
+import cx from 'classnames';
+import { VisualTheme } from '../../../gamut/src/theming/VisualTheme';
+
+type AvatarImageProps =
+  | {
+      alt: string;
+      'aria-labelledby'?: never;
+    }
+  | { alt?: never; 'aria-labelledby': string };
+
+export type AvatarBaseProps = {
+  src: string;
+  size?: 'regular' | 'large';
+  theme?: VisualTheme;
+};
+
+type AvatarProps = AvatarBaseProps & AvatarImageProps;
+
+export const Avatar: React.FC<AvatarProps> = ({
+  size = 'regular',
+  theme = VisualTheme.LightMode,
+  ...avatarImageProps
+}) => {
+  return (
+    <div
+      className={cx(
+        s.container,
+        s[`${size}Container`],
+        theme === VisualTheme.DarkMode ? s.darkContainer : s.lightContainer
+      )}
+    >
+      {/*  The current rules for alt-text don't allow images with aria-labelledby to have no alt. So, we need to disable the rule for that line. https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/411#issue-306995775 */}
+      {/* eslint-disable-next-line jsx-a11y/alt-text */}
+      <img className={cx(s.image, s[`${size}Image`])} {...avatarImageProps} />
+    </div>
+  );
+};
+
+export default Avatar;

--- a/packages/brand-components/src/Avatar/styles.module.scss
+++ b/packages/brand-components/src/Avatar/styles.module.scss
@@ -1,0 +1,62 @@
+@import "~@codecademy/gamut-styles/utils";
+
+$regular-size: 70px;
+$regular-offset: 6px;
+$large-size: 110px;
+$large-offset: 8px;
+
+.container {
+  position: relative;
+  &:before {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    z-index: -1;
+    border-radius: 50%;
+  }
+}
+
+.regularContainer {
+  width: $regular-size + $regular-offset;
+  height: $regular-size + $regular-offset;
+  &:before {
+    height: $regular-size;
+    width: $regular-size;
+  }
+}
+
+.largeContainer {
+  width: $large-size + $large-offset;
+  height: $large-size + $large-offset;
+  &:before {
+    height: $large-size;
+    width: $large-size;
+  }
+}
+
+.lightContainer {
+  &:before {
+    background: $color-orange-400;
+  }
+}
+
+.darkContainer {
+  &:before {
+    background: $color-pink-700;
+  }
+}
+
+.regularImage {
+  width: $regular-size;
+  height: $regular-size;
+}
+
+.largeImage {
+  width: $large-size;
+  height: $large-size;
+}
+
+.image {
+  border-radius: 50%;
+}

--- a/packages/brand-components/src/index.ts
+++ b/packages/brand-components/src/index.ts
@@ -1,0 +1,1 @@
+export { default as Avatar } from './Avatar';

--- a/packages/brand-components/src/typings/css.d.ts
+++ b/packages/brand-components/src/typings/css.d.ts
@@ -1,0 +1,9 @@
+declare module '*.css' {
+  const styles: { [i: string]: any };
+  export default styles;
+}
+
+declare module '*.scss' {
+  const styles: { [i: string]: any };
+  export default styles;
+}

--- a/packages/brand-components/src/typings/svg.d.ts
+++ b/packages/brand-components/src/typings/svg.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  const imageUrl: string;
+
+  export default imageUrl;
+}

--- a/packages/brand-components/tsconfig.json
+++ b/packages/brand-components/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+      "./src/**/*.ts",
+      "./src/**/*.tsx"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/packages/styleguide/stories/Avatar.stories.js
+++ b/packages/styleguide/stories/Avatar.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Avatar } from '../../brand-components/src/Avatar/';
+import { VisualTheme } from '../../gamut/src/theming/VisualTheme';
+import { withKnobs, select } from '@storybook/addon-knobs';
+
+export default {
+  component: Avatar,
+  title: 'Brand/Avatar',
+  decorators: [withKnobs],
+};
+
+export const avatar = () => (
+  <Avatar
+    src="https://content.codecademy.com/courses/free/boba.svg"
+    alt="testy"
+    size={select('size', ['regular', 'large'], 'regular')}
+    theme={select(
+      'theme',
+      [VisualTheme.LightMode, VisualTheme.DarkMode],
+      VisualTheme.LightMode
+    )}
+  />
+);
+
+avatar.story = {
+  name: 'Avatar used in Brand components',
+};


### PR DESCRIPTION
## Creates the Brand Component package

[The Brand Components package will be used for components that are more tied to brand representation and/or marketing purposes. These are components that might be more frequently subject to style updates do their nature, but are not just solely used in the main Codecademy monolith app. (e.g., a brand component might also be used in a Gatsby hosted campaign page)](https://github.com/Codecademy/client-modules/blob/86671ea7005ae43cf0fa528e8bd7775b9694fe14/packages/brand-components/README.md#component-guidelines)

Also includes the first component in the package:
#631

---

## Merging your changes

When you are ready to merge to master, use the "squash and merge" button in GitHub, and follow the [commit message guide](/README.md#commit-message-guide) to write your commit message.
