### PR TITLE
chore(Styleguide): Update tabs stories to MDX

### DIFF
--- a/packages/styleguide/stories/Core/Molecules/Tabs/Examples.tsx
+++ b/packages/styleguide/stories/Core/Molecules/Tabs/Examples.tsx
@@ -1,26 +1,9 @@
-import { Tabs, TabList, Tab, TabPanel } from '@codecademy/gamut/src';
-import { boolean, text, number } from '@storybook/addon-knobs';
 import React from 'react';
+import { Tabs, TabList, Tab, TabPanel } from '@codecademy/gamut/src';
+import { number, boolean, text } from '@storybook/addon-knobs';
 
-import {
-  StoryDescription,
-  StoryStatus,
-  StoryTemplate,
-  decoratedStory,
-} from '../../../Templating';
-
-export default {
-  title: 'Core|Molecules/Tabs',
-  component: Tabs,
-  subcomponents: { TabList, Tab, TabPanel },
-};
-
-export const tabsUncontrolled = decoratedStory('Tabs (Uncontrolled)', () => (
-  <StoryTemplate status={StoryStatus.Ready}>
-    <StoryDescription>
-      Use a series of tabbed areas for when you have multiple potential sections
-      to show, but only one should be visible at a time.
-    </StoryDescription>
+export const Uncontrolled = () => {
+  return (
     <Tabs
       defaultActiveTabIndex={number('defaultActiveTabIndex', 2)}
       onChange={() => {}}
@@ -47,16 +30,11 @@ export const tabsUncontrolled = decoratedStory('Tabs (Uncontrolled)', () => (
         <p>Hi there! I'm the contents inside Tab 3. Yippee!</p>
       </TabPanel>
     </Tabs>
-  </StoryTemplate>
-));
+  );
+};
 
-export const tabsControlled = decoratedStory('Tabs (Controlled)', () => (
-  <StoryTemplate status={StoryStatus.Ready}>
-    <StoryDescription>
-      When <code>activeTabIndex</code> is specified, the component switches to
-      being a controlled component. It won't change its own tab state, but will
-      instead notify of a request to change using <code>onChange</code>.
-    </StoryDescription>
+export const Controlled = () => {
+  return (
     <Tabs
       activeTabIndex={number('Active Tab Index', 0)}
       onChange={() => {}}
@@ -83,5 +61,5 @@ export const tabsControlled = decoratedStory('Tabs (Controlled)', () => (
         <p>Hi there! I'm the contents inside Tab 3. Yippee!</p>
       </TabPanel>
     </Tabs>
-  </StoryTemplate>
-));
+  );
+};

--- a/packages/styleguide/stories/Core/Molecules/Tabs/Tabs.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Tabs/Tabs.stories.mdx
@@ -1,0 +1,67 @@
+import { Meta, Props, Preview, Story } from '@storybook/addon-docs/dist/blocks';
+import { number } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import { StoryStatus } from '../../../../Templating/Blocks';
+import { Tabs, TabList, Tab, TabPanel } from '@codecademy/gamut/src';
+import { Controlled, Uncontrolled } from './Examples';
+
+<Meta
+  title="Core|Molecules/Tabs"
+  component={Tabs}
+  subcomponents={{ TabList, Tab, TabPanel }}
+/>
+
+# Tabs
+
+<StoryStatus status="ready" />
+
+Use a series of tabbed areas for when you have multiple potential sections
+to show, but only one should be visible at a time.
+
+<Preview withSource="none">
+  <Story name="Tabs">
+    <Uncontrolled />
+  </Story>
+</Preview>
+
+<Props of={Tabs} />
+
+## Usage
+
+Here's an example usage of any uncontrolled TabList
+
+```jsx
+import { Tabs, TabList, Tab, TabPanel } from '@codecademy/gamut/src';
+
+<Tabs defaultActiveTabIndex={2} onChange={() => {}}>
+  <TabList center={false}>
+    <Tab>Tab 1</Tab>
+    <Tab>Tab 2</Tab>
+    <Tab>Tab 3</Tab>
+  </TabList>
+  <TabPanel>
+    <h2>Welcome to Tab 1</h2>
+    <p>Hi there! I'm the contents inside Tab 1. Yippee!</p>
+  </TabPanel>
+  <TabPanel>
+    <h2>Welcome to Tab 2</h2>
+    <p>Hi there! I'm the contents inside Tab 2. Yippee!</p>
+  </TabPanel>
+  <TabPanel>
+    <h2>Welcome to Tab 3</h2>
+    <p>Hi there! I'm the contents inside Tab 3. Yippee!</p>
+  </TabPanel>
+</Tabs>;
+```
+
+## Controlled
+
+When `activeTabIndex` is specified, the component switches to
+being a controlled component. It won't change its own tab state, but will
+instead notify of a request to change using `onChange`.
+
+<Preview withSource="none">
+  <Story name="Controlled">
+    <Controlled />
+  </Story>
+</Preview>


### PR DESCRIPTION
## Tabs.stories => MDX

### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: WEB-870
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

Didn't include this in the initial wave because Tabs relies on checking component instance type to work.  Rendering directly using MDX's JSX renderer causes this to break due to wrapping each element in `MDXCreateElement` and forwarding the props. 

The work around here is either register the stories in a separate file and adding a markup block for a source example.  Potentially we could embed the stories from a separate page and have general source extraction, but for now this seems simple enough.

###  Screenshots
Before:
![Screen Shot 2020-05-14 at 1 06 58 PM](https://user-images.githubusercontent.com/52927224/81963934-e1679c00-95e3-11ea-8cdc-c593eaec3050.png)
After:
![Screen Shot 2020-05-14 at 1 07 08 PM](https://user-images.githubusercontent.com/52927224/81963918-dc0a5180-95e3-11ea-83d1-0fa0ce274f85.png)
