### PR TITLE
feat(Gamut): Allowed GridForm text fields to be of type 'date'

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
@@ -26,7 +26,7 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
       className={className}
       htmlForPrefix={field.name}
       name={field.name}
-      onChange={event => {
+      onChange={(event) => {
         const { value } = event.target;
         setValue(field.name, value);
         field.onUpdate?.(value);

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -20,9 +20,7 @@ export type GridFormInputGroupProps = {
   setValue: (value: any) => void;
 };
 
-export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
-  props
-) => {
+export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = props => {
   const getInput = () => {
     switch (props.field.type) {
       case 'checkbox':
@@ -44,6 +42,7 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
           />
         );
 
+      case 'date':
       case 'email':
       case 'text':
         return (

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -20,7 +20,9 @@ export type GridFormInputGroupProps = {
   setValue: (value: any) => void;
 };
 
-export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = props => {
+export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
+  props
+) => {
   const getInput = () => {
     switch (props.field.type) {
       case 'checkbox':

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -35,7 +35,7 @@ export type GridFormTextField = BaseFormField<string> & {
   label: string;
   placeholder?: string;
   validation?: ValidationOptions;
-  type: 'text' | 'email';
+  type: 'date' | 'email' | 'text';
 };
 
 export type GridFormRadioOption = {


### PR DESCRIPTION
## Allowed GridForm text fields to be of type 'date'

No plans on using it in prod, but it uses the built-in browser date things now and is useful on our internal admin pages.

![Screen recording of using a date input](https://user-images.githubusercontent.com/3335181/81237403-90e1b480-8fcd-11ea-9053-01894f1fed20.gif)
