### PR TITLE
fix: preserve display name on card shell

### DIFF
--- a/packages/gamut/src/Card/CardShell.tsx
+++ b/packages/gamut/src/Card/CardShell.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, RefForwardingComponent } from 'react';
 import cx from 'classnames';
 import s from './styles/CardShell.module.scss';
 
@@ -10,23 +10,26 @@ export type CardShellProps = HTMLAttributes<HTMLDivElement> & {
   hoverShadow?: boolean;
 };
 
-export const CardShell = React.forwardRef<HTMLDivElement, CardShellProps>(
-  ({ children, hoverShadow, className, ...props }, ref) => {
-    const shellClasses = cx(
-      s.shell,
-      {
-        [s.hoverShadow]: hoverShadow,
-      },
-      className
-    );
+const CardShellRef: RefForwardingComponent<HTMLDivElement, CardShellProps> = (
+  { children, hoverShadow, className, ...props },
+  ref
+) => {
+  const shellClasses = cx(
+    s.shell,
+    {
+      [s.hoverShadow]: hoverShadow,
+    },
+    className
+  );
 
-    return (
-      <div ref={ref} className={shellClasses} {...props}>
-        {children}
-      </div>
-    );
-  }
-);
+  return (
+    <div ref={ref} className={shellClasses} {...props}>
+      {children}
+    </div>
+  );
+};
+
+export const CardShell = React.forwardRef(CardShellRef);
 
 CardShell.defaultProps = defaultProps;
 CardShell.displayName = 'CardShell';

--- a/packages/gamut/src/Card/CardShell.tsx
+++ b/packages/gamut/src/Card/CardShell.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, RefForwardingComponent } from 'react';
+import React, { HTMLAttributes } from 'react';
 import cx from 'classnames';
 import s from './styles/CardShell.module.scss';
 
@@ -10,26 +10,23 @@ export type CardShellProps = HTMLAttributes<HTMLDivElement> & {
   hoverShadow?: boolean;
 };
 
-const CardShellRef: RefForwardingComponent<HTMLDivElement, CardShellProps> = (
-  { children, hoverShadow, className, ...props },
-  ref
-) => {
-  const shellClasses = cx(
-    s.shell,
-    {
-      [s.hoverShadow]: hoverShadow,
-    },
-    className
-  );
+export const CardShell = React.forwardRef<HTMLDivElement, CardShellProps>(
+  ({ children, hoverShadow, className, ...props }, ref) => {
+    const shellClasses = cx(
+      s.shell,
+      {
+        [s.hoverShadow]: hoverShadow,
+      },
+      className
+    );
 
-  return (
-    <div ref={ref} className={shellClasses} {...props}>
-      {children}
-    </div>
-  );
-};
-
-export const CardShell = React.forwardRef(CardShellRef);
+    return (
+      <div ref={ref} className={shellClasses} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
 
 CardShell.defaultProps = defaultProps;
 CardShell.displayName = 'CardShell';

--- a/packages/gamut/src/Card/CardShell.tsx
+++ b/packages/gamut/src/Card/CardShell.tsx
@@ -29,5 +29,6 @@ export const CardShell = React.forwardRef<HTMLDivElement, CardShellProps>(
 );
 
 CardShell.defaultProps = defaultProps;
+CardShell.displayName = 'CardShell';
 
 export default CardShell;


### PR DESCRIPTION
## Overview

Some of our tests were failing because using `forwardRef` removes the automatic `displayName` from the component. Need to add it back manually.

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
