### PR TITLE
ci: restrict imports from stories to the module src folders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,17 @@ references:
         echo "Build started due to commit by ${CIRCLE_USERNAME}, blocking builds started by ${GITHUB_BOT_USERNAME}"
         if [ $CIRCLE_USERNAME == $GITHUB_BOT_USERNAME ] ; then circleci step halt ; fi
 
+  skip_if_not_pr: &skip_if_not_pr
+    run:
+      name: Ensure workflow is associated with a pull request
+      command: |
+        prNumber="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
+
+        if [[ -z "${prNumber}" ]]; then
+          echo "This workflow is not associated with a pull request; halting"
+          circleci-agent step halt
+        fi
+
   add_github_ssh_key: &add_github_ssh_key
     add_ssh_keys:
       fingerprints:
@@ -162,6 +173,7 @@ jobs:
     <<: *default_env
     resource_class: large
     steps:
+      - *skip_if_not_pr
       - *skip_on_automated_commit
       - *add_github_ssh_key
       - *set_git_user
@@ -210,6 +222,7 @@ jobs:
     <<: *default_env
     resource_class: large
     steps:
+      - *skip_if_not_pr
       - *skip_on_automated_commit
       - *add_github_ssh_key
       - *set_git_user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ references:
       name: Skip build from automated commit
       command: |
         echo "Build started due to commit by ${CIRCLE_USERNAME}, blocking builds started by ${GITHUB_BOT_USERNAME}"
-        if [ $CIRCLE_USERNAME == $GITHUB_BOT_USERNAME ] ; then circleci step halt ; fi
+        if [ $CIRCLE_USERNAME == $GITHUB_BOT_USERNAME ] ; then circleci-agent step halt ; fi
 
   skip_if_not_pr: &skip_if_not_pr
     run:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,11 @@ const defaultConfig = require('./packages/eslint-config');
 
 module.exports = {
   ...defaultConfig,
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json', './packages/*/tsconfig.json'],
+  },
   overrides: [
     {
       files: ['*.js'],

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,10 @@
 codecov:
   require_ci_to_pass: yes
+  notify:
+    after_n_builds: 4 # Must be the # of parallel test builds in CircleCI
+    wait_for_ci: yes
 
 comment:
   after_n_builds: 4 # Must be the # of parallel test builds in CircleCI
   layout: "diff, files"
-  require_changes: yes
+  require_changes: true

--- a/packages/styleguide/.eslintrc.js
+++ b/packages/styleguide/.eslintrc.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  overrides: [
+    {
+      files: ['stories/**/*'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: '@codecademy/gamut',
+                message: 'Please import directly from the `gamut/src` folder',
+              },
+            ],
+            patterns: [
+              '@codecademy/*',
+              '!@codecademy/gamut-icons',
+              '../**/dist',
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/styleguide/stories/Avatar.stories.js
+++ b/packages/styleguide/stories/Avatar.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Avatar } from '../../brand-components/src/Avatar/';
-import { VisualTheme } from '@codecademy/gamut';
+import { VisualTheme } from '../../gamut/src';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import styles from './Avatar-story.scss';
 

--- a/packages/styleguide/stories/Quote.stories.js
+++ b/packages/styleguide/stories/Quote.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Quote } from '../../brand-components/src/Quote/';
-import { VisualTheme } from '@codecademy/gamut';
+import { VisualTheme } from '../../gamut/src';
 import styles from './Quote-story.scss';
 
 export default {

--- a/packages/styleguide/stories/Testimonial.stories.js
+++ b/packages/styleguide/stories/Testimonial.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Testimonial } from '../../brand-components/src/Testimonial/';
-import { VisualTheme } from '@codecademy/gamut';
+import { VisualTheme } from '../../gamut/src';
 import { withKnobs, select } from '@storybook/addon-knobs';
 
 export default {


### PR DESCRIPTION
This adds linting rules to restrict imports from the `./stories` folder to `@codecademy` modules and `../../gamut/dist` & co.

The reason for this is that when these imports exist, the styleguide is referencing code that might not exist if you didn't run `yarn build-all`. It also means we're referencing compiled code in storybook, which is meant to use the source code directly.

---

## Merging your changes

When you are ready to merge to master, use the "squash and merge" button in GitHub, and follow the [commit message guide](/README.md#commit-message-guide) to write your commit message.
