### PR TITLE
feat(Gamut): added ProgressBar minimumPercent and theme props

### DIFF
--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -1,17 +1,45 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import ProgressBar from '..';
+import ProgressBar, { ProgressBarProps } from '..';
+
+const renderComponent = (overrides: Partial<ProgressBarProps> = {}) => {
+  return mount(<ProgressBar percent={50} theme="blue" {...overrides} />);
+};
 
 describe('ProgressBar', () => {
+  it('uses percentage as width when no minimumPercent is provided', () => {
+    const wrapped = renderComponent({ percent: 50 });
+
+    expect(
+      wrapped.find('[data-testid="progress-bar-bar"]').prop('style')
+    ).toHaveProperty('width', '50%');
+  });
+
+  it('uses percentage as width when it is greater than minimumPercent', () => {
+    const wrapped = renderComponent({ minimumPercent: 25, percent: 50 });
+
+    expect(
+      wrapped.find('[data-testid="progress-bar-bar"]').prop('style')
+    ).toHaveProperty('width', '50%');
+  });
+
+  it('uses minimumPercentage as width when it is greater than percent', () => {
+    const wrapped = renderComponent({ minimumPercent: 75, percent: 50 });
+
+    expect(
+      wrapped.find('[data-testid="progress-bar-bar"]').prop('style')
+    ).toHaveProperty('width', '75%');
+  });
+
   it('does not include percentage visually when large is false', () => {
-    const wrapped = mount(<ProgressBar percent={50} theme="blue" />);
+    const wrapped = renderComponent({ large: false });
 
     expect(wrapped.text()).toEqual('');
   });
 
   it('includes percentage visually when large is true', () => {
-    const wrapped = mount(<ProgressBar large percent={50} theme="blue" />);
+    const wrapped = renderComponent({ large: true });
 
     expect(wrapped.text()).toEqual('50%');
   });

--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -3,21 +3,15 @@ import React from 'react';
 
 import ProgressBar from '..';
 
-const stubStyle = {
-  backgroundColor: 'black',
-  barColor: 'darkgrey',
-  fontColor: 'pink',
-};
-
 describe('ProgressBar', () => {
   it('does not include percentage visually when large is false', () => {
-    const wrapped = mount(<ProgressBar percent={50} style={stubStyle} />);
+    const wrapped = mount(<ProgressBar percent={50} theme="blue" />);
 
     expect(wrapped.text()).toEqual('');
   });
 
   it('includes percentage visually when large is true', () => {
-    const wrapped = mount(<ProgressBar large percent={50} style={stubStyle} />);
+    const wrapped = mount(<ProgressBar large percent={50} theme="blue" />);
 
     expect(wrapped.text()).toEqual('50%');
   });

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -14,6 +14,11 @@ export type ProgressBarProps = {
   large?: boolean;
 
   /**
+   * Minimum amount of the bar to fill in visually.
+   */
+  minimumPercent?: number;
+
+  /**
    * How much of the bar to fill in, as a number in [0, 100].
    */
   percent: number;
@@ -24,16 +29,16 @@ export type ProgressBarProps = {
 export const ProgressBar: React.FC<ProgressBarProps> = ({
   className,
   large,
+  minimumPercent = 0,
   percent,
   theme,
 }) => {
   const height = large ? 36 : 6;
   const radius = `${height / 2}px`;
-  const visualPercent = `${percent}%`;
 
   return (
     <div
-      aria-label={`Progress: ${visualPercent}`}
+      aria-label={`Progress: ${percent}%`}
       aria-live="polite"
       className={cx(styles.progressBar, styles[theme], className)}
       style={{
@@ -43,17 +48,16 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
     >
       <div
         className={styles.bar}
+        data-testid="progress-bar-bar"
         style={{
-          width: visualPercent,
+          width: `${Math.max(minimumPercent, percent)}%`,
           ...(large && {
             borderTopRightRadius: radius,
             borderBottomRightRadius: radius,
           }),
         }}
       >
-        {large && (
-          <span className={styles.displayedPercent}>{visualPercent}</span>
-        )}
+        {large && <span className={styles.displayedPercent}>{percent}%</span>}
       </div>
     </div>
   );

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import styles from './styles.module.scss';
 
+export type ProgressBarTheme = 'blue' | 'yellow';
+
 export type ProgressBarProps = {
   className?: string;
 
@@ -16,22 +18,15 @@ export type ProgressBarProps = {
    */
   percent: number;
 
-  style: ProgressBarStyle;
-};
-
-export type ProgressBarStyle = {
-  backgroundColor: string;
-  barColor: string;
-  fontColor?: string;
+  theme: ProgressBarTheme;
 };
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
   className,
   large,
   percent,
-  style,
+  theme,
 }) => {
-  const { backgroundColor, barColor, fontColor } = style;
   const height = large ? 36 : 6;
   const radius = `${height / 2}px`;
   const visualPercent = `${percent}%`;
@@ -40,18 +35,15 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
     <div
       aria-label={`Progress: ${visualPercent}`}
       aria-live="polite"
-      className={cx(styles.progressBar, className)}
+      className={cx(styles.progressBar, styles[theme], className)}
       style={{
-        background: backgroundColor,
         borderRadius: radius,
-        color: fontColor,
         height: `${height}px`,
       }}
     >
       <div
         className={styles.bar}
         style={{
-          background: barColor,
           width: visualPercent,
           ...(large && {
             borderTopRightRadius: radius,

--- a/packages/gamut/src/ProgressBar/styles.module.scss
+++ b/packages/gamut/src/ProgressBar/styles.module.scss
@@ -2,6 +2,14 @@
 
 .progressBar {
   overflow: hidden;
+
+  &.blue {
+    background: $color-blue-100;
+  }
+
+  &.yellow {
+    background: $color-gray-100;
+  }
 }
 
 .bar {
@@ -9,6 +17,14 @@
   display: flex;
   height: 100%;
   transition: width 0.5s;
+
+  .blue & {
+    background: $color-blue-700;
+  }
+
+  .yellow & {
+    background: $color-yellow-500;
+  }
 }
 
 .displayedPercent {
@@ -16,4 +32,8 @@
   padding: 0.5rem;
   text-align: right;
   width: 100%;
+
+  .yellow & {
+    color: $color-black;
+  }
 }

--- a/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { ProgressBar, LayoutGrid, Column } from '@codecademy/gamut/src';
-import { colors } from '@codecademy/gamut-styles/utils/variables';
 
 import styles from './styles.module.scss';
 import {
@@ -17,20 +16,13 @@ export default decoratedStories('Atoms', ProgressBar);
 const bars = [
   {
     large: false,
-    style: {
-      backgroundColor: colors.blue[100],
-      barColor: colors.blue[700],
-    },
+    theme: 'blue',
   },
   {
     large: true,
-    style: {
-      backgroundColor: colors.gray[100],
-      barColor: colors.yellow[500],
-      fontColor: colors.black,
-    },
+    theme: 'yellow',
   },
-];
+] as const;
 
 export const progressBar = decoratedStory(() => (
   <StoryTemplate status={StoryStatus.InProgress}>
@@ -45,9 +37,9 @@ export const progressBar = decoratedStory(() => (
     </StoryDescription>
     <LayoutGrid className={styles.progressBarGrid} columnGap="sm" rowGap="sm">
       {[0, 25, 50, 75, 100].map(percent =>
-        bars.map(({ large, style }) => (
-          <Column key={[percent, large, style].join()} size={6}>
-            <ProgressBar large={large} percent={percent} style={style} />
+        bars.map(({ large, theme }) => (
+          <Column key={[percent, large, theme].join()} size={6}>
+            <ProgressBar large={large} percent={percent} theme={theme} />
           </Column>
         ))
       )}

--- a/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
@@ -10,6 +10,7 @@ import {
   StoryDescription,
   decoratedStory,
 } from '../../Templating';
+import { number } from '@storybook/addon-knobs';
 
 export default decoratedStories('Atoms', ProgressBar);
 
@@ -46,3 +47,21 @@ export const progressBar = decoratedStory(() => (
     </LayoutGrid>
   </StoryTemplate>
 ));
+
+export const progressBarMinimumPercent = decoratedStory(
+  'Minimum Percentage',
+  () => (
+    <StoryTemplate status={StoryStatus.InProgress}>
+      <StoryDescription>
+        Some bars (generally small ones) should display at least a little bit of
+        progress, even if the technical progress number is zero. You can use the
+        <code>minimumPercent</code> prop for a minimum visual width percentage.
+      </StoryDescription>
+      <ProgressBar
+        minimumPercent={number('Minimum Percent', 5)}
+        percent={number('Percent', 0)}
+        theme="blue"
+      />
+    </StoryTemplate>
+  )
+);


### PR DESCRIPTION
## Added ProgressBar minimumPercent and theme props

* `minimumPercent` addresses the existing logic in our small blue bars that always show at least ~5% progress.
* `theme` replaces the more convoluted `style` prop and restricts us to just the approved `blue` and `yellow` themes.

As with other ProgressBar PRs, since it's not used anywhere, I'm not going to bother marking this PR as a breaking change.