### PR TITLE
feat(Gamut): added RadioGroup inputs for GridForm

### DIFF
--- a/packages/gamut/src/Form/RadioGroup.tsx
+++ b/packages/gamut/src/Form/RadioGroup.tsx
@@ -1,7 +1,11 @@
-import React, { cloneElement, HTMLAttributes } from 'react';
+import React, {
+  cloneElement,
+  HTMLAttributes,
+  InputHTMLAttributes,
+} from 'react';
 
 export type RadioGroupProps = Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> &
-  Pick<HTMLAttributes<HTMLInputElement>, 'onChange'> & {
+  Pick<InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
     /**
      * @remarks This is meant to be `Radio`s.
      */
@@ -18,7 +22,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   name,
   ...rest
 }) => (
-  <div {...(rest as HTMLAttributes<HTMLDivElement>)}>
+  <div {...rest}>
     {React.Children.map(children, (child, index) =>
       cloneElement(child, {
         onChange: onChange,

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from 'react';
+import { FormContextValues } from 'react-hook-form';
+
+import { RadioGroup, Radio } from '../../../Form';
+import { GridFormRadioGroupField } from '../../types';
+
+export type GridFormRadioGroupInputProps = {
+  className?: string;
+  field: Omit<GridFormRadioGroupField, 'label'>;
+  register: FormContextValues['register'];
+  setValue: (name: string, value: string) => void;
+};
+
+export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = ({
+  className,
+  field,
+  register,
+  setValue,
+}) => {
+  useEffect(() => {
+    register(field.name, field.validation);
+  }, [field.name, field.validation, register]);
+
+  return (
+    <RadioGroup
+      className={className}
+      htmlForPrefix={field.name}
+      name={field.name}
+      onChange={event => {
+        const { value } = event.target;
+        setValue(field.name, value);
+        field.onUpdate?.(value);
+      }}
+    >
+      {field.options.map(({ label, value }) => (
+        <Radio key={value} label={label} value={value} />
+      ))}
+    </RadioGroup>
+  );
+};
+
+export default GridFormRadioGroupInput;

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -58,7 +58,7 @@ describe('GridFormInputGroup', () => {
       field: stubSelectField,
     });
 
-    expect(wrapped.find('input[type=radio]')).toHaveLength(2);
+    expect(wrapped.find('input[type="radio"]')).toHaveLength(2);
   });
 
   it('renders a select when the field type is select', () => {

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -53,6 +53,14 @@ describe('GridFormInputGroup', () => {
     expect(wrapped.text()).toEqual(text);
   });
 
+  it('renders a radio group when the field type is radio-group', () => {
+    const { wrapped } = renderComponent({
+      field: stubSelectField,
+    });
+
+    expect(wrapped.find('input[type=radio]')).toHaveLength(2);
+  });
+
   it('renders a select when the field type is select', () => {
     const { wrapped } = renderComponent({
       field: stubSelectField,

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {
   stubFileField,
+  stubRadioGroupField,
   stubSelectField,
   stubTextField,
   stubTextareaField,
@@ -55,7 +56,7 @@ describe('GridFormInputGroup', () => {
 
   it('renders a radio group when the field type is radio-group', () => {
     const { wrapped } = renderComponent({
-      field: stubSelectField,
+      field: stubRadioGroupField,
     });
 
     expect(wrapped.find('input[type="radio"]')).toHaveLength(2);

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -7,6 +7,7 @@ import { GridFormField } from '../types';
 import GridFormCheckboxInput from './GridFormCheckboxInput';
 import GridFormCustomInput from './GridFormCustomInput';
 import GridFormFileInput from './GridFormFileInput';
+import GridFormRadioGroupInput from './GridFormRadioGroupInput';
 import GridFormTextInput from './GridFormTextInput';
 import GridFormSelectInput from './GridFormSelectInput';
 import GridFormTextArea from './GridFormTextArea';
@@ -49,6 +50,16 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = props => {
             error={!!props.error}
             field={props.field}
             register={props.register}
+          />
+        );
+
+      case 'radio-group':
+        return (
+          <GridFormRadioGroupInput
+            className={styles.gridFormInput}
+            field={props.field}
+            register={props.register}
+            setValue={props.setValue}
           />
         );
 

--- a/packages/gamut/src/GridForm/__tests__/stubs.ts
+++ b/packages/gamut/src/GridForm/__tests__/stubs.ts
@@ -13,7 +13,25 @@ export const stubCheckboxField: GridFormCheckboxField = {
   type: 'checkbox',
 };
 
-export const stubSelectOptions: string[] = ['aaa', 'bbb'];
+export const stubRadioGroupOptions = [
+  {
+    name: 'Blue Team',
+    value: 'blue',
+  },
+  {
+    name: 'Red Team',
+    value: 'red',
+  },
+];
+
+export const stubRadioGroup = {
+  label: 'Stub Radio Group',
+  options: stubRadioGroupOptions,
+  name: 'stub-radio-group',
+  type: 'radio',
+};
+
+export const stubSelectOptions = ['aaa', 'bbb'];
 
 export const stubSelectField: GridFormSelectField = {
   label: 'Stub Select',
@@ -21,6 +39,7 @@ export const stubSelectField: GridFormSelectField = {
   name: 'stub-select',
   type: 'select',
 };
+
 export const stubTextField: GridFormTextField = {
   label: 'Stub Text',
   name: 'stub-text',

--- a/packages/gamut/src/GridForm/__tests__/stubs.ts
+++ b/packages/gamut/src/GridForm/__tests__/stubs.ts
@@ -4,6 +4,8 @@ import {
   GridFormSelectField,
   GridFormTextField,
   GridFormTextAreaField,
+  GridFormRadioGroupField,
+  GridFormRadioOption,
 } from '../types';
 
 export const stubCheckboxField: GridFormCheckboxField = {
@@ -13,22 +15,22 @@ export const stubCheckboxField: GridFormCheckboxField = {
   type: 'checkbox',
 };
 
-export const stubRadioGroupOptions = [
+export const stubRadioGroupOptions: GridFormRadioOption[] = [
   {
-    name: 'Blue Team',
+    label: 'Blue Team',
     value: 'blue',
   },
   {
-    name: 'Red Team',
+    label: 'Red Team',
     value: 'red',
   },
 ];
 
-export const stubRadioGroup = {
+export const stubRadioGroupField: GridFormRadioGroupField = {
   label: 'Stub Radio Group',
   options: stubRadioGroupOptions,
   name: 'stub-radio-group',
-  type: 'radio',
+  type: 'radio-group',
 };
 
 export const stubSelectOptions = ['aaa', 'bbb'];

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -38,6 +38,18 @@ export type GridFormTextField = BaseFormField<string> & {
   type: 'text' | 'email';
 };
 
+export type GridFormRadioOption = {
+  label: string;
+  value: string;
+};
+
+export type GridFormRadioGroupField = BaseFormField<string> & {
+  label: string;
+  options: GridFormRadioOption[];
+  validation?: Pick<ValidationOptions, 'required'>;
+  type: 'radio-group';
+};
+
 export type GridFormSelectField = BaseFormField<string> & {
   label: string;
   options: string[] | Record<string, number | string>;
@@ -60,6 +72,7 @@ export type GridFormTextAreaField = BaseFormField<string> & {
 export type GridFormField =
   | GridFormCheckboxField
   | GridFormCustomField
+  | GridFormRadioGroupField
   | GridFormTextField
   | GridFormSelectField
   | GridFormFileField

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -102,7 +102,7 @@ export const gridForm = decoratedStory(() => (
           label:
             "Validated, required text that must contain the word 'swag' twice",
           name: 'validated-required-text',
-          size: 9,
+          size: 5,
           type: 'text',
           validation: {
             required: true,
@@ -118,6 +118,22 @@ export const gridForm = decoratedStory(() => (
           name: 'enough-swag',
           size: 3,
           type: 'checkbox',
+        },
+        {
+          label: 'Preferred Modern Artist',
+          name: 'artist',
+          options: [
+            {
+              label: 'Cardi B',
+              value: 'cardi',
+            },
+            {
+              label: 'Nicki Minaj',
+              value: 'nicki',
+            },
+          ],
+          size: 4,
+          type: 'radio-group',
         },
         {
           label: 'End User License Agreement',


### PR DESCRIPTION
## Added RadioGroup inputs for GridForm

It's a pretty typical input form, except that there isn't a single input element to `ref` with -- so it uses a manual `setValue` call.