### PR TITLE
feat(Gamut): added 'custom' field type to GridForm

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+import { FormContextValues } from 'react-hook-form';
+
+import { GridFormCustomField } from '../../types';
+
+export type GridFormCustomInputProps = {
+  className?: string;
+  error?: string;
+  field: GridFormCustomField;
+  register: FormContextValues['register'];
+  setValue: (name: string, value: any) => void;
+};
+
+export const GridFormCustomInput: React.FC<GridFormCustomInputProps> = ({
+  className,
+  error,
+  field,
+  register,
+  setValue,
+}) => {
+  useEffect(() => {
+    register(field.name, field.validation);
+  }, [field.name, field.validation, register]);
+
+  return (
+    <>
+      {field.render({
+        className,
+        error,
+        field,
+        register,
+        setValue: value => setValue(field.name, value),
+      })}
+    </>
+  );
+};
+
+export default GridFormCustomInput;

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -40,7 +40,7 @@ describe('GridFormInputGroup', () => {
     expect(wrapped.find('input[type="checkbox"]')).toHaveLength(1);
   });
 
-  it('renders a custom input when the field type is checkbox', () => {
+  it('renders a custom input when the field type is custom', () => {
     const text = 'Hello, world!';
     const { wrapped } = renderComponent({
       field: {

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -13,6 +13,7 @@ import GridFormInputGroup, { GridFormInputGroupProps } from '..';
 const renderComponent = (overrides: Partial<GridFormInputGroupProps>) => {
   const props = {
     field: stubSelectField,
+    setValue: jest.fn(),
     register: jest.fn(),
     ...overrides,
   };
@@ -37,6 +38,19 @@ describe('GridFormInputGroup', () => {
     });
 
     expect(wrapped.find('input[type="checkbox"]')).toHaveLength(1);
+  });
+
+  it('renders a custom input when the field type is checkbox', () => {
+    const text = 'Hello, world!';
+    const { wrapped } = renderComponent({
+      field: {
+        render: () => text,
+        name: 'stub-custom',
+        type: 'custom',
+      },
+    });
+
+    expect(wrapped.text()).toEqual(text);
   });
 
   it('renders a select when the field type is select', () => {

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -5,6 +5,7 @@ import { FormError, FormGroup, FormGroupLabel } from '../../Form';
 import { Column } from '../../Layout';
 import { GridFormField } from '../types';
 import GridFormCheckboxInput from './GridFormCheckboxInput';
+import GridFormCustomInput from './GridFormCustomInput';
 import GridFormFileInput from './GridFormFileInput';
 import GridFormTextInput from './GridFormTextInput';
 import GridFormSelectInput from './GridFormSelectInput';
@@ -15,6 +16,7 @@ export type GridFormInputGroupProps = {
   error?: string;
   field: GridFormField;
   register: FormContextValues['register'];
+  setValue: (value: any) => void;
 };
 
 export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = props => {
@@ -26,6 +28,16 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = props => {
             className={styles.gridFormInput}
             field={props.field}
             register={props.register}
+          />
+        );
+
+      case 'custom':
+        return (
+          <GridFormCustomInput
+            className={styles.gridFormInput}
+            field={props.field}
+            register={props.register}
+            setValue={props.setValue}
           />
         );
 

--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -50,7 +50,7 @@ export function GridForm<
   rowGap = 'md',
   submit,
 }: GridFormProps<Values>) {
-  const { errors, handleSubmit, register } = useForm<Values>({
+  const { errors, handleSubmit, register, setValue } = useForm<Values>({
     defaultValues: fields.reduce(
       (defaultValues, field) => ({
         ...defaultValues,
@@ -78,6 +78,7 @@ export function GridForm<
               field={field}
               key={field.name}
               register={register}
+              setValue={setValue}
             />
           );
         })}

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -1,4 +1,4 @@
-import { ValidationOptions } from 'react-hook-form';
+import { FormContextValues, ValidationOptions } from 'react-hook-form';
 
 import { ColumnSizes, ResponsiveProperty } from '../Layout';
 
@@ -13,6 +13,22 @@ export type GridFormCheckboxField = BaseFormField & {
   label?: string;
   validation?: Pick<ValidationOptions, 'required'>;
   type: 'checkbox';
+};
+
+export type GridFormCustomFieldProps = {
+  className: string;
+  error?: string;
+  field: GridFormCustomField;
+  register: FormContextValues['register'];
+  setValue: (value: any) => void;
+};
+
+export type GridFormCustomField = BaseFormField & {
+  defaultValue?: any;
+  label?: string;
+  render: (props: GridFormCustomFieldProps) => React.ReactNode;
+  validation?: ValidationOptions;
+  type: 'custom';
 };
 
 export type GridFormTextField = BaseFormField & {
@@ -46,6 +62,7 @@ export type GridFormTextAreaField = BaseFormField & {
 
 export type GridFormField =
   | GridFormCheckboxField
+  | GridFormCustomField
   | GridFormTextField
   | GridFormSelectField
   | GridFormFileField

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -157,8 +157,8 @@ export const gridFormWithCustomInput = () => (
     <GridForm
       fields={[
         {
-          render: ({ error, setValue }) => (
-            <>
+          render: ({ className, error, setValue }) => (
+            <div className={className}>
               <Input
                 error={!!error}
                 id="custom-text-input"
@@ -168,7 +168,7 @@ export const gridFormWithCustomInput = () => (
               <span aria-label="Dancing person" role="img">
                 🕺
               </span>
-            </>
+            </div>
           ),
           label: 'Gimme two more swags',
           name: 'custom-input',

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -1,4 +1,4 @@
-import { GridForm } from '@codecademy/gamut/src';
+import { GridForm, Input } from '@codecademy/gamut/src';
 import { action } from '@storybook/addon-actions';
 import React from 'react';
 
@@ -127,6 +127,60 @@ export const gridForm = () => (
           validation: {
             required: 'Please check the box to agree to the terms.',
           },
+        },
+      ]}
+      onSubmit={async values => {
+        action('Form Submitted')(values);
+      }}
+      submit={{
+        contents: 'Submit Me!?',
+      }}
+    />
+  </StoryTemplate>
+);
+
+export const gridFormWithCustomInput = () => (
+  <StoryTemplate status={StoryStatus.Ready}>
+    <StoryDescription>
+      Some forms, such as the checkout flows that use Recurly, need to define
+      their own inputs. We can specify a 'custom' field type to with a{' '}
+      <a
+        href="https://reactjs.org/docs/render-props.html"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        render prop
+      </a>
+      .
+    </StoryDescription>
+
+    <GridForm
+      fields={[
+        {
+          render: ({ error, setValue }) => (
+            <>
+              <Input
+                error={!!error}
+                id="custom-text-input"
+                type="text"
+                onChange={event => setValue(event.target.value)}
+              />
+              <span aria-label="Dancing person" role="img">
+                🕺
+              </span>
+            </>
+          ),
+          label: 'Gimme two more swags',
+          name: 'custom-input',
+          validation: {
+            required: true,
+            pattern: {
+              value: /swag(.*)swag/,
+              message: 'Still not enough swag, what are you doing... 💢',
+            },
+          },
+          size: 12,
+          type: 'custom',
         },
       ]}
       onSubmit={async values => {


### PR DESCRIPTION
## Added 'custom' field type to GridForm

Some forms, such as the checkout flows that use Recurly, need to define their own inputs. This adds a `'custom'` field type to `GridForm` with a [render prop](https://reactjs.org/docs/render-props.html) to allow such a thing.

Most notably, that render prop receives both a `react-hook-form`-style `register` and a traditional React-style `setValue`, which it can use either of to hook up its state. 