### PR TITLE
fix: Overlay click-outside functionality was still not working after previous update

### DIFF
--- a/packages/gamut/src/Overlay/__tests__/Overlay-test.tsx
+++ b/packages/gamut/src/Overlay/__tests__/Overlay-test.tsx
@@ -51,15 +51,16 @@ describe('Overlay', () => {
     expect(onRequestClose.mock.calls.length).toBe(0);
   });
 
-  it('triggers onRequestClose callback when clicking outside', () => {
+  it('triggers onRequestClose callback when clicking the container', () => {
     const onRequestClose = jest.fn();
-    const { baseElement } = renderOverlay({
+    renderOverlay({
       isOpen: true,
       clickOutsideCloses: true,
       onRequestClose,
     });
+
     // focus-trap listens to mouseDown, not click
-    fireEvent.mouseDown(baseElement);
+    fireEvent.mouseDown(screen.queryByTestId('overlay-content').parentElement);
     expect(onRequestClose.mock.calls.length).toBe(1);
   });
 

--- a/packages/gamut/src/Overlay/index.tsx
+++ b/packages/gamut/src/Overlay/index.tsx
@@ -36,15 +36,17 @@ export const Overlay: React.FC<OverlayProps> = ({
 
   return (
     <BodyPortal>
-      <FocusTrap
-        focusTrapOptions={{
-          clickOutsideDeactivates: clickOutsideCloses,
-          escapeDeactivates: escapeCloses,
-          onDeactivate: onRequestClose,
-        }}
-      >
-        <div className={cx(styles.container, className)}>{children}</div>
-      </FocusTrap>
+      <div className={cx(styles.container, className)}>
+        <FocusTrap
+          focusTrapOptions={{
+            clickOutsideDeactivates: clickOutsideCloses,
+            escapeDeactivates: escapeCloses,
+            onDeactivate: onRequestClose,
+          }}
+        >
+          {children}
+        </FocusTrap>
+      </div>
     </BodyPortal>
   );
 };


### PR DESCRIPTION
## Overview

I made a change towards the end of the previous modal updates that broke clicking outside of an overlay.

The overlay container is the "outside" element you click on, and I moved it inside of the focus-trap.

This wasn't caught by tests because in the test i clicked on the `body` element.

This also fixes the test.

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
