### PR TITLE
feat(Gamut): corrected ProgressBar blues

### DIFF
--- a/packages/gamut/src/ProgressBar/styles.module.scss
+++ b/packages/gamut/src/ProgressBar/styles.module.scss
@@ -4,7 +4,7 @@
   overflow: hidden;
 
   &.blue {
-    background: $color-blue-100;
+    background: $color-blue-800;
   }
 
   &.yellow {
@@ -19,7 +19,7 @@
   transition: width 0.5s;
 
   .blue & {
-    background: $color-blue-700;
+    background: $color-blue-500;
   }
 
   .yellow & {


### PR DESCRIPTION

## Corrected ProgressBar blues 

I swear, this component is a gift that keeps on giving...
🎶 

Before:
![image](https://user-images.githubusercontent.com/3335181/80548537-2905eb00-8989-11ea-8ffa-b1dd85df7b2d.png)

After:
![image](https://user-images.githubusercontent.com/3335181/80548578-420e9c00-8989-11ea-9c25-ae4d6dc54495.png)
