### PR TITLE
feat(gamut-styles): formalized Editor colors in gamut-styles

### DIFF
--- a/packages/gamut-styles/utils/variables/_colors.scss
+++ b/packages/gamut-styles/utils/variables/_colors.scss
@@ -110,7 +110,6 @@ $brand-dark-blue: #141c3a;
 // =======================================
 
 $color-editor-blue: #83fff5;
-$color-editor-comment: #939598;
 $color-editor-deep-purple: #cc7bc2;
 $color-editor-gray: #939598;
 $color-editor-green: #b4d353;

--- a/packages/gamut-styles/utils/variables/_colors.scss
+++ b/packages/gamut-styles/utils/variables/_colors.scss
@@ -106,6 +106,20 @@ $brand-beige: #efd9ca;
 $brand-dark-blue: #141c3a;
 
 // =======================================
+//      EDITOR COLORS
+// =======================================
+
+$color-editor-blue: #83fff5;
+$color-editor-comment: #939598;
+$color-editor-deep-purple: #cc7bc2;
+$color-editor-gray: #939598;
+$color-editor-green: #b4d353;
+$color-editor-orange: #ff8973;
+$color-editor-purple: #b3ccff;
+$color-editor-red: #e85d7f;
+$color-editor-yellow: #ffe083;
+
+// =======================================
 //      DEPRECATED COLORS
 // =======================================
 
@@ -308,28 +322,6 @@ $deprecated-color-darkblue: #204056;
 $deprecated-color-midnightblue: #152b39;
 $deprecated-color-mint: #34b3a0;
 $deprecated-color-red: #f65a5b;
-
-$deprecated-swatches-basic-black: $color-black;
-$deprecated-swatches-basic-white: $color-white;
-$deprecated-swatches-code-default: $color-white;
-$deprecated-swatches-code-atom: #ff7155;
-$deprecated-swatches-code-attribute: #ceff00;
-$deprecated-swatches-code-builtin: #ddda6f;
-$deprecated-swatches-code-comment: #737887;
-$deprecated-swatches-code-def: #b5a1a1;
-$deprecated-swatches-code-error: #e83131;
-$deprecated-swatches-code-keyword: #64ffe1;
-$deprecated-swatches-code-meta: #d478ea;
-$deprecated-swatches-code-number: #ef9eb4;
-$deprecated-swatches-code-operator: #b5a1a1;
-$deprecated-swatches-code-property: #9771ff;
-$deprecated-swatches-code-qualifier: #fff543;
-$deprecated-swatches-code-string-1: #ffde52;
-$deprecated-swatches-code-string-2: #ac99bf;
-$deprecated-swatches-code-tag: #e85d7f;
-$deprecated-swatches-code-variable-1: #249cff;
-$deprecated-swatches-code-variable-2: #57ff93;
-$deprecated-swatches-code-variable-3: #5affef;
 
 $deprecated-swatches-blue-100: #dceff8;
 $deprecated-swatches-blue-200: #bae0f1;

--- a/packages/gamut-styles/utils/variables/index.js
+++ b/packages/gamut-styles/utils/variables/index.js
@@ -206,28 +206,16 @@ export const deprecatedColors = {
   },
 };
 
-export const deprecatedEditorColors = {
-  black: '#000',
-  white: '#fff',
-  default: '#fff',
-  atom: '#ff7155',
-  attribute: '#ceff00',
-  builtin: '#ddda6f',
-  comment: '#737887',
-  def: '#b5a1a1',
-  error: '#e83131',
-  keyword: '#64ffe1',
-  meta: '#d478ea',
-  number: '#ef9eb4',
-  operator: '#b5a1a1',
-  property: '#9771ff',
-  qualifier: '#fff543',
-  string1: '#ffde52',
-  string2: '#ac99bf',
-  tag: '#e85d7f',
-  variable1: '#249cff',
-  variable2: '#57ff93',
-  variable3: '#5affef',
+export const editorColors = {
+  blue: '#83fff5',
+  comment: '#939598',
+  deepPurple: '#cc7bc2',
+  gray: '#939598',
+  green: '#b4d353',
+  orange: '#ff8973',
+  purple: '#b3ccff',
+  red: '#e85d7f',
+  yellow: '#ffe083',
 };
 
 export const deprecatedGamutColors = {
@@ -343,8 +331,8 @@ export default {
   colors,
   brandColors,
   deprecatedColors,
-  deprecatedEditorColors,
   deprecatedGamutColors,
+  editorColors,
   effectColors,
   grid,
   legacyBreakpoints,

--- a/packages/gamut-styles/utils/variables/index.js
+++ b/packages/gamut-styles/utils/variables/index.js
@@ -208,7 +208,6 @@ export const deprecatedColors = {
 
 export const editorColors = {
   blue: '#83fff5',
-  comment: '#939598',
   deepPurple: '#cc7bc2',
   gray: '#939598',
   green: '#b4d353',

--- a/packages/styleguide/stories/Foundations/Colors/Colors.stories.tsx
+++ b/packages/styleguide/stories/Foundations/Colors/Colors.stories.tsx
@@ -2,10 +2,16 @@ import {
   brandColors,
   colors,
   deprecatedColors,
-  deprecatedEditorColors,
+  editorColors,
   deprecatedGamutColors,
 } from '@codecademy/gamut-styles/utils/variables';
-import { Container, LayoutGrid, Column } from '@codecademy/gamut/src';
+import {
+  Container,
+  LayoutGrid,
+  Column,
+  VisualTheme,
+} from '@codecademy/gamut/src';
+import cx from 'classnames';
 import { startCase } from 'lodash';
 import React from 'react';
 
@@ -117,6 +123,29 @@ export const Colors = () => (
   </StoryTemplate>
 );
 
+export const Editor = () => {
+  return (
+    <StoryTemplate status={StoryStatus.Ready} theme={VisualTheme.DarkMode} wide>
+      <StoryDescription>
+        The LE's code editor uses its own colors for text.
+      </StoryDescription>
+      <LayoutGrid className={styles.swatchesContainer} rowGap="md">
+        {objectKeys(editorColors).map(color => (
+          <Column key={color} size={3}>
+            <h2 className={cx(styles.heading, styles.headingDark)}>
+              Editor {startCase(color)}
+            </h2>
+            {renderSwatch(
+              `color-editor-${parseCamelCase(color)}`,
+              editorColors[color]
+            )}
+          </Column>
+        ))}
+      </LayoutGrid>
+    </StoryTemplate>
+  );
+};
+
 export const GamutDeprecated = () => (
   <StoryTemplate status={StoryStatus.Deprecated} wide>
     <StoryDescription>
@@ -174,21 +203,3 @@ export const PortalDeprecated = () => (
     </Container>
   </StoryTemplate>
 );
-
-export const EditorDeprecated = () => {
-  const { white, black, ...platformRest } = deprecatedEditorColors;
-
-  return (
-    <StoryTemplate status={StoryStatus.Deprecated} wide>
-      <StoryDescription>
-        Similar to the deprecated Gamut colors, these ones are an old palette
-        from the Portal.
-      </StoryDescription>
-      <div>
-        <h2 className={styles.heading}>deprecated editor colors</h2>
-        {renderSwatches({ white, black }, 'deprecated-swatches-basic')}
-        {renderSwatches(platformRest, 'deprecated-swatches-code')}
-      </div>
-    </StoryTemplate>
-  );
-};

--- a/packages/styleguide/stories/Foundations/Colors/styles.module.scss
+++ b/packages/styleguide/stories/Foundations/Colors/styles.module.scss
@@ -11,6 +11,10 @@
   padding: 0;
 }
 
+h2.headingDark {
+  color: $color-gray-100;
+}
+
 .swatchContainer {
   width: max-content;
 

--- a/packages/styleguide/stories/Templating/StoryTemplate/index.tsx
+++ b/packages/styleguide/stories/Templating/StoryTemplate/index.tsx
@@ -17,14 +17,13 @@ export type StoryTemplateProps = {
 export const StoryTemplate: React.FC<StoryTemplateProps> = ({
   children,
   status,
-  wide,
-}) => {
-  const theme = select(
+  theme = select(
     'Visual Theme',
     { Light: VisualTheme.LightMode, Dark: VisualTheme.DarkMode },
     VisualTheme.LightMode
-  );
-
+  ),
+  wide,
+}) => {
   return (
     <div
       className={cx(


### PR DESCRIPTION
## Formalized Editor colors in gamut-styles

The previous `basic-` and `code-` swatches are unused in the monolith and LE colors are generally hardcoded. This PR will let us `import { editorColors }` to reference them in JS.

### Notes

Existing locations that match exactly:

* CodeMirror: [`theme.scss`](https://github.com/codecademy-engineering/Codecademy/blob/4e807c71b01debdcec2153b87ad4cafd26bbedbc/webpack/assets/components/CodeMirror/styles/theme.scss#L7)
* Monaco: [`colors-dark.tsx`](https://github.com/codecademy-engineering/Codecademy/blob/c284f875790ae877dcc5fcf5122f8141bcee6439/webpack/assets/components/MonacoEditor/themes/colors-dark.tsx#L3)