### PR TITLE
feat(Gamut): switched ProgressBar back to taking in a 'style' prop

### DIFF
--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -3,8 +3,13 @@ import React from 'react';
 
 import ProgressBar, { ProgressBarProps } from '..';
 
+const stubStyle = {
+  backgroundColor: 'pink',
+  barColor: 'magenta',
+};
+
 const renderComponent = (overrides: Partial<ProgressBarProps> = {}) => {
-  return mount(<ProgressBar percent={50} theme="blue" {...overrides} />);
+  return mount(<ProgressBar percent={50} style={stubStyle} {...overrides} />);
 };
 
 describe('ProgressBar', () => {

--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -3,13 +3,8 @@ import React from 'react';
 
 import ProgressBar, { ProgressBarProps } from '..';
 
-const stubStyle = {
-  backgroundColor: 'pink',
-  barColor: 'magenta',
-};
-
 const renderComponent = (overrides: Partial<ProgressBarProps> = {}) => {
-  return mount(<ProgressBar percent={50} style={stubStyle} {...overrides} />);
+  return mount(<ProgressBar percent={50} theme="blue" {...overrides} />);
 };
 
 describe('ProgressBar', () => {

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 
 import styles from './styles.module.scss';
 
-export type ProgressBarTheme = 'blue' | 'yellow';
-
 export type ProgressBarProps = {
   className?: string;
 
@@ -23,7 +21,13 @@ export type ProgressBarProps = {
    */
   percent: number;
 
-  theme: ProgressBarTheme;
+  style: ProgressBarStyle;
+};
+
+export type ProgressBarStyle = {
+  backgroundColor: string;
+  barColor: string;
+  fontColor?: string;
 };
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
@@ -31,8 +35,9 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   large,
   minimumPercent = 0,
   percent,
-  theme,
+  style,
 }) => {
+  const { backgroundColor, barColor, fontColor } = style;
   const height = large ? 36 : 6;
   const radius = `${height / 2}px`;
 
@@ -40,9 +45,11 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
     <div
       aria-label={`Progress: ${percent}%`}
       aria-live="polite"
-      className={cx(styles.progressBar, styles[theme], className)}
+      className={cx(styles.progressBar, className)}
       style={{
+        background: backgroundColor,
         borderRadius: radius,
+        color: fontColor,
         height: `${height}px`,
       }}
     >
@@ -50,6 +57,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
         className={styles.bar}
         data-testid="progress-bar-bar"
         style={{
+          background: barColor,
           width: `${Math.max(minimumPercent, percent)}%`,
           ...(large && {
             borderTopRightRadius: radius,

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -21,12 +21,20 @@ export type ProgressBarProps = {
    */
   percent: number;
 
-  style: ProgressBarStyle;
+  /**
+   * Style overrides to apply on top of the theme, if any.
+   */
+  style?: ProgressBarStyle;
+
+  /**
+   * Base color theme to extend from.
+   */
+  theme: 'blue' | 'yellow';
 };
 
 export type ProgressBarStyle = {
-  backgroundColor: string;
-  barColor: string;
+  backgroundColor?: string;
+  barColor?: string;
   fontColor?: string;
 };
 
@@ -35,7 +43,8 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   large,
   minimumPercent = 0,
   percent,
-  style,
+  style = {},
+  theme,
 }) => {
   const { backgroundColor, barColor, fontColor } = style;
   const height = large ? 36 : 6;
@@ -45,7 +54,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
     <div
       aria-label={`Progress: ${percent}%`}
       aria-live="polite"
-      className={cx(styles.progressBar, className)}
+      className={cx(styles.progressBar, styles[theme], className)}
       style={{
         background: backgroundColor,
         borderRadius: radius,

--- a/packages/gamut/src/ProgressBar/styles.module.scss
+++ b/packages/gamut/src/ProgressBar/styles.module.scss
@@ -2,14 +2,6 @@
 
 .progressBar {
   overflow: hidden;
-
-  &.blue {
-    background: $color-blue-100;
-  }
-
-  &.yellow {
-    background: $color-gray-800;
-  }
 }
 
 .bar {
@@ -17,14 +9,6 @@
   display: flex;
   height: 100%;
   transition: width 0.5s;
-
-  .blue & {
-    background: $color-blue-700;
-  }
-
-  .yellow & {
-    background: $color-yellow-500;
-  }
 }
 
 .displayedPercent {
@@ -32,8 +16,4 @@
   padding: 0.5rem;
   text-align: right;
   width: 100%;
-
-  .yellow & {
-    color: $color-black;
-  }
 }

--- a/packages/gamut/src/ProgressBar/styles.module.scss
+++ b/packages/gamut/src/ProgressBar/styles.module.scss
@@ -2,6 +2,14 @@
 
 .progressBar {
   overflow: hidden;
+
+  &.blue {
+    background: $color-blue-100;
+  }
+
+  &.yellow {
+    background: $color-gray-100;
+  }
 }
 
 .bar {
@@ -9,6 +17,14 @@
   display: flex;
   height: 100%;
   transition: width 0.5s;
+
+  .blue & {
+    background: $color-blue-700;
+  }
+
+  .yellow & {
+    background: $color-yellow-500;
+  }
 }
 
 .displayedPercent {
@@ -16,4 +32,8 @@
   padding: 0.5rem;
   text-align: right;
   width: 100%;
+
+  .yellow & {
+    color: $color-black;
+  }
 }

--- a/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ProgressBar, LayoutGrid, Column } from '@codecademy/gamut/src';
+import { colors } from '@codecademy/gamut-styles/utils/variables';
 
 import styles from './styles.module.scss';
 import {
@@ -17,11 +18,18 @@ export default decoratedStories('Atoms', ProgressBar);
 const bars = [
   {
     large: false,
-    theme: 'blue',
+    style: {
+      backgroundColor: colors.blue[100],
+      barColor: colors.blue[700],
+    },
   },
   {
     large: true,
-    theme: 'yellow',
+    style: {
+      backgroundColor: colors.gray[100],
+      barColor: colors.yellow[500],
+      fontColor: colors.black,
+    },
   },
 ] as const;
 
@@ -33,14 +41,14 @@ export const progressBar = decoratedStory(() => (
       might show one on a quiz page indicating how many questions have been
       completed.
       <br />
-      Bars with <code>large</code> specified are thicker, and will display a
-      percentage label if a font color is specified.
+      Bars with <code>large</code> specified are thicker and will display a
+      percentage label.
     </StoryDescription>
     <LayoutGrid className={styles.progressBarGrid} columnGap="sm" rowGap="sm">
       {[0, 25, 50, 75, 100].map(percent =>
-        bars.map(({ large, theme }) => (
-          <Column key={[percent, large, theme].join()} size={6}>
-            <ProgressBar large={large} percent={percent} theme={theme} />
+        bars.map(({ large, style }) => (
+          <Column key={[percent, large].join()} size={6}>
+            <ProgressBar large={large} percent={percent} style={style} />
           </Column>
         ))
       )}
@@ -60,7 +68,7 @@ export const progressBarMinimumPercent = decoratedStory(
       <ProgressBar
         minimumPercent={number('Minimum Percent', 5)}
         percent={number('Percent', 0)}
-        theme="blue"
+        style={bars[0].style}
       />
     </StoryTemplate>
   )

--- a/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/styleguide/stories/Atoms/ProgressBar/ProgressBar.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { ProgressBar, LayoutGrid, Column } from '@codecademy/gamut/src';
-import { colors } from '@codecademy/gamut-styles/utils/variables';
 
 import styles from './styles.module.scss';
 import {
@@ -12,24 +11,18 @@ import {
   decoratedStory,
 } from '../../Templating';
 import { number } from '@storybook/addon-knobs';
+import { colors } from '@codecademy/gamut-styles/utils/variables';
 
 export default decoratedStories('Atoms', ProgressBar);
 
 const bars = [
   {
     large: false,
-    style: {
-      backgroundColor: colors.blue[100],
-      barColor: colors.blue[700],
-    },
+    theme: 'blue',
   },
   {
     large: true,
-    style: {
-      backgroundColor: colors.gray[100],
-      barColor: colors.yellow[500],
-      fontColor: colors.black,
-    },
+    theme: 'yellow',
   },
 ] as const;
 
@@ -41,14 +34,14 @@ export const progressBar = decoratedStory(() => (
       might show one on a quiz page indicating how many questions have been
       completed.
       <br />
-      Bars with <code>large</code> specified are thicker and will display a
-      percentage label.
+      Bars with <code>large</code> specified are thicker, and will display a
+      percentage label if a font color is specified.
     </StoryDescription>
     <LayoutGrid className={styles.progressBarGrid} columnGap="sm" rowGap="sm">
       {[0, 25, 50, 75, 100].map(percent =>
-        bars.map(({ large, style }) => (
-          <Column key={[percent, large].join()} size={6}>
-            <ProgressBar large={large} percent={percent} style={style} />
+        bars.map(({ large, theme }) => (
+          <Column key={[percent, large, theme].join()} size={6}>
+            <ProgressBar large={large} percent={percent} theme={theme} />
           </Column>
         ))
       )}
@@ -68,7 +61,30 @@ export const progressBarMinimumPercent = decoratedStory(
       <ProgressBar
         minimumPercent={number('Minimum Percent', 5)}
         percent={number('Percent', 0)}
-        style={bars[0].style}
+        theme="blue"
+      />
+    </StoryTemplate>
+  )
+);
+
+export const progressBarStyleOverrides = decoratedStory(
+  'Style Overrides',
+  () => (
+    <StoryTemplate status={StoryStatus.InProgress}>
+      <StoryDescription>
+        For the sake of rapid iteration, you can pass in custom style colors via
+        the <code>style</code> prop.
+      </StoryDescription>
+      <ProgressBar
+        minimumPercent={number('Minimum Percent', 5)}
+        large
+        percent={number('Percent', 0)}
+        style={{
+          backgroundColor: colors.red[900],
+          barColor: colors.red[600],
+          fontColor: colors.white,
+        }}
+        theme="blue"
       />
     </StoryTemplate>
   )


### PR DESCRIPTION
## Switched ProgressBar back to taking in a 'style' prop

Per discussions with @hmafzal, our preference (#749) is to keep atoms open to custom themes while we flesh out their usage. `ProgressBar` is still pretty new so we're going to want to keep it theme-happy. 