### PR TITLE
fix(Alert): Export BannerType enum to be used from root

### DIFF
--- a/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
+++ b/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
@@ -18,6 +18,7 @@ Array [
   "Badge",
   "Banner",
   "BannerStyle",
+  "BannerType",
   "BayesIcon",
   "BellIcon",
   "BulbIcon",

--- a/packages/gamut/src/Alert/index.tsx
+++ b/packages/gamut/src/Alert/index.tsx
@@ -123,4 +123,6 @@ export const Alert: React.FC<AlertProps> = ({
   );
 };
 
+export { BannerType } from './constants';
+
 export default Alert;


### PR DESCRIPTION
This was not exported before and needed to be pulled in from `/dist` 