### PR TITLE
feat(styleguide): corrected displayLabel/large prop name for ProgressBar story

### DIFF
--- a/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
@@ -15,14 +15,14 @@ export default decoratedStory('Atoms', ProgressBar);
 
 const bars = [
   {
-    displayLabel: false,
+    large: false,
     style: {
       backgroundColor: colors.blue[100],
       barColor: colors.blue[700],
     },
   },
   {
-    displayLabel: true,
+    large: true,
     style: {
       backgroundColor: colors.gray[100],
       barColor: colors.yellow[500],
@@ -39,18 +39,14 @@ export const progressBar = () => (
       might show one on a quiz page indicating how many questions have been
       completed.
       <br />
-      Bars that <code>displayLabel</code> are thicker, and will display a
+      Bars with <code>large</code> specified are thicker, and will display a
       percentage label if a font color is specified.
     </StoryDescription>
     <LayoutGrid className={styles.progressBarGrid} columnGap="sm" rowGap="sm">
       {[0, 25, 50, 75, 100].map(percent =>
-        bars.map(({ displayLabel, style }) => (
-          <Column key={[percent, displayLabel, style].join()} size={6}>
-            <ProgressBar
-              displayLabel={displayLabel}
-              percent={percent}
-              style={style}
-            />
+        bars.map(({ large, style }) => (
+          <Column key={[percent, large, style].join()} size={6}>
+            <ProgressBar large={large} percent={percent} style={style} />
           </Column>
         ))
       )}


### PR DESCRIPTION
## Corrected displayLabel/large prop name for ProgressBar story

It was switched to `large` around the same time as I redid stories. Oops.