### PR TITLE
feat(Gamut)!: Added underlines to Text links

### DIFF
--- a/packages/gamut/src/Typography/styles/Text.module.scss
+++ b/packages/gamut/src/Typography/styles/Text.module.scss
@@ -2,6 +2,10 @@
 
 .text {
   margin: 0;
+
+  a {
+    text-decoration: underline;
+  }
 }
 
 @each $screenSize in $screenSizes {

--- a/packages/styleguide/stories/Core/Foundations/Typography/Typography.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Typography/Typography.stories.mdx
@@ -94,7 +94,8 @@ This is a single primitive to handle all `<p>` and
               nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
               reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.
+              sunt in culpa qui officia deserunt mollit anim id est laborum.{' '}
+              <a href="https://gamut.codecademy.com">Link!</a>
             </Text>
           </Column>
         </React.Fragment>

--- a/packages/styleguide/stories/Core/Foundations/Typography/Typography.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Typography/Typography.stories.mdx
@@ -94,8 +94,7 @@ This is a single primitive to handle all `<p>` and
               nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
               reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-              sunt in culpa qui officia deserunt mollit anim id est laborum.{' '}
-              <a href="https://gamut.codecademy.com">Link!</a>
+              sunt in culpa qui officia deserunt mollit anim id est laborum.
             </Text>
           </Column>
         </React.Fragment>


### PR DESCRIPTION
## Overview

### PR Checklist

- [x] Related to Abstract designs: https://app.abstract.com/projects/a4a24600-c8c9-11e8-a177-81a5fa367641/branches/328ef9fe-09cf-43f4-8dd1-40947f5d4fb4/commits/3a51a13f42daf13efbfd15dc96f34ad00a72052d/files/FA9AF2C4-35B2-4183-8E93-A9D84A525613/layers/7598FF01-E0C7-4FAD-A505-B6136FA4DC91?mode=design
- [x] Related to JIRA ticket: [A11Y-377](https://codecademy.atlassian.net/browse/A11Y-377)
- [x] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

### Description

Per the designs, we want our general-purpose links to be purple and have underlines. Our global "reboot" styles already apply the purple color but removes the underline; this adds in the underline. If we get rid of "reboot" we can get rid of the underline here too probably.

We [talked on Slack](https://codecademy.slack.com/archives/CTVEHH2PP/p1589410113035600) about how applying to `<Markdown>` initially would be a good entry into accessible links: that's in #793. This starts on our _other_ general-purpose body text container.

![Screenshot of the Text story with link text.](https://user-images.githubusercontent.com/3335181/82508630-a679d280-9ad3-11ea-8aa6-fbb817338b9d.png)

