### PR TITLE
fix(Gamut): Removed unnecessary useEffect registers in GridForm

### DIFF
--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -60,12 +60,6 @@ export function GridForm<
     ),
   });
 
-  useEffect(() => {
-    for (const field of fields) {
-      register({ name: field.name });
-    }
-  }, [fields, register]);
-
   return (
     <Form className={className} onSubmit={handleSubmit(onSubmit)}>
       <LayoutGrid columnGap={columnGap} rowGap={rowGap}>

--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useForm, FieldError } from 'react-hook-form';
 
 import { Form } from '../Form';


### PR DESCRIPTION
## Removed unnecessary useEffect registers in GridForm

In our static Gatsby site's `GridForm`, `register` is getting called twice per input element... once in the React logic `ref={register(field.validation)}`, then a second time in the GridForm's `useEffect` that does `register({ name: field.name })`. That means react-hook-form's understanding of the field gets overridden to that second, dumb object, which doesn't know anything.

On the monolith, we rerender in React a bunch of times unnecessarily, so the component's ref overrides the dumb object (so, 3 or more registrations), and this bug gets fixed by accident.

