### PR TITLE
fix(Gamut): Correctly hooked up GridForm's radio-group inputs for validation updates

### DIFF
--- a/packages/gamut/src/Form/Radio.tsx
+++ b/packages/gamut/src/Form/Radio.tsx
@@ -1,8 +1,8 @@
-import React, { ReactNode, HTMLAttributes } from 'react';
+import React, { ReactNode, InputHTMLAttributes } from 'react';
 import cx from 'classnames';
 import s from './styles/Radio.module.scss';
 
-export type RadioProps = HTMLAttributes<HTMLInputElement> & {
+export type RadioProps = InputHTMLAttributes<HTMLInputElement> & {
   checked?: boolean;
   disabled?: boolean;
   htmlFor?: string;
@@ -16,38 +16,44 @@ export type RadioProps = HTMLAttributes<HTMLInputElement> & {
   readOnly?: boolean;
 };
 
-export const Radio: React.FC<RadioProps> = ({
-  name,
-  value,
-  label,
-  checked,
-  className,
-  disabled,
-  htmlFor,
-  onChange,
-  required,
-  ...rest
-}) => {
-  const classNames = cx(s.Radio, className);
-  return (
-    <div className={classNames}>
-      <input
-        className={s.radioInput}
-        id={htmlFor}
-        name={name}
-        required={required}
-        type="radio"
-        checked={checked}
-        disabled={disabled}
-        onChange={onChange}
-        value={value}
-        {...rest}
-      />
-      <label htmlFor={htmlFor} className={s.radioLabel}>
-        {label}
-      </label>
-    </div>
-  );
-};
+export const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
+  (
+    {
+      name,
+      value,
+      label,
+      checked,
+      className,
+      disabled,
+      htmlFor,
+      onChange,
+      required,
+      ...rest
+    },
+    ref
+  ) => {
+    const classNames = cx(s.Radio, className);
+    return (
+      <div className={classNames}>
+        <input
+          className={s.radioInput}
+          id={htmlFor}
+          name={name}
+          required={required}
+          type="radio"
+          checked={checked}
+          disabled={disabled}
+          onChange={onChange}
+          ref={ref}
+          value={value}
+          {...rest}
+        />
+        <label htmlFor={htmlFor} className={s.radioLabel}>
+          {label}
+        </label>
+      </div>
+    );
+  }
+);
 
 export default Radio;

--- a/packages/gamut/src/Form/__tests__/RadioGroup-test.tsx
+++ b/packages/gamut/src/Form/__tests__/RadioGroup-test.tsx
@@ -1,42 +1,46 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import RadioGroup from '../RadioGroup';
 import Radio from '../Radio';
 
 describe('<RadioGroup>', () => {
-  const onChangeCallback = () => {};
-  const wrapper = shallow(
-    <RadioGroup
-      htmlForPrefix="what-salad-maker-do-you-prefer"
-      name="what-salad-maker-do-you-prefer"
-      onChange={onChangeCallback}
-      data-testid="my-test-id"
-    >
-      <Radio label="Sweet Green" value="sweet-green" />
-      <Radio label="Chopt" value="chopt" />
-    </RadioGroup>
-  );
-
-  it('sets the htmlFor prop on the child', () => {
-    expect(wrapper.find('Radio').first().prop('htmlFor')).toEqual(
-      'what-salad-maker-do-you-prefer-0'
+  const createComponent = () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      <RadioGroup
+        htmlForPrefix="what-salad-maker-do-you-prefer"
+        name="what-salad-maker-do-you-prefer"
+        onChange={onChange}
+        data-testid="my-test-id"
+      >
+        <Radio label="Sweet Green" value="sweet-green" />
+        <Radio label="Chopt" value="chopt" />
+      </RadioGroup>
     );
+    const firstInput = wrapper.find('input[type="radio"]').first();
+
+    return { firstInput, onChange, wrapper };
+  };
+
+  it('sets the name prop on the child', () => {
+    const { firstInput } = createComponent();
+
+    expect(firstInput.prop('name')).toEqual('what-salad-maker-do-you-prefer');
   });
 
   it('sets the onChange prop on the child', () => {
-    expect(wrapper.find('Radio').first().prop('onChange')).toEqual(
-      onChangeCallback
-    );
-  });
+    const { firstInput, onChange } = createComponent();
+    const event = {} as React.FormEvent;
 
-  it('sets the name prop on the child', () => {
-    expect(wrapper.find('Radio').first().prop('name')).toEqual(
-      'what-salad-maker-do-you-prefer'
-    );
+    firstInput.props().onChange(event);
+
+    expect(onChange).toHaveBeenCalledWith(event);
   });
 
   it('sets any additional props on the outer div', () => {
+    const { wrapper } = createComponent();
     const getByTestId = wrapper.find('div[data-testid="my-test-id"]');
+
     expect(getByTestId.exists()).toBe(true);
     expect(getByTestId.isEmptyRender()).toBe(false);
   });

--- a/packages/gamut/src/Form/__tests__/RadioGroup-test.tsx
+++ b/packages/gamut/src/Form/__tests__/RadioGroup-test.tsx
@@ -22,10 +22,13 @@ describe('<RadioGroup>', () => {
     return { firstInput, onChange, wrapper };
   };
 
-  it('sets the name prop on the child', () => {
+  it('sets the id and name props on the child', () => {
     const { firstInput } = createComponent();
 
-    expect(firstInput.prop('name')).toEqual('what-salad-maker-do-you-prefer');
+    expect(firstInput.props()).toMatchObject({
+      id: 'what-salad-maker-do-you-prefer-0',
+      name: 'what-salad-maker-do-you-prefer',
+    });
   });
 
   it('sets the onChange prop on the child', () => {

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { FormContextValues } from 'react-hook-form';
 
 import { RadioGroup, Radio } from '../../../Form';
@@ -17,10 +17,6 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
   register,
   setValue,
 }) => {
-  useEffect(() => {
-    register(field.name, field.validation);
-  }, [field.name, field.validation, register]);
-
   return (
     <RadioGroup
       className={className}
@@ -33,7 +29,12 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
       }}
     >
       {field.options.map(({ label, value }) => (
-        <Radio key={value} label={label} value={value} />
+        <Radio
+          key={value}
+          label={label}
+          ref={register(field.validation)}
+          value={value}
+        />
       ))}
     </RadioGroup>
   );

--- a/packages/styleguide/stories/Organisms/GridForm.stories.tsx
+++ b/packages/styleguide/stories/Organisms/GridForm.stories.tsx
@@ -139,6 +139,9 @@ export const gridForm = decoratedStory(() => (
           ],
           size: 4,
           type: 'radio-group',
+          validation: {
+            required: 'You gotta pick one!',
+          },
         },
         {
           label: 'End User License Agreement',


### PR DESCRIPTION
## Correctly hooked up GridForm's radio-group inputs for validation updates

Per [GM-10](https://codecademy.atlassian.net/browse/GM-10), we want to add a registration for the individual `Radio` elements. That's the good stuff. 

Added a validation to the `GridForm` story to show it off.

Steps to repro:

1. View a GridForm that includes a radio group input with a validation (such as being required)
2. Submit the form in a way that fails that validation → you should see complaint text on the radio group
3. Update the radio group to pass the validation → the complaint text does not go away  
4. Submit the form → the complaint text now does go away  

