### PR TITLE
fix: testimonial component background pattern

### DIFF
--- a/packages/brand-components/src/Testimonial/__tests__/Testimonial-test.tsx
+++ b/packages/brand-components/src/Testimonial/__tests__/Testimonial-test.tsx
@@ -28,7 +28,7 @@ describe('Testimonial', () => {
       .first()
       .prop('className');
 
-    expect(containerClassName).toContain(styles.lightContainer);
+    expect(containerClassName).toContain(styles.lightWrapper);
   });
 
   it('adds the dark class to the container name when its theme is dark', () => {
@@ -45,6 +45,6 @@ describe('Testimonial', () => {
       .first()
       .prop('className');
 
-    expect(containerClassName).toContain(styles.darkContainer);
+    expect(containerClassName).toContain(styles.darkWrapper);
   });
 });

--- a/packages/brand-components/src/Testimonial/index.tsx
+++ b/packages/brand-components/src/Testimonial/index.tsx
@@ -25,23 +25,35 @@ export const Testimonial: React.FC<TestimonialProps> = ({
 }) => {
   return (
     <div
-      className={cx(s.contentContainer, s[`${size}Container`], {
-        [s.darkContainer]: theme === VisualTheme.DarkMode,
-        [s.lightContainer]: theme === VisualTheme.LightMode,
+      className={cx(s.testimonialWrapper, {
+        [s.darkWrapper]: theme === VisualTheme.DarkMode,
+        [s.lightWrapper]: theme === VisualTheme.LightMode,
       })}
     >
-      <div className={s.avatarContainer}>
-        <Avatar
-          src={testimonial.imageUrl}
-          alt={`Photo of ${testimonial.name}`}
-          theme={theme}
-        />
-      </div>
-      <div className={cx(s.bylineContainer, s[`${size}Byline`])}>
-        <Byline name={testimonial.name} occupation={testimonial.occupation} />
-      </div>
-      <div className={s.quoteContainer}>
-        <Quote text={testimonial.quote} theme={theme} />
+      <div className={s.testimonialCardContainer}>
+        <div
+          className={cx(s.contentContainer, s[`${size}Container`], {
+            [s.darkContainer]: theme === VisualTheme.DarkMode,
+            [s.lightContainer]: theme === VisualTheme.LightMode,
+          })}
+        >
+          <div className={s.avatarContainer}>
+            <Avatar
+              src={testimonial.imageUrl}
+              alt={`Photo of ${testimonial.name}`}
+              theme={theme}
+            />
+          </div>
+          <div className={cx(s.bylineContainer, s[`${size}Byline`])}>
+            <Byline
+              name={testimonial.name}
+              occupation={testimonial.occupation}
+            />
+          </div>
+          <div className={s.quoteContainer}>
+            <Quote text={testimonial.quote} theme={theme} />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/brand-components/src/Testimonial/styles.module.scss
+++ b/packages/brand-components/src/Testimonial/styles.module.scss
@@ -1,5 +1,7 @@
 @import "~@codecademy/gamut-styles/utils";
 
+$background-pattern-offset: px-rem(16px);
+
 .testimonialWrapper {
   position: relative;
   width: fit-content;
@@ -10,8 +12,8 @@
     bottom: 0;
     background-image: url("./assets/dots.svg");
     background-repeat: repeat;
-    height: calc(100% - 1rem);
-    width: calc(100% - 1rem);
+    height: calc(100% - #{$background-pattern-offset});
+    width: calc(100% - #{$background-pattern-offset});
   }
 }
 
@@ -31,8 +33,7 @@
 
 .testimonialCardContainer {
   display: grid;
-  grid-template-columns: max-content 1rem;
-  grid-template-rows: max-content 1rem;
+  grid-template: max-content #{$background-pattern-offset} / max-content #{$background-pattern-offset};
 }
 
 .contentContainer {

--- a/packages/brand-components/src/Testimonial/styles.module.scss
+++ b/packages/brand-components/src/Testimonial/styles.module.scss
@@ -1,24 +1,47 @@
 @import "~@codecademy/gamut-styles/utils";
 
-.contentContainer {
-  display: grid;
+.testimonialWrapper {
   position: relative;
+  width: fit-content;
   &::before {
     content: "";
     position: absolute;
-    left: 1rem;
-    top: 2rem;
+    right: 0;
+    bottom: 0;
     background-image: url("./assets/dots.svg");
     background-repeat: repeat;
     height: calc(100% - 1rem);
-    width: 100%;
-    z-index: -1;
+    width: calc(100% - 1rem);
   }
+}
+
+.darkWrapper {
+  &::before {
+    filter: invert(72%) sepia(58%) saturate(2004%) hue-rotate(266deg)
+      brightness(99%) contrast(103%);
+  }
+}
+
+.lightWrapper {
+  &::before {
+    filter: invert(49%) sepia(85%) saturate(1427%) hue-rotate(-20deg)
+      brightness(100%) contrast(233%);
+  }
+}
+
+.testimonialCardContainer {
+  display: grid;
+  grid-template-columns: max-content 1rem;
+  grid-template-rows: max-content 1rem;
+}
+
+.contentContainer {
+  display: grid;
+  position: relative;
 }
 
 .smallContainer {
   padding: 1.75rem 1.5rem 2rem;
-  width: calc(100% - 1rem);
   max-width: px-rem(396px);
   grid-template-columns: auto 1fr;
   grid-gap: 1rem;
@@ -30,19 +53,11 @@
 .darkContainer {
   background-color: $brand-dark-blue;
   color: $color-white;
-  &::before {
-    filter: invert(72%) sepia(58%) saturate(2004%) hue-rotate(266deg)
-      brightness(99%) contrast(103%);
-  }
 }
 
 .lightContainer {
   background-color: $color-white;
   color: $brand-dark-blue;
-  &::before {
-    filter: invert(49%) sepia(85%) saturate(1427%) hue-rotate(-20deg)
-      brightness(100%) contrast(233%);
-  }
 }
 
 .avatarContainer {


### PR DESCRIPTION
## Learner Testimonial Style Update

**Prior**: The background shape image was absolutely positioned on the card itself, and had used `z-index` to display correctly.

<img width="552" alt="Screen Shot 2020-02-25 at 4 34 41 PM" src="https://user-images.githubusercontent.com/17210163/75289879-3f5ac380-57ed-11ea-8e1a-4f3ce83ec35f.png">
<img width="547" alt="Screen Shot 2020-02-25 at 4 34 35 PM" src="https://user-images.githubusercontent.com/17210163/75289882-3f5ac380-57ed-11ea-9e4e-e53128e5e9cd.png">

This meant that if the parent of the element had a background color, the pattern would _disappear_ D:

<img width="654" alt="Screen Shot 2020-02-25 at 4 34 20 PM" src="https://user-images.githubusercontent.com/17210163/75289889-441f7780-57ed-11ea-99ed-f2af14aa0bf3.png">


**Change**: 
I wanted to ensure that card and shape were self-contained within a parent component that would wrap it all together. (And not use z-index)

<img width="564" alt="Screen Shot 2020-02-25 at 4 34 56 PM" src="https://user-images.githubusercontent.com/17210163/75289980-6e713500-57ed-11ea-8e1f-62b8f7e46be9.png">

<img width="626" alt="Screen Shot 2020-02-25 at 4 34 07 PM" src="https://user-images.githubusercontent.com/17210163/75289987-7335e900-57ed-11ea-8671-bdf793651375.png">


### Notes:

<img width="534" alt="Screen Shot 2020-02-25 at 4 25 01 PM" src="https://user-images.githubusercontent.com/17210163/75290006-7df07e00-57ed-11ea-8404-12745974a2f6.png">

The implementation here was to use two wrapping divs.

The highest div in the hierarchy would be used to display the shape using pseudo selectors.

The second highest div would wrap the testimonial card in a `grid` display and use `grid-template` to specify that the first child (the card) should sized according to itself (`max-content` : The intrinsic preferred width.)

Then the second value for `grid-template`, `#{$background-pattern-offset}`, would ensure that the grid had an additional column and row to display the background shape correctly.

---

## Merging your changes

When you are ready to merge to master, use the "squash and merge" button in GitHub, and follow the [commit message guide](/README.md#commit-message-guide) to write your commit message.
