### PR TITLE
feat(Icons): Add named export to gamut icons and update SVGR

### DIFF
--- a/packages/gamut-icons/icon-template.js
+++ b/packages/gamut-icons/icon-template.js
@@ -11,7 +11,7 @@ function iconTemplate(api, opts, { jsx /* imports, props, exports */ }) {
   return template.ast`
     import * as React from 'react';
     import { GamutIconProps } from '../types';
-    const ${componentName} = React.forwardRef<SVGSVGElement, GamutIconProps>(({
+    export const ${componentName} = React.forwardRef<SVGSVGElement, GamutIconProps>(({
       title = "${title}",
       titleId = '',
       size,

--- a/packages/gamut-icons/index-template.js
+++ b/packages/gamut-icons/index-template.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+function indexTemplate(files) {
+  const exportEntries = files.map(file => {
+    const basename = path.basename(file, path.extname(file));
+    return `export * from './${basename}';`;
+  });
+  return exportEntries.join('\n');
+}
+module.exports = indexTemplate;

--- a/packages/gamut-icons/package.json
+++ b/packages/gamut-icons/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@svgr/cli": "5.0.0",
+    "@svgr/cli": "5.3.1",
     "svgo": "^1.3.2",
     "typescript": "*"
   }


### PR DESCRIPTION
## Icon build updates
Ran into a weird parsing error on the default index template:

```
  127 | export { default as ViewIcon } from './ViewIcon'
  128 | export { default as YoutubeIcon } from './YoutubeIcon'
> 129 | export { default as ZoomIcon } from './ZoomIcon'try {
      |                                                 ^
  130 |     // @ts-ignore
  131 |     ForwardRefExoticComponent.displayName = "ForwardRefExoticComponent";
  132 |     // @ts-ignore
```

Changes:
- Bumped SVGR version
- Added index template and changed export syntax to match other packages
- All icons now are named exports and defaults.



