### PR TITLE
feat(Gamut)!: switched ProgressBar's displayLabel prop name to be large

### DIFF
--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -10,16 +10,14 @@ const stubStyle = {
 };
 
 describe('ProgressBar', () => {
-  it('does not include percentage visually when displayLabel is false', () => {
+  it('does not include percentage visually when large is false', () => {
     const wrapped = mount(<ProgressBar percent={50} style={stubStyle} />);
 
     expect(wrapped.text()).toEqual('');
   });
 
-  it('includes percentage visually when displayLabel is true', () => {
-    const wrapped = mount(
-      <ProgressBar displayLabel percent={50} style={stubStyle} />
-    );
+  it('includes percentage visually when large is true', () => {
+    const wrapped = mount(<ProgressBar large percent={50} style={stubStyle} />);
 
     expect(wrapped.text()).toEqual('50%');
   });

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -9,7 +9,7 @@ export type ProgressBarProps = {
   /**
    * Whether to increase size and display the percentage as text.
    */
-  displayLabel?: boolean;
+  large?: boolean;
 
   /**
    * How much of the bar to fill in, as a number in [0, 100].
@@ -22,17 +22,17 @@ export type ProgressBarProps = {
 export type ProgressBarStyle = {
   backgroundColor: string;
   barColor: string;
-  fontColor: string;
+  fontColor?: string;
 };
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
   className,
-  displayLabel,
+  large,
   percent,
   style,
 }) => {
   const { backgroundColor, barColor, fontColor } = style;
-  const height = displayLabel ? 36 : 6;
+  const height = large ? 36 : 6;
   const radius = `${height / 2}px`;
   const visualPercent = `${percent}%`;
 
@@ -53,13 +53,13 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
         style={{
           background: barColor,
           width: visualPercent,
-          ...(displayLabel && {
+          ...(large && {
             borderTopRightRadius: radius,
             borderBottomRightRadius: radius,
           }),
         }}
       >
-        {displayLabel && (
+        {large && (
           <span className={styles.displayedPercent}>{visualPercent}</span>
         )}
       </div>


### PR DESCRIPTION
## Switched ProgressBar's displayLabel prop name to be large

Splitting off from #695, this is a more technically correct name for the prop. 