### PR TITLE
fix: Allow `className` prop to override all styles

### DIFF
--- a/packages/gamut/src/Tabs/Tab/index.tsx
+++ b/packages/gamut/src/Tabs/Tab/index.tsx
@@ -24,9 +24,8 @@ export const Tab: FunctionComponent<TabProps> = ({
   onChange = () => {},
   tabIndex = 0,
 }: TabProps) => {
-  const tabLinkClasses = cx(s.tab, {
+  const tabLinkClasses = cx(s.tab, className, {
     [s.active]: active,
-    [className]: className !== undefined,
     [activeClassName]: active && activeClassName !== undefined,
   });
   return (

--- a/packages/gamut/src/Tabs/Tab/index.tsx
+++ b/packages/gamut/src/Tabs/Tab/index.tsx
@@ -26,6 +26,7 @@ export const Tab: FunctionComponent<TabProps> = ({
 }: TabProps) => {
   const tabLinkClasses = cx(s.tab, {
     [s.active]: active,
+    [className]: className !== undefined,
     [activeClassName]: active && activeClassName !== undefined,
   });
   return (


### PR DESCRIPTION
## Fix: Allow `className` prop to override all styles

I am pretty sure this was unitentional, but please correct me if I'm wrong.

We allow the `<Tab />` component to have additional styles through the props `className` and `activeClassName`. However, in the `tabLinkClasses` object that we pass to the `<a>` tag, we don't include `className` (only `activeClassName`). The result of this is that certain styling of the `<a>` link cannot be overriden by `className`. Border color is one example of this. There may be others.

In this PR I propose we resolve this by including `className` in `tabLinkClasses`. If there is a better way to handle this, I'm open to alternatives.
