### PR TITLE
fix: update `grid-template-row` on small and medium testimonials

### DIFF
--- a/packages/brand-components/src/Testimonial/styles.module.scss
+++ b/packages/brand-components/src/Testimonial/styles.module.scss
@@ -91,7 +91,7 @@ $background-pattern-offset: px-rem(16px);
   max-width: px-rem(364px);
   grid-template-columns: auto 1fr;
   grid-row-gap: 1rem;
-  grid-template-rows: 76px auto;
+  grid-template-rows: minmax(px-rem(76px), auto) auto;
 
   .avatarContainer + .bylineContainer {
     grid-area: 1 / 2;
@@ -107,7 +107,7 @@ $background-pattern-offset: px-rem(16px);
   grid-template-columns: px-rem(100px) 1fr;
   grid-row-gap: 1.75rem;
   padding: 2rem 1.5rem 1.5rem;
-  grid-template-rows: 76px auto;
+  grid-template-rows: minmax(px-rem(76px), auto) auto;
   @include screen-size-gte($grid-xs-min) {
     padding: 3rem 3rem 1.5rem;
   }


### PR DESCRIPTION
## Style fix for property for `grid-template-row` on small and medium testimonials

The Byline row for Small and Medium sizes had a fix row right height of 76px, (to account when no picture is present and avoid bouncing). What's a better thing is to use `minmax` on that property for flexibility.

See: https://github.com/codecademy-engineering/static-sites/pull/25#pullrequestreview-385087061 which is causing the styling to look off.

<img width="294" alt="Screen Shot 2020-03-31 at 5 11 33 PM" src="https://user-images.githubusercontent.com/17210163/78075742-180a8f80-7373-11ea-97b9-e9fd18f58bdb.png">
<img width="1154" alt="Screen Shot 2020-03-31 at 5 03 11 PM" src="https://user-images.githubusercontent.com/17210163/78075743-18a32600-7373-11ea-946f-4948e482204a.png">
<img width="1066" alt="Screen Shot 2020-03-31 at 5 02 12 PM" src="https://user-images.githubusercontent.com/17210163/78075744-19d45300-7373-11ea-9cfc-3dbe873358e9.png">

---

## Merging your changes

When you are ready to merge to master, use the "squash and merge" button in GitHub, and follow the [commit message guide](/README.md#commit-message-guide) to write your commit message.
