### PR TITLE
feat: add `testimonial` object prop to Testimonial component

### DIFF
--- a/packages/brand-components/src/Testimonial/__tests__/Testimonial-test.tsx
+++ b/packages/brand-components/src/Testimonial/__tests__/Testimonial-test.tsx
@@ -6,10 +6,10 @@ import { Testimonial } from '..';
 import styles from '../../styles.module.scss';
 
 const exampleTestmonial = {
-  name: 'Frank Reynolds',
+  firstName: 'Frank',
+  lastName: 'Reynolds',
   occupation: "Co-Owner @ Paddy's Pub",
-  imageUrl: '',
-  short_quote:
+  quote:
     "I don't know how many years on this Earth I got left, I'm gonna get real weird with it.",
 };
 
@@ -17,9 +17,7 @@ describe('Testimonial', () => {
   it('adds the light class to the wrapper container when its theme is light', () => {
     const wrapper = mount(
       <Testimonial
-        name={exampleTestmonial.name}
-        occupation={exampleTestmonial.occupation}
-        quote={exampleTestmonial.short_quote}
+        testimonial={exampleTestmonial}
         size="small"
         theme={VisualTheme.LightMode}
       />
@@ -35,9 +33,7 @@ describe('Testimonial', () => {
   it('adds the dark class to the wrapper container when its theme is dark', () => {
     const wrapper = mount(
       <Testimonial
-        name={exampleTestmonial.name}
-        occupation={exampleTestmonial.occupation}
-        quote={exampleTestmonial.short_quote}
+        testimonial={exampleTestmonial}
         size="small"
         theme={VisualTheme.DarkMode}
       />
@@ -53,9 +49,7 @@ describe('Testimonial', () => {
   it('adds the small class to the content container when its size is small', () => {
     const wrapper = mount(
       <Testimonial
-        name={exampleTestmonial.name}
-        occupation={exampleTestmonial.occupation}
-        quote={exampleTestmonial.short_quote}
+        testimonial={exampleTestmonial}
         size="small"
         theme={VisualTheme.DarkMode}
       />
@@ -71,9 +65,7 @@ describe('Testimonial', () => {
   it('adds the medium class to the content container when its size is medium', () => {
     const wrapper = mount(
       <Testimonial
-        name={exampleTestmonial.name}
-        occupation={exampleTestmonial.occupation}
-        quote={exampleTestmonial.short_quote}
+        testimonial={exampleTestmonial}
         size="medium"
         theme={VisualTheme.DarkMode}
       />
@@ -89,9 +81,7 @@ describe('Testimonial', () => {
   it('adds the large class to the content container when its size is large', () => {
     const wrapper = mount(
       <Testimonial
-        name={exampleTestmonial.name}
-        occupation={exampleTestmonial.occupation}
-        quote={exampleTestmonial.short_quote}
+        testimonial={exampleTestmonial}
         size="large"
         theme={VisualTheme.DarkMode}
       />
@@ -107,10 +97,7 @@ describe('Testimonial', () => {
   it('renders the Avatar component when an imageUrl prop is present', () => {
     const wrapper = mount(
       <Testimonial
-        name={exampleTestmonial.name}
-        occupation={exampleTestmonial.occupation}
-        quote={exampleTestmonial.short_quote}
-        imageUrl="someCoolUrl"
+        testimonial={{ ...exampleTestmonial, imageUrl: 'someCoolUrl' }}
         size="small"
         theme={VisualTheme.DarkMode}
       />
@@ -124,9 +111,7 @@ describe('Testimonial', () => {
   it('does _not_ render the Avatar component when an imageUrl prop is _not_ present', () => {
     const wrapper = mount(
       <Testimonial
-        name={exampleTestmonial.name}
-        occupation={exampleTestmonial.occupation}
-        quote={exampleTestmonial.short_quote}
+        testimonial={exampleTestmonial}
         size="small"
         theme={VisualTheme.DarkMode}
       />

--- a/packages/brand-components/src/Testimonial/index.tsx
+++ b/packages/brand-components/src/Testimonial/index.tsx
@@ -25,14 +25,7 @@ export const Testimonial: React.FC<TestimonialProps> = ({
   size,
   theme,
 }) => {
-  const {
-    firstName,
-    lastName,
-    occupation,
-    quote,
-    company,
-    imageUrl,
-  } = testimonial;
+  const { firstName, lastName, occupation, quote, imageUrl } = testimonial;
   return (
     <div
       className={cx(s.testimonialWrapper, {

--- a/packages/brand-components/src/Testimonial/index.tsx
+++ b/packages/brand-components/src/Testimonial/index.tsx
@@ -5,23 +5,34 @@ import cx from 'classnames';
 
 import s from './styles.module.scss';
 
-type TestimonialProps = {
-  name: string;
+export type Testimonial = {
+  firstName: string;
+  lastName: string;
   occupation: string;
   quote: string;
+  company?: string;
   imageUrl?: string;
+};
+
+type TestimonialProps = {
+  testimonial: Testimonial;
   size: 'small' | 'medium' | 'large';
   theme: VisualTheme;
 };
 
 export const Testimonial: React.FC<TestimonialProps> = ({
-  name,
-  occupation,
-  imageUrl,
-  quote,
+  testimonial,
   size,
   theme,
 }) => {
+  const {
+    firstName,
+    lastName,
+    occupation,
+    quote,
+    company,
+    imageUrl,
+  } = testimonial;
   return (
     <div
       className={cx(s.testimonialWrapper, {
@@ -35,14 +46,14 @@ export const Testimonial: React.FC<TestimonialProps> = ({
             <div className={s.avatarContainer}>
               <Avatar
                 src={imageUrl}
-                alt={`Photo of ${name}`}
+                alt={`Photo of ${firstName} ${lastName}`}
                 theme={theme}
                 className={cx({ [s.largeContainerAvatar]: size === 'large' })}
               />
             </div>
           )}
           <div className={s.bylineContainer}>
-            <Byline name={name} occupation={occupation} />
+            <Byline name={`${firstName} ${lastName}`} occupation={occupation} />
           </div>
           <div className={s.quoteContainer}>
             <Quote text={quote} theme={theme} />

--- a/packages/styleguide/stories/Testimonial.stories.js
+++ b/packages/styleguide/stories/Testimonial.stories.js
@@ -9,31 +9,27 @@ export default {
   decorators: [withKnobs],
 };
 
-const laceyTestimonialProps = {
-  name: 'Lacey Bathala',
+const short_quote =
+  "Coding isn't rocket science, it’s just falsely intimidating.";
+const long_quote =
+  'If it weren’t for Codecademy, I’d probably be in my old job. Codecademy enabled me to learn quick lessons between calls, on my lunch break, while multitasking. It was fun and easy and I went from 0 coding skills to a promotion within 6 months.';
+const imageUrl = 'https://content.codecademy.com/courses/free/boba.svg';
+
+const laceyTestimonial = {
+  firstName: 'Lacey',
+  lastName: 'Bathala',
   occupation: 'Data Analyst',
-  short_quote: "Coding isn't rocket science, it’s just falsely intimidating.",
-  long_quote:
-    'If it weren’t for Codecademy, I’d probably be in my old job. Codecademy enabled me to learn quick lessons between calls, on my lunch break, while multitasking. It was fun and easy and I went from 0 coding skills to a promotion within 6 months.',
-  imageUrl: 'https://content.codecademy.com/courses/free/boba.svg',
 };
 
-const josephineTestimonialProps = {
-  name: 'Josephine Anderson-Weber',
+const josephineTestimonial = {
+  firstName: 'Josephine',
+  lastName: 'Anderson-Weber',
   occupation: 'Junior Back-End Developer',
-  short_quote:
-    'Codecademy’s small lessons really help a person who has trouble focusing on long lessons.',
-  long_quote:
-    'The Codecademy quizzes and projects were so helpful. The quizzes test your knowledge and the projects reinforce what you learned by making you apply that knowledge to real world situations.',
-  imageUrl: 'https://content.codecademy.com/courses/free/boba.svg',
 };
 
 export const testimonialSmallWithAvatar = () => (
   <Testimonial
-    name={laceyTestimonialProps.name}
-    occupation={laceyTestimonialProps.occupation}
-    quote={laceyTestimonialProps.short_quote}
-    imageUrl={laceyTestimonialProps.imageUrl}
+    testimonial={{ ...laceyTestimonial, quote: short_quote, imageUrl }}
     size="small"
     theme={select(
       'theme',
@@ -49,9 +45,7 @@ testimonialSmallWithAvatar.story = {
 
 export const testimonialSmallWithoutAvatar = () => (
   <Testimonial
-    name={laceyTestimonialProps.name}
-    occupation={laceyTestimonialProps.occupation}
-    quote={laceyTestimonialProps.short_quote}
+    testimonial={{ ...laceyTestimonial, quote: short_quote }}
     size="small"
     theme={select(
       'theme',
@@ -67,10 +61,7 @@ testimonialSmallWithoutAvatar.story = {
 
 export const testimonialMediumWithAvatar = () => (
   <Testimonial
-    name={laceyTestimonialProps.name}
-    occupation={laceyTestimonialProps.occupation}
-    quote={laceyTestimonialProps.long_quote}
-    imageUrl={laceyTestimonialProps.imageUrl}
+    testimonial={{ ...laceyTestimonial, quote: long_quote, imageUrl }}
     size="medium"
     theme={select(
       'theme',
@@ -86,9 +77,7 @@ testimonialMediumWithAvatar.story = {
 
 export const testimonialMediumWithoutAvatar = () => (
   <Testimonial
-    name={laceyTestimonialProps.name}
-    occupation={laceyTestimonialProps.occupation}
-    quote={laceyTestimonialProps.long_quote}
+    testimonial={{ ...laceyTestimonial, quote: long_quote }}
     size="medium"
     theme={select(
       'theme',
@@ -104,10 +93,7 @@ testimonialMediumWithoutAvatar.story = {
 
 export const testimonialLargeWithAvatar = () => (
   <Testimonial
-    name={josephineTestimonialProps.name}
-    occupation={josephineTestimonialProps.occupation}
-    quote={josephineTestimonialProps.long_quote}
-    imageUrl={josephineTestimonialProps.imageUrl}
+    testimonial={{ ...laceyTestimonial, quote: long_quote, imageUrl }}
     size="large"
     theme={select(
       'theme',
@@ -123,9 +109,7 @@ testimonialLargeWithAvatar.story = {
 
 export const testimonialLargeWithoutAvatar = () => (
   <Testimonial
-    name={josephineTestimonialProps.name}
-    occupation={josephineTestimonialProps.occupation}
-    quote={josephineTestimonialProps.long_quote}
+    testimonial={{ ...laceyTestimonial, quote: long_quote }}
     size="large"
     theme={select(
       'theme',


### PR DESCRIPTION
## Add `testimonial` prop to Testimonial component

Update testimonial component so that it takes in a `testimonial` prop that is an object, rather than several individual props.

```
export type Testimonial = {
  firstName: string;
  lastName: string;
  occupation: string;
  quote: string;
  company?: string;
  imageUrl?: string;
};
```
We want to have both a `firstName` and `lastName` field, as well as `company` so that the Byline container can be updated to show `lastName`/`company` depending on the size of the component.

See:
![Screen Shot 2020-03-25 at 12 28 46 PM](https://user-images.githubusercontent.com/17210163/77560705-30bb0700-6e94-11ea-98b9-02a37028b28a.png)



---

## Merging your changes

When you are ready to merge to master, use the "squash and merge" button in GitHub, and follow the [commit message guide](/README.md#commit-message-guide) to write your commit message.
