### PR TITLE
feat(Gamut): Allowed general text inputs for GridForm

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -45,18 +45,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
           />
         );
 
-      case 'date':
-      case 'email':
-      case 'text':
-        return (
-          <GridFormTextInput
-            className={styles.gridFormInput}
-            error={!!props.error}
-            field={props.field}
-            register={props.register}
-          />
-        );
-
       case 'radio-group':
         return (
           <GridFormRadioGroupInput
@@ -90,6 +78,16 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
       case 'textarea':
         return (
           <GridFormTextArea
+            className={styles.gridFormInput}
+            error={!!props.error}
+            field={props.field}
+            register={props.register}
+          />
+        );
+
+      default:
+        return (
+          <GridFormTextInput
             className={styles.gridFormInput}
             error={!!props.error}
             field={props.field}

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -32,11 +32,26 @@ export type GridFormCustomField = BaseFormField<any> & {
   type: 'custom';
 };
 
+export type BasicInputType =
+  | 'color'
+  | 'date'
+  | 'datetime-local'
+  | 'email'
+  | 'month'
+  | 'number'
+  | 'password'
+  | 'search'
+  | 'tel'
+  | 'text'
+  | 'time'
+  | 'url'
+  | 'week';
+
 export type GridFormTextField = BaseFormField<string> & {
   label: string;
   placeholder?: string;
   validation?: ValidationOptions;
-  type: 'date' | 'email' | 'text';
+  type: BasicInputType;
 };
 
 export type GridFormRadioOption = {


### PR DESCRIPTION
## Overview

I have a need for `password`. @jakemhiller mentioned recently that we could just use a `default` case for these input types. Works for me!

### PR Checklist

- ~[ ] Related to Abstract designs:~
- [x] Related to JIRA ticket: [GM-9](https://codecademy.atlassian.net/browse/GM-9)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
