### PR TITLE
fix: remove alt text on Testimonial avatars

### DIFF
--- a/packages/gamut-labs/src/brand/Testimonial/index.tsx
+++ b/packages/gamut-labs/src/brand/Testimonial/index.tsx
@@ -47,9 +47,9 @@ export const Testimonial: React.FC<TestimonialProps> = ({
             <div className={s.avatarContainer}>
               <Avatar
                 src={imageUrl}
-                alt={`Photo of ${firstName} ${lastName}`}
                 theme={theme}
                 className={cx({ [s.largeContainerAvatar]: size === 'large' })}
+                alt=""
               />
             </div>
           )}


### PR DESCRIPTION
## Overview
According to https://www.w3.org/WAI/tutorials/images/decorative/, images adjacent to text that has the same information (in this case the name of the person is next to the avatar) should be considered decorative and therefore not have alt tags. This came up in a test.io bug recently. (Linked in the JIRA ticket).

### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: GROW-1607
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change