### PR TITLE
chore: also export all as in non-Gamut packages

### DIFF
--- a/packages/brand-components/src/index.ts
+++ b/packages/brand-components/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Avatar } from './Avatar';
-export { default as Byline } from './Byline';
-export { default as Quote } from './Quote';
-export { default as Testimonial } from './Testimonial';
+export * from './Avatar';
+export * from './Byline';
+export * from './Quote';
+export * from './Testimonial';

--- a/packages/gamut-templates/src/index.ts
+++ b/packages/gamut-templates/src/index.ts
@@ -1,3 +1,3 @@
-export { default as Interstitial } from './Interstitial';
-export { default as GridForm } from './GridForm';
-export { default as SplitInterstitial } from './SplitInterstitial';
+export * from './Interstitial';
+export * from './GridForm';
+export * from './SplitInterstitial';


### PR DESCRIPTION
## Also export all as in non-Gamut packages

Might as well, right? It doesn't fix the `yarn start` issues with gamut-templates, but I think it at least helps with exporting props?