### PR TITLE
chore: mentioned gamut-icons in deprecation messages for icons

### DIFF
--- a/packages/gamut/src/Icon/iconMap.tsx
+++ b/packages/gamut/src/Icon/iconMap.tsx
@@ -73,7 +73,7 @@ import VideoIcon from './icons/VideoIcon';
 import jQueryIcon from './icons/jQueryIcon';
 
 /**
- * @deprecated Directly import icons from @codecademy/gamut instead.
+ * @deprecated Directly import icons from @codecademy/gamut-icons instead.
  */
 const iconMap = {
   accessibility: AccessibilityIcon,
@@ -153,6 +153,6 @@ const iconMap = {
 };
 
 /**
- * @deprecated Directly import icons from @codecademy/gamut instead.
+ * @deprecated Directly import icons from @codecademy/gamut-icons instead.
  */
 export default iconMap;

--- a/packages/gamut/src/Icon/index.tsx
+++ b/packages/gamut/src/Icon/index.tsx
@@ -2,7 +2,7 @@ import React, { SVGProps, HTMLAttributes } from 'react';
 import iconMap from './iconMap';
 
 /**
- * @deprecated Directly import icons from @codecademy/gamut instead.
+ * @deprecated Directly import icons from @codecademy/gamut-icons instead.
  */
 export type IconPropsDeprecated = HTMLAttributes<SVGElement> &
   SVGProps<SVGSVGElement> & {
@@ -14,7 +14,7 @@ export type IconPropsDeprecated = HTMLAttributes<SVGElement> &
   };
 
 /**
- * @deprecated Directly import icons from @codecademy/gamut instead.
+ * @deprecated Directly import icons from @codecademy/gamut-icons instead.
  */
 export function Icon({ name, size, ...props }: IconPropsDeprecated) {
   const MappedIcon = iconMap[name];


### PR DESCRIPTION
## Mentioned gamut-icons in deprecation messages for icons

That's the new location, right?