### PR TITLE
feat(gamut): Add GridForm Submit Button functionality

### DIFF
--- a/packages/gamut/src/GridForm/GridFormSubmit/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormSubmit/index.tsx
@@ -1,20 +1,30 @@
 import React from 'react';
+import cx from 'classnames';
 
 import { Button } from '../../Button';
 import { Column, ColumnSizes, ResponsiveProperty } from '../../Layout';
+import styles from './styles.module.scss';
+
+export type GridFormSubmitPosition = 'left' | 'center' | 'right';
 
 export type GridFormSubmitProps = {
   contents: React.ReactNode;
+  position?: GridFormSubmitPosition;
   size?: ResponsiveProperty<ColumnSizes>;
+  theme?: string;
 };
 
 export const GridFormSubmit: React.FC<GridFormSubmitProps> = ({
   contents,
+  position = 'left',
   size,
+  theme = 'brand-purple',
 }) => {
+  const positionStyle = styles[position];
+
   return (
-    <Column size={size}>
-      <Button theme="brand-purple" type="submit">
+    <Column className={cx(styles.base, positionStyle)} size={size}>
+      <Button theme={theme} type="submit">
         {contents}
       </Button>
     </Column>

--- a/packages/gamut/src/GridForm/GridFormSubmit/styles.module.scss
+++ b/packages/gamut/src/GridForm/GridFormSubmit/styles.module.scss
@@ -1,0 +1,15 @@
+.base {
+  align-items: center;
+}
+
+.left {
+  justify-content: flex-start;
+}
+
+.center {
+  justify-content: center;
+}
+
+.right {
+  justify-content: flex-end;
+}

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -134,6 +134,9 @@ export const gridForm = () => (
       }}
       submit={{
         contents: 'Submit Me!?',
+        position: 'right',
+        size: 12,
+        theme: 'brand-blue',
       }}
     />
   </StoryTemplate>

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -134,9 +134,172 @@ export const gridForm = () => (
       }}
       submit={{
         contents: 'Submit Me!?',
+        size: 12,
+      }}
+    />
+  </StoryTemplate>
+);
+
+export const gridFormWithSubmitButtonPosition = () => (
+  <StoryTemplate status={StoryStatus.Ready}>
+    <StoryDescription>
+      We can position the submit button by passing the position prop with a
+      value of left, center or right.
+    </StoryDescription>
+    <GridForm
+      fields={[
+        {
+          label: 'Simple text',
+          name: 'simple-text',
+          size: 12,
+          type: 'text',
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Right Submit!?',
         position: 'right',
         size: 12,
+      }}
+    />
+    <GridForm
+      fields={[
+        {
+          label: 'Simple text',
+          name: 'simple-text',
+          size: 12,
+          type: 'text',
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Center Submit!?',
+        position: 'center',
+        size: 12,
+      }}
+    />
+    <GridForm
+      fields={[
+        {
+          label: 'Simple text',
+          name: 'simple-text',
+          size: 12,
+          type: 'text',
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Left Submit!?',
+        position: 'left',
+        size: 12,
+      }}
+    />
+  </StoryTemplate>
+);
+
+export const gridFormWithSubmitButtonColor = () => (
+  <StoryTemplate status={StoryStatus.Ready}>
+    <StoryDescription>
+      We can specify the color of our button by passing the theme prop with a
+      button atom theme prop value. i.e. 'brand-blue', 'brand-purple'. The
+      default value is 'brand-purple'.
+    </StoryDescription>
+    <GridForm
+      fields={[
+        {
+          label: 'Simple text',
+          name: 'simple-text',
+          size: 12,
+          type: 'text',
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Default Purple Submit!?',
+        size: 12,
+      }}
+    />
+    <GridForm
+      fields={[
+        {
+          label: 'Simple text',
+          name: 'simple-text',
+          size: 12,
+          type: 'text',
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Blue Submit!?',
+        size: 12,
         theme: 'brand-blue',
+      }}
+    />
+  </StoryTemplate>
+);
+
+export const gridFormWithInlineSubmitButton = () => (
+  <StoryTemplate status={StoryStatus.NotReady}>
+    <StoryDescription>
+      We can make the Submit button inline with an input by setting the column
+      sizes so they fit on the same row. e.g size 8 for an input and size 4 for
+      the submit.
+      <br />
+      Caveats: We need to adjust params to allow us to properly align elements
+      for the following use cases.
+    </StoryDescription>
+    <h4>
+      Submit with no label text (but label still rendered) does not align
+      properly with the checkbox
+    </h4>
+    <GridForm
+      fields={[
+        {
+          description: 'I approve of inline swag',
+          name: 'enough-swag',
+          size: 8,
+          type: 'checkbox',
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Inline Submit!?',
+        size: 4,
+        position: 'right',
+      }}
+    />
+    <hr />
+    <h4>
+      Submit even when the lable has visible text, is still not aligned right
+    </h4>
+    <GridForm
+      fields={[
+        {
+          label: 'Label',
+          name: 'email',
+          size: 8,
+          type: 'text',
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Inline Submit!?',
+        size: 4,
+        position: 'right',
       }}
     />
   </StoryTemplate>


### PR DESCRIPTION
## GridForm Submit Button functionality
- allow positioning of button to be left, right, or center
- allow button theme selection


We wrote this PR in order to make GridForm a better fit for CheckoutV3. These changes will allow us to use it for the [Membership Step](https://app.abstract.com/projects/746e0c79-eaf0-45b4-a413-bd470026837d/branches/c5e9bd98-2b7f-456e-933f-04c825facdc2/commits/33e86423f7efb02aae30e469db3e198912d3605f/files/2d17f083-174b-4794-b03d-45d5ff463f43/layers/4E6CBFE1-24CC-476B-A856-99FDEC37EE82?collectionId=d87a4292-ae3f-4118-b248-1edbab34341e&collectionLayerId=1f9501f1-bce7-422a-aed4-b41ba619bb3c).
See [Checkout V3 design PR ](https://github.com/codecademy-engineering/Codecademy/pull/16835) for context

@JoshuaKGoldberg - we initially did positioning via offset, this however did not fully solve the use-case as doing so would not make the button flush to the right side.

We instead opted to use flex styling to allow users to position the button to the left, center, or right of the column it is in. Toby mentioned this as a desired feature when we talked with him.

This also has the added benefit of properly sizing the button when it is a sibling of an input element on the same row. Before it would take up the entire height + width of the column it is a child of. Now it follows the existing button sizing. 

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
