### PR TITLE
chore(Gamut): Removed unused deprecated button themes

### DIFF
--- a/packages/gamut-styles/utils/variables/_colors.scss
+++ b/packages/gamut-styles/utils/variables/_colors.scss
@@ -207,8 +207,6 @@ $deprecated-color-grey-3: #bebfc1;
 $deprecated-color-grey-4: #939598;
 $deprecated-color-grey-5: #3e3e40;
 $deprecated-color-blue: #52b1db;
-$deprecated-color-darkblue: #204056;
-$deprecated-color-midnightblue: #152b39;
 $deprecated-color-mint: #34b3a0;
 $deprecated-color-red: #f65a5b;
 

--- a/packages/gamut-styles/utils/variables/index.js
+++ b/packages/gamut-styles/utils/variables/index.js
@@ -114,7 +114,6 @@ export const deprecatedColors = {
   portal: {
     blue: '#52b1db',
     darkblue: '#204056',
-    midnightblue: '#152b39',
     mint: '#34b3a0',
   },
   swatches: {

--- a/packages/gamut/src/Button/styles/variables.scss
+++ b/packages/gamut/src/Button/styles/variables.scss
@@ -36,12 +36,9 @@ $btn-box-shadow-color: rgba(0, 0, 0, 0.3);
 $btn-swatches: (
   "mint": $deprecated-swatches-mint-700,
   "darkmint": $deprecated-swatches-mint-800,
-  "darkblue": $deprecated-swatches-cc-blue-500,
-  "midnightblue": $deprecated-swatches-grey-blue-500,
   "grey": $color-gray-300,
   "greyblue": $deprecated-swatches-grey-blue-600,
   "white": $color-white,
-  "ccblue": $deprecated-swatches-cc-blue-700,
   "royalblue": $deprecated-gamut-royal-blue,
   "purple": $deprecated-gamut-purple,
   "brand-red": $brand-red,

--- a/packages/styleguide/stories/Atoms/Button.stories.tsx
+++ b/packages/styleguide/stories/Atoms/Button.stories.tsx
@@ -33,12 +33,9 @@ const deprecatedThemeKeys = [
   ...Object.keys(buttonPresetThemes),
   'mint',
   'darkmint',
-  'darkblue',
-  'midnightblue',
   'grey',
   'greyblue',
   'white',
-  'ccblue',
   'royalblue',
   'purple',
 ];


### PR DESCRIPTION
## Removed unused deprecated button themes

### Monolith Usage

* `darkblue`: the "Start" button on the soon-to-be-deprecated course page. [Monolith PR: swap to `brand-blue`](https://github.com/codecademy-engineering/Codecademy/pull/17326)
![Screenshot of the Start button on the course page](https://user-images.githubusercontent.com/3335181/81006941-5554b800-8e1e-11ea-9b03-4e55084ee5af.png)

### Author Usage

* `midnightblue`: the cancel button on deleting drafts. [Author PR: swap to `brand-dark-blue`](https://github.com/codecademy-engineering/author/pull/1193)
![Screenshot of the draft deletion modal](https://user-images.githubusercontent.com/3335181/81007201-d14f0000-8e1e-11ea-8a09-a63a529184a2.png)

