### PR TITLE
feat(Gamut): tweaked AccordionButton to look more like the nice LE yellow ones

### DIFF
--- a/packages/gamut/src/AccordionButton/styles.module.scss
+++ b/packages/gamut/src/AccordionButton/styles.module.scss
@@ -13,7 +13,8 @@
 
   &.yellow {
     background-color: $color-yellow-200;
-    border: 1px solid $color-yellow-400;
+    border: solid $color-yellow-400;
+    border-width: 1px 0;
     font-weight: normal;
     transition: background-color 0.15s ease-in-out;
 
@@ -29,9 +30,9 @@
 }
 
 .expansionIcon {
-  transition: transform 0.5s;
+  transition: transform 0.35s ease-out;
 }
 
 .expansionIconExpanded {
-  transform: rotateX(180deg);
+  transform: rotate(-180deg);
 }


### PR DESCRIPTION
## Tweaked AccordionButton to look more like the nice LE yellow ones

* Removed the yellow theme's left and right borders (since the LE doesn't have them)
* Made the arrow rotate into position instead of flip - and a little more quickly

Mike Kenny indicated a lack of preference for which animation is used, and I like the rotate-y one more. 