### PR TITLE
chore: Add recommendation for styled-components highlighting extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["jounqin.vscode-mdx"]
+  "recommendations": [
+    "jounqin.vscode-mdx",
+    "jpoissonnier.vscode-styled-components"
+  ]
 }


### PR DESCRIPTION
Adds recommendation for highlighting for styled component template strings.

Storybook native components use this so might as well start.

![Screen Shot 2020-05-13 at 1 01 27 PM](https://user-images.githubusercontent.com/52927224/81842347-dfd1a180-9519-11ea-81a1-45fbfb8a11d9.png)
