### PR TITLE
feat(Gamut): Checkbox default style changes and add multiline prop

### DIFF
--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, InputHTMLAttributes } from 'react';
 import s from './styles/Checkbox.module.scss';
+import cx from 'classnames';
 
 export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
   checked?: boolean;
@@ -7,13 +8,14 @@ export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
   disabled?: boolean;
   htmlFor: string;
   label: ReactNode;
+  multiline?: boolean;
   name?: string;
   required?: boolean;
   value?: string;
 };
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ className, label, htmlFor, ...inputProps }, ref) => (
+  ({ className, label, htmlFor, multiline, ...inputProps }, ref) => (
     <div className={className}>
       <input
         id={htmlFor}
@@ -23,7 +25,11 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         ref={ref}
       />
       <label className={s.checkboxLabel} htmlFor={htmlFor}>
-        <div className={s.checkbox}>
+        <div
+          className={cx(s.checkbox, {
+            [s.checkboxMultiline]: multiline,
+          })}
+        >
           <svg
             width="24px"
             height="24px"

--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -40,7 +40,11 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             <polyline points="4 11 8 15 16 6" className={s.checkVector} />
           </svg>
         </div>
-        <span className={s.checkboxText}>{label}</span>
+        <span
+          className={cx(s.checkboxText, multiline && s.checkboxTextMultiline)}
+        >
+          {label}
+        </span>
       </label>
     </div>
   )

--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -25,11 +25,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         ref={ref}
       />
       <label className={s.checkboxLabel} htmlFor={htmlFor}>
-        <div
-          className={cx(s.checkbox, {
-            [s.checkboxMultiline]: multiline,
-          })}
-        >
+        <div className={cx(s.checkbox, multiline && s.checkboxMultiline)}>
           <svg
             width="24px"
             height="24px"

--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -38,7 +38,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             <polyline points="4 11 8 15 16 6" className={s.checkVector} />
           </svg>
         </div>
-        <span>{label}</span>
+        <span className={s.checkboxText}>{label}</span>
       </label>
     </div>
   )

--- a/packages/gamut/src/Form/styles/Checkbox.module.scss
+++ b/packages/gamut/src/Form/styles/Checkbox.module.scss
@@ -11,6 +11,10 @@
   padding: $form-padding;
 }
 
+.checkboxText {
+  align-self: center;
+}
+
 input:checked + .checkboxLabel .checkbox {
   border-color: $color-blue-500;
 

--- a/packages/gamut/src/Form/styles/Checkbox.module.scss
+++ b/packages/gamut/src/Form/styles/Checkbox.module.scss
@@ -68,6 +68,10 @@ input:disabled + .checkboxLabel {
   }
 }
 
+.checkboxMultiline {
+  margin-top: 3px;
+}
+
 .invisible {
   @include sr-only;
 }

--- a/packages/gamut/src/Form/styles/Checkbox.module.scss
+++ b/packages/gamut/src/Form/styles/Checkbox.module.scss
@@ -15,6 +15,10 @@
   align-self: center;
 }
 
+.checkboxTextMultiline {
+  font-size: 0.75rem;
+}
+
 input:checked + .checkboxLabel .checkbox {
   border-color: $color-blue-500;
 

--- a/packages/gamut/src/Form/styles/Checkbox.module.scss
+++ b/packages/gamut/src/Form/styles/Checkbox.module.scss
@@ -3,7 +3,7 @@
 .checkboxLabel {
   @include no-select;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   cursor: pointer;
   margin: ($form-padding / 2) 0;
   width: 100%;

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
@@ -23,6 +23,7 @@ export const GridFormCheckboxInput: React.FC<GridFormCheckboxInputProps> = ({
       name={field.name}
       onChange={(event) => field.onUpdate?.(event.target.checked)}
       label={field.description}
+      multiline={field.multiline}
       ref={register(field.validation)}
     />
   );

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -12,6 +12,7 @@ export type BaseFormField<Value> = {
 export type GridFormCheckboxField = BaseFormField<boolean> & {
   description: React.ReactNode;
   label?: string;
+  multiline?: boolean;
   validation?: Pick<ValidationOptions, 'required'>;
   type: 'checkbox';
 };

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -10,7 +10,7 @@ export type BaseFormField<Value> = {
 };
 
 export type GridFormCheckboxField = BaseFormField<boolean> & {
-  description: React.ReactNode;
+  description: string;
   label?: string;
   multiline?: boolean;
   validation?: Pick<ValidationOptions, 'required'>;

--- a/packages/styleguide/stories/Atoms/FormInputs/FormInputs.stories.tsx
+++ b/packages/styleguide/stories/Atoms/FormInputs/FormInputs.stories.tsx
@@ -46,6 +46,11 @@ export const checkbox = decoratedStory(() => (
       <Checkbox htmlFor="html-css" label="HTML & CSS" />
       <Checkbox htmlFor="javascript" label="JavaScript" />
       <Checkbox htmlFor="ruby" label="Ruby" />
+      <Checkbox
+        htmlFor="multiline"
+        label="I am a really long input that takes multiple lines. To make the checkbox better aligned with the text we can add the multiline prop which will add some margin-top to it!"
+        multiline
+      />
     </div>
   </StoryTemplate>
 ));

--- a/packages/styleguide/stories/Atoms/FormInputs/FormInputs.stories.tsx
+++ b/packages/styleguide/stories/Atoms/FormInputs/FormInputs.stories.tsx
@@ -48,7 +48,7 @@ export const checkbox = decoratedStory(() => (
       <Checkbox htmlFor="ruby" label="Ruby" />
       <Checkbox
         htmlFor="multiline"
-        label="I am a really long input that takes multiple lines. To make the checkbox better aligned with the text we can add the multiline prop which will add some margin-top to it!"
+        label="I am a really long input that takes multiple lines. To make the checkbox better aligned with the text we can add the multiline prop which will add some margin-top to it and reduce the fontsize to be much smaller. Yay to a better looking block of text and checkbox! Now I am sort of grasping at straws in my attempt to fill this up. Look at that though; another sentence."
         multiline
       />
     </div>


### PR DESCRIPTION
##  Default style changes and add multiline prop

- top-align checkbox
- center align label
- add multiline prop to add margin-top to checkbox making it look better aligned with a long label

### Notes

We collaborated with @JoshuaKGoldberg and Tamar on this. We are currently using static values to address the multiline use-case. This mostly aligns the checkbox and the label text for font-sizes between 12 and 16px. For other sizes it will not look as good.
Please advise if we want to make this more flexible through the passing of a className for the checkbox or some other means.

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
