### PR TITLE
feat(Gamut): Allow GridFormCheckboxInput to take in a ReactNode as its label

### DIFF
--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -10,7 +10,7 @@ export type BaseFormField<Value> = {
 };
 
 export type GridFormCheckboxField = BaseFormField<boolean> & {
-  description: string;
+  description: React.ReactNode;
   label?: string;
   validation?: Pick<ValidationOptions, 'required'>;
   type: 'checkbox';


### PR DESCRIPTION
## Allow `GridFormCheckboxInput` to take in a ReactNode as its `label` type

- `GridFormCheckboxInput` currently only accepts `string` as `label` type. This limits customization and does not parallel the existing `Checkbox` functionality. So in this PR, we extend `GridFormCheckboxInput` to accept ReactNode as its `label` type.
- JIRA: https://codecademy.atlassian.net/browse/GM-7