### PR TITLE
feat(Gamut): Allowed GridForm to not take in any fields

### DIFF
--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -19,9 +19,9 @@ export type GridFormProps<Values extends {}> = {
   columnGap?: LayoutGridProps['columnGap'];
 
   /**
-   * Descriptions of the fields comprising the form.
+   * Descriptions of any fields comprising the form.
    */
-  fields: GridFormField[];
+  fields?: GridFormField[];
 
   /**
    * Function called with field values on submit, if all validations have passed.
@@ -45,7 +45,7 @@ export function GridForm<
   children,
   className,
   columnGap = 'lg',
-  fields,
+  fields = [],
   onSubmit,
   rowGap = 'md',
   submit,


### PR DESCRIPTION
## Allowed GridForm to not take in any fields

For fields that are just a single submit button, such as the account deletion field, we don't need to pass in fields. It's still a nice thing to use GridForm for them because we'll get standardized loading behavior.