### PR TITLE
ci: move changelog generation to commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "start:storybook": "cd ./packages/styleguide && yarn start",
     "build-storybook": "cd ./packages/styleguide && yarn build-storybook",
     "deploy": "gh-pages -b gh-pages -d dist",
-    "regenerate-changelog": "yarn lerna exec --concurrency 1 --stream -- 'node $LERNA_ROOT_PATH/script/update-changelog'",
-    "postpublish": "yarn regenerate-changelog"
+    "regenerate-changelog": "yarn lerna exec --concurrency 1 --stream -- 'node $LERNA_ROOT_PATH/script/update-changelog'"
   },
   "lint-staged": {
     "**/*.{mdx,js,ts,tsx,json,css,scss}": [
       "prettier --ignore-path .prettierignore --write"
+    ],
+    "**/CHANGELOG.md": [
+      "yarn regenerate-changelog"
     ]
   },
   "repository": {

--- a/packages/gamut/CHANGELOG.md
+++ b/packages/gamut/CHANGELOG.md
@@ -1,18 +1,11 @@
-# Change Log
+### [8.2.1](https://github.com/Codecademy/client-modules/compare/@codecademy/gamut@8.2.1...@codecademy/gamut@8.2.1) (2020-05-22)
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## <small>8.2.1 (2020-05-22)</small>
-
-* fix(Overlay): Fixed Overlay click-outside functionality (#817) ([0971c33](https://github.com/RyzacInc/client-modules/commit/0971c33)), closes [#817](https://github.com/RyzacInc/client-modules/issues/817)
-* ci: cleanup changelogs ([a64dcfc](https://github.com/RyzacInc/client-modules/commit/a64dcfc))
-* ci: script to rebuild changelogs on publish [WEB-891] (#815) ([acb1f18](https://github.com/RyzacInc/client-modules/commit/acb1f18)), closes [#815](https://github.com/RyzacInc/client-modules/issues/815)
-* ci: update changelogs & fix lerna syntax ([b258dc4](https://github.com/RyzacInc/client-modules/commit/b258dc4))
+### [8.2.1](https://github.com/Codecademy/client-modules/compare/@codecademy/gamut@8.2.0...@codecademy/gamut@8.2.1) (2020-05-22)
 
 
+### 🐛 Bug Fixes
 
-
+* **Overlay:** Fixed Overlay click-outside functionality ([#817](https://github.com/Codecademy/client-modules/issues/817)) ([0971c33](https://github.com/Codecademy/client-modules/commit/0971c339a5b9dc8cde6d57be7edf914e59475b36))
 
 ## [8.2.0](https://github.com/Codecademy/client-modules/compare/@codecademy/gamut@8.1.0...@codecademy/gamut@8.2.0) (2020-05-21)
 
@@ -2510,3 +2503,4 @@ import { Button } from '@codecademy/gamut'
 * moved styles ([cbe6f5b](https://github.com/Codecademy/client-modules/commit/cbe6f5bb8f77e2e733b6651599929335bdf64efe))
 * Publish ([34caefe](https://github.com/Codecademy/client-modules/commit/34caefe2cc7f180bd3b88c38d746c6d4703f4a30))
 * rename gamut-identity ([52f14f2](https://github.com/Codecademy/client-modules/commit/52f14f20a98700ea00ebf5ce2374599190bdbddd))
+


### PR DESCRIPTION
This wasn't happening at the right time, so the updated changelogs weren't being committed.

After digging through lerna, there isn't a great place to put this in the lifecycle without needing to manually add/commit the files, so this seemed to be the easiest way.