### PR TITLE
feat: created ProgressBar primitive for Gamut

### DIFF
--- a/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
+++ b/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
@@ -88,6 +88,7 @@ Array [
   "PHPIcon",
   "PlayIcon",
   "PracticeIcon",
+  "ProgressBar",
   "ProjectIcon",
   "PythonIcon",
   "QuizIcon",

--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -1,0 +1,27 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import ProgressBar from '..';
+
+describe('ProgressBar', () => {
+  it('includes a hidden label when one is provided', () => {
+    const hiddenLabel = 'Quiz progress percentage';
+    const wrapped = mount(
+      <ProgressBar hiddenLabel={hiddenLabel} percent={0.5} />
+    );
+
+    expect(wrapped.text()).toContain(hiddenLabel);
+  });
+
+  it('does not include percentage visually when displayPercent is false', () => {
+    const wrapped = mount(<ProgressBar percent={0.5} />);
+
+    expect(wrapped.text()).toEqual('');
+  });
+
+  it('includes percentage visually when displayPercent is true', () => {
+    const wrapped = mount(<ProgressBar displayPercent percent={0.5} />);
+
+    expect(wrapped.text()).toEqual('50%');
+  });
+});

--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -3,24 +3,23 @@ import React from 'react';
 
 import ProgressBar from '..';
 
+const stubStyle = {
+  backgroundColor: 'black',
+  barColor: 'darkgrey',
+  fontColor: 'pink',
+};
+
 describe('ProgressBar', () => {
-  it('includes a hidden label when one is provided', () => {
-    const hiddenLabel = 'Quiz progress percentage';
-    const wrapped = mount(
-      <ProgressBar hiddenLabel={hiddenLabel} percent={0.5} />
-    );
-
-    expect(wrapped.text()).toContain(hiddenLabel);
-  });
-
   it('does not include percentage visually when displayPercent is false', () => {
-    const wrapped = mount(<ProgressBar percent={0.5} />);
+    const wrapped = mount(<ProgressBar percent={0.5} style={stubStyle} />);
 
     expect(wrapped.text()).toEqual('');
   });
 
   it('includes percentage visually when displayPercent is true', () => {
-    const wrapped = mount(<ProgressBar displayPercent percent={0.5} />);
+    const wrapped = mount(
+      <ProgressBar displayPercent percent={0.5} style={stubStyle} />
+    );
 
     expect(wrapped.text()).toEqual('50%');
   });

--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -10,15 +10,15 @@ const stubStyle = {
 };
 
 describe('ProgressBar', () => {
-  it('does not include percentage visually when displayPercent is false', () => {
+  it('does not include percentage visually when displayLabel is false', () => {
     const wrapped = mount(<ProgressBar percent={0.5} style={stubStyle} />);
 
     expect(wrapped.text()).toEqual('');
   });
 
-  it('includes percentage visually when displayPercent is true', () => {
+  it('includes percentage visually when displayLabel is true', () => {
     const wrapped = mount(
-      <ProgressBar displayPercent percent={0.5} style={stubStyle} />
+      <ProgressBar displayLabel percent={0.5} style={stubStyle} />
     );
 
     expect(wrapped.text()).toEqual('50%');

--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -11,14 +11,14 @@ const stubStyle = {
 
 describe('ProgressBar', () => {
   it('does not include percentage visually when displayLabel is false', () => {
-    const wrapped = mount(<ProgressBar percent={0.5} style={stubStyle} />);
+    const wrapped = mount(<ProgressBar percent={50} style={stubStyle} />);
 
     expect(wrapped.text()).toEqual('');
   });
 
   it('includes percentage visually when displayLabel is true', () => {
     const wrapped = mount(
-      <ProgressBar displayLabel percent={0.5} style={stubStyle} />
+      <ProgressBar displayLabel percent={50} style={stubStyle} />
     );
 
     expect(wrapped.text()).toEqual('50%');

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -5,33 +5,36 @@ import styles from './styles.module.scss';
 
 export type ProgressBarProps = {
   className?: string;
+
+  /**
+   * Whether to increase size and display the percentage as text.
+   */
   displayPercent?: boolean;
-  hiddenLabel?: string;
+
+  /**
+   * How much of the bar to fill in, as a number in [0, 100].
+   */
   percent: number;
-  style?: ProgressBarStyle;
+
+  style: ProgressBarStyle;
 };
 
 export type ProgressBarStyle = {
-  backgroundColor?: string;
-  barColor?: string;
-  fontColor?: string;
+  backgroundColor: string;
+  barColor: string;
+  fontColor: string;
 };
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
   className,
   displayPercent,
-  hiddenLabel,
   percent,
-  style = {},
+  style,
 }) => {
-  const {
-    backgroundColor = 'black',
-    barColor = 'gray',
-    fontColor = 'white',
-  } = style;
+  const { backgroundColor, barColor, fontColor } = style;
   const height = displayPercent ? 36 : 6;
   const radius = `${height / 2}px`;
-  const visualPercent = `${percent * 100}%`;
+  const visualPercent = `${percent}%`;
 
   return (
     <div
@@ -45,7 +48,6 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
         height: `${height}px`,
       }}
     >
-      {hiddenLabel && <div className={styles.hiddenLabel}>{hiddenLabel}</div>}
       <div
         className={styles.bar}
         style={{

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -9,7 +9,7 @@ export type ProgressBarProps = {
   /**
    * Whether to increase size and display the percentage as text.
    */
-  displayPercent?: boolean;
+  displayLabel?: boolean;
 
   /**
    * How much of the bar to fill in, as a number in [0, 100].
@@ -27,12 +27,12 @@ export type ProgressBarStyle = {
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
   className,
-  displayPercent,
+  displayLabel,
   percent,
   style,
 }) => {
   const { backgroundColor, barColor, fontColor } = style;
-  const height = displayPercent ? 36 : 6;
+  const height = displayLabel ? 36 : 6;
   const radius = `${height / 2}px`;
   const visualPercent = `${percent}%`;
 
@@ -53,13 +53,13 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
         style={{
           background: barColor,
           width: visualPercent,
-          ...(displayPercent && {
+          ...(displayLabel && {
             borderTopRightRadius: radius,
             borderBottomRightRadius: radius,
           }),
         }}
       >
-        {displayPercent && (
+        {displayLabel && (
           <span className={styles.displayedPercent}>{visualPercent}</span>
         )}
       </div>

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -1,0 +1,68 @@
+import cx from 'classnames';
+import React from 'react';
+
+import styles from './styles.module.scss';
+
+export type ProgressBarProps = {
+  className?: string;
+  displayPercent?: boolean;
+  hiddenLabel?: string;
+  percent: number;
+  style?: ProgressBarStyle;
+};
+
+export type ProgressBarStyle = {
+  backgroundColor?: string;
+  barColor?: string;
+  fontColor?: string;
+};
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({
+  className,
+  displayPercent,
+  hiddenLabel,
+  percent,
+  style = {},
+}) => {
+  const {
+    backgroundColor = 'black',
+    barColor = 'gray',
+    fontColor = 'white',
+  } = style;
+  const height = displayPercent ? 36 : 6;
+  const radius = `${height / 2}px`;
+  const visualPercent = `${percent * 100}%`;
+
+  return (
+    <div
+      aria-label={`Progress: ${visualPercent}`}
+      aria-live="polite"
+      className={cx(styles.progressBar, className)}
+      style={{
+        background: backgroundColor,
+        borderRadius: radius,
+        color: fontColor,
+        height: `${height}px`,
+      }}
+    >
+      {hiddenLabel && <div className={styles.hiddenLabel}>{hiddenLabel}</div>}
+      <div
+        className={styles.bar}
+        style={{
+          background: barColor,
+          width: visualPercent,
+          ...(displayPercent && {
+            borderTopRightRadius: radius,
+            borderBottomRightRadius: radius,
+          }),
+        }}
+      >
+        {displayPercent && (
+          <span className={styles.displayedPercent}>{visualPercent}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/packages/gamut/src/ProgressBar/styles.module.scss
+++ b/packages/gamut/src/ProgressBar/styles.module.scss
@@ -1,0 +1,18 @@
+@import "~@codecademy/gamut-styles/utils";
+
+.progressBar {
+  overflow: hidden;
+}
+
+.bar {
+  align-items: center;
+  display: flex;
+  height: 100%;
+}
+
+.displayedPercent {
+  font-weight: bold;
+  padding: 0.5rem;
+  text-align: right;
+  width: 100%;
+}

--- a/packages/gamut/src/index.tsx
+++ b/packages/gamut/src/index.tsx
@@ -23,6 +23,7 @@ export { Overlay as Modal } from './Overlay';
 export * from './NotificationList';
 export * from './NotificationList/NotificationIcon';
 export * from './NotificationList/NotificationItem';
+export * from './ProgressBar';
 export * from './RadialProgress';
 export * from './Spinner';
 export * from './theming/VisualTheme';

--- a/packages/styleguide/stories/ProgressBar-story.scss
+++ b/packages/styleguide/stories/ProgressBar-story.scss
@@ -1,0 +1,15 @@
+@import "../../gamut-styles/utils";
+
+.sections {
+  display: flex;
+  flex-direction: column;
+}
+
+.section {
+  display: grid;
+  grid-template-columns: 1;
+  margin-top: 2rem;
+  min-width: 100%;
+  row-gap: 0.5rem;
+  width: 50%;
+}

--- a/packages/styleguide/stories/ProgressBar.stories.js
+++ b/packages/styleguide/stories/ProgressBar.stories.js
@@ -29,14 +29,14 @@ export const progressbar = () => (
         }}
       />
       <ProgressBar
-        percent={0.5}
+        percent={50}
         style={{
           backgroundColor: colors.green['200'],
           barColor: colors.green['800'],
         }}
       />
       <ProgressBar
-        percent={0.95}
+        percent={95}
         style={{
           backgroundColor: colors.gray['100'],
           barColor: colors.yellow['500'],
@@ -58,7 +58,7 @@ export const progressbar = () => (
       />
       <ProgressBar
         displayPercent
-        percent={0.5}
+        percent={50}
         style={{
           backgroundColor: colors.green['200'],
           barColor: colors.green['500'],
@@ -67,7 +67,7 @@ export const progressbar = () => (
       />
       <ProgressBar
         displayPercent
-        percent={0.95}
+        percent={95}
         style={{
           backgroundColor: colors.gray['100'],
           barColor: colors.yellow['500'],

--- a/packages/styleguide/stories/ProgressBar.stories.js
+++ b/packages/styleguide/stories/ProgressBar.stories.js
@@ -48,7 +48,7 @@ export const progressbar = () => (
       You can opt to have them display their percentage progress as a number.
       This increases the height of the bar.
       <ProgressBar
-        displayPercent
+        displayLabel
         percent={0}
         style={{
           backgroundColor: colors.blue['100'],
@@ -57,7 +57,7 @@ export const progressbar = () => (
         }}
       />
       <ProgressBar
-        displayPercent
+        displayLabel
         percent={50}
         style={{
           backgroundColor: colors.green['200'],
@@ -66,7 +66,7 @@ export const progressbar = () => (
         }}
       />
       <ProgressBar
-        displayPercent
+        displayLabel
         percent={95}
         style={{
           backgroundColor: colors.gray['100'],

--- a/packages/styleguide/stories/ProgressBar.stories.js
+++ b/packages/styleguide/stories/ProgressBar.stories.js
@@ -12,7 +12,7 @@ export default {
 
 export const progressbar = () => (
   <div className={styles.sections}>
-    ProgressBars are to be used when you'd like to indicate a known or
+    ProgressBars are to be used when you would like to indicate a known or
     somewhat-known amount of progress along a fixed course. For example, you
     might show one on a quiz page indicated how many questions have been
     completed.

--- a/packages/styleguide/stories/ProgressBar.stories.js
+++ b/packages/styleguide/stories/ProgressBar.stories.js
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { ProgressBar } from '../../gamut/src';
+import { colors } from '../../gamut-styles/utils/variables';
+
+import styles from './ProgressBar-story.scss';
+
+export default {
+  component: ProgressBar,
+  title: 'Component/ProgressBar',
+};
+
+export const progressbar = () => (
+  <div className={styles.sections}>
+    ProgressBars are to be used when you'd like to indicate a known or
+    somewhat-known amount of progress along a fixed course. For example, you
+    might show one on a quiz page indicated how many questions have been
+    completed.
+    <br />
+    Styles for the background, bar, and font colors are configurable.
+    <div className={styles.section}>
+      <h2>Hidden percent</h2>
+      By default, they are thin bars that only show progress visully.
+      <ProgressBar
+        percent={0}
+        style={{
+          backgroundColor: colors.blue['100'],
+          barColor: colors.blue['700'],
+        }}
+      />
+      <ProgressBar
+        percent={0.5}
+        style={{
+          backgroundColor: colors.green['200'],
+          barColor: colors.green['800'],
+        }}
+      />
+      <ProgressBar
+        percent={0.95}
+        style={{
+          backgroundColor: colors.gray['100'],
+          barColor: colors.yellow['500'],
+        }}
+      />
+    </div>
+    <div className={styles.section}>
+      <h2>Displaying percent</h2>
+      You can opt to have them display their percentage progress as a number.
+      This increases the height of the bar.
+      <ProgressBar
+        displayPercent
+        percent={0}
+        style={{
+          backgroundColor: colors.blue['100'],
+          barColor: colors.blue['700'],
+          fontColor: colors.black,
+        }}
+      />
+      <ProgressBar
+        displayPercent
+        percent={0.5}
+        style={{
+          backgroundColor: colors.green['200'],
+          barColor: colors.green['500'],
+          fontColor: colors.black,
+        }}
+      />
+      <ProgressBar
+        displayPercent
+        percent={0.95}
+        style={{
+          backgroundColor: colors.gray['100'],
+          barColor: colors.yellow['500'],
+          fontColor: colors.black,
+        }}
+      />
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Created ProgressBar primitive for Gamut

ProgressBars are to be used when you'd like to indicate a known or somewhat-known amount of progress along a fixed course. For example, you might show one on a quiz page indicated how many questions have been completed.

Styles for the background, bar, and font colors are configurable.

WEB-779

![Screenshot of the progress bars in action](https://user-images.githubusercontent.com/3335181/78171476-7c385c80-7422-11ea-91b4-d77891230b8d.png)
