### PR TITLE
feat(GridForm): added columnGap and rowGap as props to GridForm

### DIFF
--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -10,10 +10,30 @@ import { GridFormField } from './types';
 export type GridFormProps<Values extends {}> = {
   children?: React.ReactNode;
   className?: string;
+
+  /**
+   * Layout grid column gap override.
+   */
   columnGap?: LayoutGridProps['columnGap'];
+
+  /**
+   * Descriptions of the fields comprising the form.
+   */
   fields: GridFormField[];
+
+  /**
+   * Function called with field values on submit, if all validations have passed.
+   */
   onSubmit: (values: Values) => Promise<void>;
+
+  /**
+   * Layout grid row gap override.
+   */
   rowGap?: LayoutGridProps['rowGap'];
+
+  /**
+   * Description of the submit button at the end of the form.
+   */
   submit: GridFormSubmitProps;
 };
 

--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -2,22 +2,32 @@ import React, { useEffect } from 'react';
 import { useForm, FieldError } from 'react-hook-form';
 
 import { Form } from '../Form';
-import { LayoutGrid } from '../Layout';
+import { LayoutGrid, LayoutGridProps } from '../Layout';
 import GridFormInputGroup from './GridFormInputGroup';
 import GridFormSubmit, { GridFormSubmitProps } from './GridFormSubmit';
 import { GridFormField } from './types';
 
 export type GridFormProps<Values extends {}> = {
-  className?: string;
   children?: React.ReactNode;
+  className?: string;
+  columnGap?: LayoutGridProps['columnGap'];
   fields: GridFormField[];
   onSubmit: (values: Values) => Promise<void>;
+  rowGap?: LayoutGridProps['rowGap'];
   submit: GridFormSubmitProps;
 };
 
 export function GridForm<
   Values extends Record<string, boolean | string | undefined>
->({ children, className, fields, submit, onSubmit }: GridFormProps<Values>) {
+>({
+  children,
+  className,
+  columnGap = 'lg',
+  fields,
+  onSubmit,
+  rowGap = 'md',
+  submit,
+}: GridFormProps<Values>) {
   const { errors, handleSubmit, register, setValue } = useForm<Values>({
     defaultValues: fields.reduce(
       (defaultValues, field) => ({
@@ -36,7 +46,7 @@ export function GridForm<
 
   return (
     <Form className={className} onSubmit={handleSubmit(onSubmit)}>
-      <LayoutGrid columnGap="lg" rowGap="md">
+      <LayoutGrid columnGap={columnGap} rowGap={rowGap}>
         {fields.map(field => {
           const errorMessage = (errors[field.name] as FieldError)?.message;
 

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -37,6 +37,10 @@ export const gridForm = () => (
       You should only ever directly use <code>GridForm</code> to create your
       form. <code>Form</code> atoms compose the structure of these forms but
       should not be used directly.
+      <br />
+      `GridForm`s are laid out with `LayoutGrid`, so you can override its{' '}
+      <code>columnGap</code> and <code>rowGap</code> with the normal string or
+      responsive layouts.
     </StoryDescription>
     <GridForm
       fields={[


### PR DESCRIPTION
## Added columnGap and rowGap as props to GridForm

We'll need to allow responsive layouts for our forms. This allows consumers of `GridForm` to specify their gaps.