### PR TITLE
feat(LayoutGrid): Adds XS size to layout grid responsive components

### DIFF
--- a/packages/gamut/src/Layout/Column.tsx
+++ b/packages/gamut/src/Layout/Column.tsx
@@ -7,12 +7,13 @@ import {
   ColumnSizes,
   ResponsiveProperty,
   OffsetColumnSizes,
+  OptionalResponsiveProperty,
 } from './types';
 import s from './styles/Column.module.scss';
 
 export type ColumnProps = {
   size: ResponsiveProperty<ColumnSizes>;
-  offset?: ResponsiveProperty<OffsetColumnSizes>;
+  offset?: OptionalResponsiveProperty<OffsetColumnSizes>;
 } & ContainerElementProps;
 
 export const Column: React.FC<ColumnProps> = ({

--- a/packages/gamut/src/Layout/__tests__/utilities-test.ts
+++ b/packages/gamut/src/Layout/__tests__/utilities-test.ts
@@ -2,9 +2,9 @@ import { createClassnames } from '../utilities';
 
 describe('createClassnames', () => {
   const styleMap = {
-    coolProp_sm__smScreen: 'coolClass',
+    coolProp_sm__xsScreen: 'coolClass',
     coolProp_md__mdScreen: 'coolClassMedium',
-    lessCoolProp_1__smScreen: 'lessCoolClass',
+    lessCoolProp_1__xsScreen: 'lessCoolClass',
   };
 
   it('handles string configurations', () => {
@@ -20,14 +20,14 @@ describe('createClassnames', () => {
   });
 
   it('handles screen size configurations', () => {
-    const classList = createClassnames({ lessCoolProp: { sm: 1 } }, styleMap);
+    const classList = createClassnames({ lessCoolProp: { xs: 1 } }, styleMap);
 
     expect(classList).toEqual([['lessCoolClass']]);
   });
 
   it('handles multiple configurations for different screen sizes', () => {
     const classList = createClassnames(
-      { coolProp: { sm: 'sm', md: 'md' } },
+      { coolProp: { xs: 'sm', md: 'md' } },
       styleMap
     );
 
@@ -55,7 +55,7 @@ describe('createClassnames', () => {
     const classList = createClassnames(
       {
         coolProp: { lg: 'sm', md: 'md' },
-        lessCoolProp: { lg: 'sm', sm: 1 },
+        lessCoolProp: { lg: 'sm', xs: 1 },
       },
       styleMap
     );

--- a/packages/gamut/src/Layout/styles/shared.scss
+++ b/packages/gamut/src/Layout/styles/shared.scss
@@ -2,7 +2,7 @@
 
 $columnSizes: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
-$screenSizes: ("sm", "md", "lg");
+$screenSizes: ("xs", "sm", "md", "lg");
 
 $gapSizes: (
   "sm": $base-unit / 2,
@@ -23,6 +23,11 @@ $gapSizes: (
     }
   }
   @if $viewport == "sm" {
+    @include sm-viewport {
+      @content;
+    }
+  }
+  @if $viewport == "xs" {
     @content;
   }
 }

--- a/packages/gamut/src/Layout/types.ts
+++ b/packages/gamut/src/Layout/types.ts
@@ -8,7 +8,17 @@ export type GapSizes = 'sm' | 'md' | 'lg' | 'xl';
 export type ResponsiveProperty<T> =
   | T
   | {
-      sm: T;
+      xs: T;
+      sm?: T;
+      md?: T;
+      lg?: T;
+    };
+
+export type OptionalResponsiveProperty<T> =
+  | T
+  | {
+      xs?: T;
+      sm?: T;
       md?: T;
       lg?: T;
     };

--- a/packages/gamut/src/Layout/utilities.ts
+++ b/packages/gamut/src/Layout/utilities.ts
@@ -11,7 +11,7 @@ export const createClassnames = (
     switch (typeof propValue) {
       case 'number':
       case 'string': {
-        return styleMap[`${propName}_${propValue}__smScreen`];
+        return styleMap[`${propName}_${propValue}__xsScreen`];
       }
       case 'object': {
         return Object.entries(propValue).map(

--- a/packages/styleguide/stories/Layout.stories.js
+++ b/packages/styleguide/stories/Layout.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { LayoutGrid, Column } from '../../gamut/src';
+import gamut from '../../gamut-styles/utils/variables';
 
 export default {
   component: LayoutGrid,
@@ -7,16 +8,28 @@ export default {
 };
 
 const Container = ({ children }) => {
-  return <div style={{ width: '800px', maxWidth: '100%' }}>{children}</div>;
-};
-
-const Test = ({ color, children }) => {
   return (
     <div
       style={{
-        backgroundColor: color,
+        width: '100%',
+        maxWidth: '1440px',
+        padding: '25px',
+        backgroundColor: gamut.deprecatedColors.swatches.ccBlue[100],
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const Content = ({ children }) => {
+  return (
+    <div
+      style={{
+        backgroundColor: gamut.deprecatedColors.swatches.ccBlue[500],
         color: 'white',
         display: 'grid',
+        padding: '5px 0',
         justifyContent: 'center',
         alignContent: 'center',
       }}
@@ -29,79 +42,25 @@ const Test = ({ color, children }) => {
 const KitchenSinkColumns = () => (
   <>
     <Column size={12}>
-      <Test color="grey">12</Test>
+      <Content>12</Content>
     </Column>
     <Column size={6}>
-      <Test color="grey">6</Test>
+      <Content>6</Content>
     </Column>
     <Column size={6}>
-      <Test color="grey">6</Test>
+      <Content>6</Content>
     </Column>
     <Column size={3}>
-      <Test color="grey">3</Test>
+      <Content>3</Content>
     </Column>
     <Column size={3}>
-      <Test color="grey">3</Test>
+      <Content>3</Content>
     </Column>
     <Column size={3}>
-      <Test color="grey">3</Test>
+      <Content>3</Content>
     </Column>
     <Column size={3}>
-      <Test color="grey">3</Test>
-    </Column>
-    <Column size={2}>
-      <Test color="grey">2</Test>
-    </Column>
-    <Column size={2}>
-      <Test color="grey">2</Test>
-    </Column>
-    <Column size={2}>
-      <Test color="grey">2</Test>
-    </Column>
-    <Column size={2}>
-      <Test color="grey">2</Test>
-    </Column>
-    <Column size={2}>
-      <Test color="grey">2</Test>
-    </Column>
-    <Column size={2}>
-      <Test color="grey">2</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
-    </Column>
-    <Column size={1}>
-      <Test color="grey">1</Test>
+      <Content>3</Content>
     </Column>
   </>
 );
@@ -110,10 +69,84 @@ export const responsiveGridGap = () => {
   return (
     <Container>
       <LayoutGrid
-        columnGap={{ sm: 'sm', md: 'md', lg: 'lg' }}
-        rowGap={{ sm: 'sm', md: 'md', lg: 'lg' }}
+        columnGap={{ xs: 'sm', lg: 'lg' }}
+        rowGap={{ xs: 'sm', lg: 'lg' }}
       >
-        <KitchenSinkColumns />
+        <Column size={12}>
+          <Content>12</Content>
+        </Column>
+        <Column size={6}>
+          <Content>6</Content>
+        </Column>
+        <Column size={6}>
+          <Content>6</Content>
+        </Column>
+        <Column size={3}>
+          <Content>3</Content>
+        </Column>
+        <Column size={3}>
+          <Content>3</Content>
+        </Column>
+        <Column size={3}>
+          <Content>3</Content>
+        </Column>
+        <Column size={3}>
+          <Content>3</Content>
+        </Column>
+        <Column size={2}>
+          <Content>2</Content>
+        </Column>
+        <Column size={2}>
+          <Content>2</Content>
+        </Column>
+        <Column size={2}>
+          <Content>2</Content>
+        </Column>
+        <Column size={2}>
+          <Content>2</Content>
+        </Column>
+        <Column size={2}>
+          <Content>2</Content>
+        </Column>
+        <Column size={2}>
+          <Content>2</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
+        <Column size={1}>
+          <Content>1</Content>
+        </Column>
       </LayoutGrid>
     </Container>
   );
@@ -198,19 +231,19 @@ export const offsets = () => {
     <Container>
       <LayoutGrid rowGap="sm" columnGap="sm">
         <Column offset={2} size={4}>
-          <Test color="grey">2 Column offset</Test>
+          <Content>2 Column offset</Content>
         </Column>
         <Column size={2}>
-          <Test color="grey" />
+          <Content />
         </Column>
         <Column size={2}>
-          <Test color="grey" />
+          <Content />
         </Column>
         <Column size={4}>
-          <Test color="grey">No offset</Test>
+          <Content>No offset</Content>
         </Column>
         <Column size={4}>
-          <Test color="grey" />
+          <Content />
         </Column>
       </LayoutGrid>
     </Container>
@@ -226,11 +259,11 @@ export const optionalOffsetColumns = () => {
     <>
       <Container>
         <LayoutGrid rowGap="sm" columnGap="sm">
-          <Column offset={{ sm: 6, md: 4, lg: 2 }} size={6}>
-            <Test color="grey">sm: 6, md: 4, lg: 2</Test>
+          <Column offset={{ xs: 6, md: 4, lg: 2 }} size={6}>
+            <Content>sm: 6, md: 4, lg: 2</Content>
           </Column>
-          <Column offset={{ sm: 0, md: 4 }} size={4}>
-            <Test color="grey">no offset sm, md: 4</Test>
+          <Column offset={{ xs: 0, md: 4 }} size={4}>
+            <Content>no offset sm, md: 4</Content>
           </Column>
         </LayoutGrid>
       </Container>


### PR DESCRIPTION
## More Mobile Breakpoints

- Adds an XS config to layout grid for sizes smaller that 768.  Still not ideal but it will give us more flexibility in the meantime.
- Also makes all props optional on offset so we don't have to add xs, but without type complexity.  If they leave it blank it just does nothing.
- Makes the docs a bit nicer and the code samples more transparent.

I might propose we remap the sizes to something like this if we have continued mobile woes with the possibility of adding XL at ~1200:
`xs > 0 | sm > 480 | md > 768 | lg > 1024` 
