### PR TITLE
feat(StepNavigation): Add StepNavigation component

### DIFF
--- a/packages/gamut/src/StepNavigation/__tests__/StepNavigation-test.tsx
+++ b/packages/gamut/src/StepNavigation/__tests__/StepNavigation-test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import StepNavigation from '../index';
+
+describe('StepNavigation', () => {
+  const noOp = () => {};
+  const steps = ['StepOne', 'StepTwo', 'StepThree'];
+
+  const renderComponent = (currentStep: string, onStepClick = noOp) => {
+    return mount(
+      <StepNavigation
+        steps={steps}
+        currentStep={currentStep}
+        onStepClick={onStepClick}
+      />
+    );
+  };
+
+  it('displays the name of each step', () => {
+    const wrapper = renderComponent('StepOne');
+
+    expect(wrapper.find(`[data-testid='stepone-nav']`)).toIncludeText(
+      'StepOne'
+    );
+    expect(wrapper.find(`[data-testid='steptwo-nav']`)).toIncludeText(
+      'StepTwo'
+    );
+    expect(wrapper.find(`[data-testid='stepthree-nav']`)).toIncludeText(
+      'StepThree'
+    );
+  });
+
+  it('applies a current class only to the second step', () => {
+    const wrapper = renderComponent('StepTwo');
+
+    expect(wrapper.find(`[data-testid='stepone-nav']`)).toHaveClassName(
+      'visited'
+    );
+    expect(wrapper.find(`[data-testid='steptwo-nav']`)).toHaveClassName(
+      'current'
+    );
+    expect(wrapper.find(`[data-testid='stepthree-nav']`)).toHaveClassName(
+      'remaining'
+    );
+  });
+
+  it('applies a current class only to the first step', () => {
+    const wrapper = renderComponent('StepOne');
+
+    expect(wrapper.find(`[data-testid='stepone-nav']`)).toHaveClassName(
+      'current'
+    );
+    expect(wrapper.find(`[data-testid='steptwo-nav']`)).toHaveClassName(
+      'remaining'
+    );
+    expect(wrapper.find(`[data-testid='stepthree-nav']`)).toHaveClassName(
+      'remaining'
+    );
+  });
+
+  it('applies visited class to previous steps', () => {
+    const wrapper = renderComponent('StepThree');
+
+    expect(wrapper.find(`[data-testid='stepone-nav']`)).toHaveClassName(
+      'visited'
+    );
+    expect(wrapper.find(`[data-testid='steptwo-nav']`)).toHaveClassName(
+      'visited'
+    );
+    expect(wrapper.find(`[data-testid='stepthree-nav']`)).toHaveClassName(
+      'current'
+    );
+  });
+
+  it('passes clicked step to callback', () => {
+    const stepClickSpy = jest.fn();
+
+    const wrapper = renderComponent('StepTwo', stepClickSpy);
+
+    wrapper.find(`[data-testid='stepone-nav']`).simulate('click');
+
+    expect(stepClickSpy).toHaveBeenCalledWith('StepOne');
+  });
+
+  it('does NOT allow clicking on a remaining link', () => {
+    const stepClickSpy = jest.fn();
+
+    const wrapper = renderComponent('StepOne', stepClickSpy);
+
+    wrapper.find(`[data-testid='steptwo-nav']`).simulate('click');
+
+    expect(stepClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT allow clicking on a current link', () => {
+    const stepClickSpy = jest.fn();
+
+    const wrapper = renderComponent('StepOne', stepClickSpy);
+
+    wrapper.find(`[data-testid='stepone-nav']`).simulate('click');
+
+    expect(stepClickSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gamut/src/StepNavigation/index.tsx
+++ b/packages/gamut/src/StepNavigation/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styles from './styles.scss';
+import { ChevronRightIcon } from '@codecademy/gamut';
+
+type StepNavigationProps = {
+  steps: string[];
+  currentStep: string;
+  onStepClick: (step: string) => void;
+};
+
+const isVisited = (steps: string[], step: string, currentStep: string) => {
+  return steps.indexOf(step) < steps.indexOf(currentStep);
+};
+
+const getClassName = (steps: string[], step: string, currentStep: string) => {
+  if (isVisited(steps, step, currentStep)) {
+    return styles.visited;
+  } else if (currentStep === step) {
+    return styles.current;
+  } else {
+    return styles.remaining;
+  }
+};
+
+const isLastStep = (steps: string[], index: number) => {
+  return steps.length - 1 === index;
+};
+
+const StepNavigation: React.FC<StepNavigationProps> = props => {
+  return (
+    <nav className={styles.wrapper} data-testid="stepNavigation">
+      <ol>
+        {props.steps.map((step, index) => {
+          return (
+            <li key={step}>
+              <button
+                data-testid={`${step.toLowerCase()}-nav`}
+                className={getClassName(props.steps, step, props.currentStep)}
+                disabled={!isVisited(props.steps, step, props.currentStep)}
+                onClick={() => props.onStepClick(step)}
+                type="button"
+              >
+                {step}
+              </button>
+              {!isLastStep(props.steps, index) && (
+                <ChevronRightIcon className={styles.chevron} width=".8rem" />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+};
+
+export default StepNavigation;

--- a/packages/gamut/src/StepNavigation/styles.scss
+++ b/packages/gamut/src/StepNavigation/styles.scss
@@ -1,0 +1,58 @@
+@import "~styles/cc";
+
+ol {
+  display: none;
+
+  li {
+    display: inline;
+  }
+
+  button {
+    border: 0;
+
+    &:disabled {
+      color: $color-gray-900;
+    }
+  }
+
+  .chevron {
+    color: $color-gray-400;
+    margin: 0 18px -6px;
+  }
+}
+
+.visited {
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}
+
+.current {
+  font-weight: bold;
+  font-color: $color-gray-900;
+}
+
+.remaining {
+  &:disabled {
+    color: $color-gray-400;
+  }
+}
+
+@include md-viewport {
+  ol {
+    display: block;
+    margin: 0;
+  }
+}
+
+.wrapper {
+  display: none;
+}
+
+@include md-viewport {
+  .wrapper {
+    display: flex;
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
## Adds StepNavigation component

StepNavigation is a navigation component that allows users to revisit previous steps while seeing which steps are upcoming. The component takes a list of `steps`, and a `currentStep`. The `currentStep` is assumed to be a member of the `steps` list. 

When the steps are rendered they are marked with either a `visited`, `current`, or `remaining` class based on where they are in relation to the current step. Each class determines how a user can interact with that step. The steps have the following interactions:

- `visited` can be clicked on by the user
- `current` is bolded, but not clickable
- `remaining` is slightly greyed, and not clickable

When a `visited` step is clicked, it calls the `onStepClick` handler that is passed to StepNavigation component.

---
This was co-authored by:
@masungwon 
@JennMiller 

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
