### PR TITLE
feat(Gamut): Add docs/command for working with Gamut pre-publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Every PR that changes files in a package publishes alpha releases that you can u
 ### Working with pre-published changes
 
 For quicker development cycles, it's possible to run a pre-published version of Gamut in another project. We do that using
-symlinks. The following instructions assume you have set up and built client-modules, and it's in your home folder:
+symlinks (the following instructions assume you have set up and built client-modules):
 
-1. `cd ~/client-modules/packages/gamut`
+1. `cd /path/to/client-modules/packages/gamut`
 1. `yarn link`
 1. `cd path/to/other/repo`
 1. `yarn link @codecademy/gamut`
@@ -62,7 +62,7 @@ If your other project uses React, you must link that copy of React in Gamut:
 1. `cd path/to/other/repo`
 1. `cd node_modules/react`
 1. `yarn link`
-1. `cd ~/client-modules`
+1. `cd /path/to/client-modules/packages/gamut`
 1. `yarn link react`
 1. `yarn build-all`
 ```

--- a/README.md
+++ b/README.md
@@ -28,32 +28,6 @@ This repository is a monorepo that we manage using [Lerna](https://lernajs.io/).
 1.  Add new stories to `packages/styleguide/stories`
 1.  Stories are written using storybook's [Component Story Format](https://storybook.js.org/docs/formats/component-story-format/)
 
-### Working with pre-published changes
-
-For quicker development cycles, it's possible to run a pre-published version of Gamut in the monolith. We do that using
-symlinks. The following instructions assume you have set up client_modules and Codecademy, and the repos are in your home folder:
-
-1. `cd ~/client-modules/packages/gamut`
-1. `yarn link`
-1. `cd ~/Codecademy`
-1. `yarn link @codecademy/gamut`
-1. `cd node_modules/react`
-1. `yarn link`
-1. `yarn install`
-1. `cd ~/client-modules`
-1. `yarn link react`
-1. `yarn install`
-
-You must link the monolith's copy of React in Gamut. [See the docs](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react)
-for more information for why we have to do this.
-
-To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` use `yarn build:watch`
-
-#### Troubleshooting
-
-If you run into compilation issues after linking, try `yarn install` in the monolith and restarting its dev server
-or running `yarn build-all` in this repo.
-
 ### Publishing Modules
 
 1.  Make your changes in a feature branch, and get another engineer to review your code
@@ -70,6 +44,38 @@ Every PR that changes files in a package publishes alpha releases that you can u
 1.  In the github "checks" UI, find the "Publish Alpha" task
 1.  Once this check has passed, click on it, and look through the output for the alpha version number
 1.  Use this version in the other application you want to test your changes on
+
+### Working with pre-published changes
+
+For quicker development cycles, it's possible to run a pre-published version of Gamut in another project. We do that using
+symlinks. The following instructions assume you have set up and built client-modules, and the repos are in your home folder:
+
+1. `cd ~/client-modules/packages/gamut`
+1. `yarn link`
+1. `cd ~/${yourOtherProject}`
+1. `yarn link @codecademy/gamut`
+1. `yarn install`
+
+If your other project uses React, you must link that copy of React in Gamut:
+
+```
+1. `cd ~/${yourOtherProject}`
+1. `cd node_modules/react`
+1. `yarn link`
+1. `cd ~/client-modules`
+1. `yarn link react`
+1. `yarn build-all`
+```
+
+[See the docs](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react)
+for more information for why you have to do this.
+
+To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` use `yarn build:watch`
+
+#### Troubleshooting
+
+If you run into compilation issues after linking, try `yarn install` in the monolith and restarting its dev server
+or running `yarn build-all` in this repo.
 
 ### PR Title Guide
 

--- a/README.md
+++ b/README.md
@@ -31,21 +31,23 @@ This repository is a monorepo that we manage using [Lerna](https://lernajs.io/).
 ### Working with pre-published changes
 
 For quicker development cycles, it's possible to run a pre-published version of Gamut in the monolith. We do that using
-symlinks. The following instructions assume your client_modules and Codecademy repo are in your home folder:
+symlinks. The following instructions assume you have set up client_modules and Codecademy, and the repos are in your home folder:
 
-1. `cd ~/client_modules/packages/gamut`
+1. `cd ~/client-modules/packages/gamut`
 1. `yarn link`
 1. `cd ~/Codecademy`
 1. `yarn link @codecademy/gamut`
 1. `cd node_modules/react`
 1. `yarn link`
-1. `cd ~/client_modules`
+1. `yarn install`
+1. `cd ~/client-modules`
 1. `yarn link react`
+1. `yarn install`
 
 You must link the monolith's copy of React in Gamut. [See the docs](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react)
 for more information for why we have to do this.
 
-To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` use `yarn build-all && yarn build:watch`
+To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` use `yarn build:watch`
 
 #### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ This repository is a monorepo that we manage using [Lerna](https://lernajs.io/).
 1.  Add new stories to `packages/styleguide/stories`
 1.  Stories are written using storybook's [Component Story Format](https://storybook.js.org/docs/formats/component-story-format/)
 
+### Working with pre-published changes
+
+For quicker development cycles, it's possible to run a pre-published version of Gamut in the monolith. We do that using
+symlinks. The following instructions assume your client_modules and Codecademy repo are in your home folder:
+
+1. `cd ~/client_modules/packages/gamut`
+1. `yarn link`
+1. `cd ~/Codecademy`
+1. `yarn link @codecademy/gamut`
+1. `cd node_modules/react`
+1. `yarn link`
+1. `cd ~/client_modules`
+1. `yarn link react`
+
+You must link the monolith's copy of React in Gamut. [See the docs](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react)
+for more information for why we have to do this.
+
+To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` use `yarn build-all && build:watch`
+
+#### Troubleshooting
+
+If you run into compilation issues, try restarting your monolith dev server or running `yarn build-all` in this repo.
+
 ### Publishing Modules
 
 1.  Make your changes in a feature branch, and get another engineer to review your code

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` 
 
 #### Troubleshooting
 
-If you run into compilation issues after linking, try `yarn install` in the monolith and restarting its dev server
+If you run into compilation issues after linking, try `yarn install` in your other project and restarting its dev server
 or running `yarn build-all` in this repo.
 
 ### PR Title Guide

--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ symlinks. The following instructions assume your client_modules and Codecademy r
 You must link the monolith's copy of React in Gamut. [See the docs](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react)
 for more information for why we have to do this.
 
-To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` use `yarn build-all && build:watch`
+To run a watcher and build Gamut on changes, in `client_modules/packages/gamut` use `yarn build-all && yarn build:watch`
 
 #### Troubleshooting
 
-If you run into compilation issues, try restarting your monolith dev server or running `yarn build-all` in this repo.
+If you run into compilation issues after linking, try `yarn install` in the monolith and restarting its dev server
+or running `yarn build-all` in this repo.
 
 ### Publishing Modules
 

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ Every PR that changes files in a package publishes alpha releases that you can u
 ### Working with pre-published changes
 
 For quicker development cycles, it's possible to run a pre-published version of Gamut in another project. We do that using
-symlinks. The following instructions assume you have set up and built client-modules, and the repos are in your home folder:
+symlinks. The following instructions assume you have set up and built client-modules, and it's in your home folder:
 
 1. `cd ~/client-modules/packages/gamut`
 1. `yarn link`
-1. `cd ~/${yourOtherProject}`
+1. `cd path/to/other/repo`
 1. `yarn link @codecademy/gamut`
 1. `yarn install`
 
 If your other project uses React, you must link that copy of React in Gamut:
 
 ```
-1. `cd ~/${yourOtherProject}`
+1. `cd path/to/other/repo`
 1. `cd node_modules/react`
 1. `yarn link`
 1. `cd ~/client-modules`

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -40,7 +40,7 @@
     "build:clean": "rm -rf dist",
     "build:types": "tsc --emitDeclarationOnly",
     "build": "yarn build:clean && yarn build:compile && yarn build:types",
-    "build:watch": "onchange ./src -- yarn build:compile && yarn build:types",
+    "build:watch": "yarn build && onchange ./src -- yarn build:compile && yarn build:types",
     "prepublishOnly": "yarn build"
   },
   "license": "MIT",

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -40,10 +40,12 @@
     "build:clean": "rm -rf dist",
     "build:types": "tsc --emitDeclarationOnly",
     "build": "yarn build:clean && yarn build:compile && yarn build:types",
+    "build:watch": "onchange ./src -- yarn build:compile && yarn build:types",
     "prepublishOnly": "yarn build"
   },
   "license": "MIT",
   "devDependencies": {
-    "copyfiles": "^2.1.1"
+    "copyfiles": "^2.1.1",
+    "onchange": "^7.0.2"
   }
 }

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -45,7 +45,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "copyfiles": "^2.1.1",
     "onchange": "^7.0.2"
   }
 }

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -59,7 +59,7 @@ export type GridFormSelectField = BaseFormField<string> & {
 };
 
 export type GridFormFileField = BaseFormField<FileList> & {
-  label: string;
+  label: React.ReactNode;
   validation?: ValidationOptions;
   type: 'file';
 };

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -59,7 +59,7 @@ export type GridFormSelectField = BaseFormField<string> & {
 };
 
 export type GridFormFileField = BaseFormField<FileList> & {
-  label: React.ReactNode;
+  label: string;
   validation?: ValidationOptions;
   type: 'file';
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,6 +1460,16 @@
   resolved "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
+"@blakeembrey/deque@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/@blakeembrey/deque/-/deque-1.0.5.tgz#f4fa17fc5ee18317ec01a763d355782c7b395eaf"
+  integrity sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==
+
+"@blakeembrey/template@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@blakeembrey/template/-/template-1.0.0.tgz#bf8828bc3ae8004d97904d78f64e3cc2cd216438"
+  integrity sha512-J6WGZqCLdRMHUkyRG6fBSIFJ0rL60/nsQNh5rQvsYZ5u0PsKw6XQcJcA3DWvd9cN3j/IQx5yB1fexhCafwwUUw==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
@@ -4446,6 +4456,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -5779,6 +5794,21 @@ chokidar@^3.3.0:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chokidar@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
+  integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.3"
   resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
@@ -6449,7 +6479,7 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.2"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
   integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
@@ -9307,6 +9337,11 @@ ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 immer@1.10.0:
   version "1.10.0"
@@ -12431,6 +12466,19 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onchange@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/onchange/-/onchange-7.0.2.tgz#77f98263cc8412210c1a2d89a55cc5eb32ad33ec"
+  integrity sha512-pyJroR9gZKilbJtdGsuyxhFhwaeYSpYVle9hAORGJ5vQQH8n7QT+qWpncJTMEk9dlIXI9tOMjdJwbPaTSPTKFA==
+  dependencies:
+    "@blakeembrey/deque" "^1.0.5"
+    "@blakeembrey/template" "^1.0.0"
+    arg "^4.1.3"
+    chokidar "^3.3.1"
+    cross-spawn "^7.0.1"
+    ignore "^5.1.4"
+    tree-kill "^1.2.2"
+
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
@@ -12913,7 +12961,7 @@ performance-now@^2.1.0:
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.7:
+picomatch@^2.0.4, picomatch@^2.0.7, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -14325,6 +14373,13 @@ readdirp@~3.3.0:
   integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
   dependencies:
     picomatch "^2.0.7"
+
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -16189,6 +16244,11 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 trim-lines@^1.0.0:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6322,18 +6322,6 @@ copy-to-clipboard@^3.0.8:
   dependencies:
     toggle-selection "^1.0.6"
 
-copyfiles@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/copyfiles/-/copyfiles-2.2.0.tgz#d9fc6c06f299337fb7eeb7ea5887e9d7188d9d47"
-  integrity sha512-iJbHJI+8OKqsq+4JF0rqgRkZzo++jqO6Wf4FUU1JM41cJF6JcY5968XyF4tm3Kkm7ZOMrqlljdm8N9oyY5raGw==
-  dependencies:
-    glob "^7.0.5"
-    minimatch "^3.0.3"
-    mkdirp "^0.5.1"
-    noms "0.0.0"
-    through2 "^2.0.1"
-    yargs "^13.2.4"
-
 core-js-compat@^3.6.2:
   version "3.6.4"
   resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz#938476569ebb6cda80d339bcf199fae4f16fff17"
@@ -8717,7 +8705,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -10016,11 +10004,6 @@ is-wsl@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -11766,7 +11749,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -12186,14 +12169,6 @@ node-sass@^4.13.0:
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
-
-noms@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
-  integrity sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "~1.0.31"
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -14338,16 +14313,6 @@ read@1, read@~1.0.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@~1.0.31:
-  version "1.0.34"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readdir-scoped-modules@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
@@ -15711,11 +15676,6 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
-
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -16106,7 +16066,7 @@ throttle-debounce@^2.1.0:
   resolved "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
   integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
-through2@^2.0.0, through2@^2.0.1, through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -17437,7 +17397,7 @@ yargs@13.2.4:
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
 
-yargs@^13.2.4, yargs@^13.3.0:
+yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==


### PR DESCRIPTION
## Title
Add docs and a watcher for working with Gamut locally using symlinks. Update `GridFormField` type to accept ReactNodes.

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: WEB-676
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description
- Allowing a node prop for a GridFormField labels allows for more flexible use.
- One gotcha I couldn't figure out: Running Jest tests in the monolith with this set-up. In the current state, Jest throws an error saying
```
babel-jest: Babel ignores ../client-modules/packages/gamut/dist/index.js - 
make sure to include the file in Jest's transformIgnorePatterns as well.
```

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
