### PR TITLE
feat: GridForm checkbox and select required validation

### DIFF
--- a/packages/gamut/src/Form/Select.tsx
+++ b/packages/gamut/src/Form/Select.tsx
@@ -12,7 +12,7 @@ export type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   (props, ref) => {
     const className = cx(s.Select, props.className, props.error && s.error);
-    const { options, ...propsToTransfer } = props;
+    const { options, error, ...propsToTransfer } = props;
 
     let selectOptions: ReactNode[] = [];
 

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
@@ -22,7 +22,7 @@ export const GridFormCheckboxInput: React.FC<GridFormCheckboxInputProps> = ({
       htmlFor={field.name}
       name={field.name}
       label={field.description}
-      ref={register()}
+      ref={register(field.validation)}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
@@ -24,7 +24,7 @@ export const GridFormSelectInput: React.FC<GridFormSelectInputProps> = ({
       error={error}
       htmlFor={field.name}
       name={field.name}
-      ref={register()}
+      ref={register(field.validation)}
       options={field.options}
     />
   );

--- a/packages/gamut/src/GridForm/GridFormSubmit/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormSubmit/index.tsx
@@ -5,16 +5,18 @@ import { Column, ColumnSizes, ResponsiveProperty } from '../../Layout';
 
 export type GridFormSubmitProps = {
   contents: React.ReactNode;
+  disabled?: boolean;
   size?: ResponsiveProperty<ColumnSizes>;
 };
 
 export const GridFormSubmit: React.FC<GridFormSubmitProps> = ({
   contents,
+  disabled,
   size,
 }) => {
   return (
     <Column size={size}>
-      <Button theme="brand-purple" type="submit">
+      <Button disabled={disabled} theme="brand-purple" type="submit">
         {contents}
       </Button>
     </Column>

--- a/packages/gamut/src/GridForm/GridFormSubmit/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormSubmit/index.tsx
@@ -5,18 +5,16 @@ import { Column, ColumnSizes, ResponsiveProperty } from '../../Layout';
 
 export type GridFormSubmitProps = {
   contents: React.ReactNode;
-  disabled?: boolean;
   size?: ResponsiveProperty<ColumnSizes>;
 };
 
 export const GridFormSubmit: React.FC<GridFormSubmitProps> = ({
   contents,
-  disabled,
   size,
 }) => {
   return (
     <Column size={size}>
-      <Button disabled={disabled} theme="brand-purple" type="submit">
+      <Button theme="brand-purple" type="submit">
         {contents}
       </Button>
     </Column>

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -11,6 +11,7 @@ export type GridFormCheckboxField = BaseFormField & {
   description: string;
   defaultValue?: boolean;
   label?: string;
+  validation?: Pick<ValidationOptions, 'required'>;
   type: 'checkbox';
 };
 

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -114,6 +114,17 @@ export const gridForm = () => (
           size: 3,
           type: 'checkbox',
         },
+        {
+          label: 'End User License Agreement',
+          description:
+            'I accept the terms and conditions (required or else!!!)',
+          name: 'eula-checkbox-required',
+          size: 12,
+          type: 'checkbox',
+          validation: {
+            required: 'Please check the box to agree to the terms.',
+          },
+        },
       ]}
       onSubmit={async values => {
         action('Form Submitted')(values);

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -57,11 +57,14 @@ export const gridForm = () => (
           type: 'text',
         },
         {
-          label: 'Simple select',
+          label: 'Simple select (required)',
           name: 'simple-select',
-          options: ['One fish', 'Two fish', 'Red fish', 'Blue fish'],
+          options: ['', 'One fish', 'Two fish', 'Red fish', 'Blue fish'],
           size: 5,
           type: 'select',
+          validation: {
+            required: 'Please select an option',
+          },
         },
         {
           label: 'Upload a cat image (we support pdf, jpeg, or png files)',


### PR DESCRIPTION
## [RRT-89] GridForm checkbox and select required validation
- Allows a checkbox to be required. Example: check to agree to the TOC.
- Allows a select input to be required. Example: many sets of select options include a blank first option. Requiring means making sure they choose a non-blank option.
- Includes a story to illustrate this.

**Additional changes**
- ~feature: allow `GridForm` submit button to have a disabled state~ Update: not doing this today
- fix: removed a pesky react warning about `error` attribute passed to an html div tag
