### PR TITLE
feat: add Id props for GridFormInputGroups

### DIFF
--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -12,16 +12,17 @@ export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
   name?: string;
   required?: boolean;
   value?: string;
+  id?: string;
 };
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ className, label, htmlFor, multiline, ...inputProps }, ref) => (
+  ({ className, label, htmlFor, multiline, id, ...rest }, ref) => (
     <div className={className}>
       <input
-        id={htmlFor}
+        id={id || htmlFor}
         type="checkbox"
         className={s.invisible}
-        {...inputProps}
+        {...rest}
         ref={ref}
       />
       <label className={s.checkboxLabel} htmlFor={htmlFor}>

--- a/packages/gamut/src/Form/Input.tsx
+++ b/packages/gamut/src/Form/Input.tsx
@@ -13,7 +13,7 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 };
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ error, htmlFor, className, ...rest }, ref) => {
+  ({ error, htmlFor, className, id, ...rest }, ref) => {
     const classNames = cx(
       s.Input,
       {
@@ -24,7 +24,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       },
       className
     );
-    return <input {...rest} id={htmlFor} ref={ref} className={classNames} />;
+    return (
+      <input {...rest} id={id || htmlFor} ref={ref} className={classNames} />
+    );
   }
 );
 

--- a/packages/gamut/src/Form/Radio.tsx
+++ b/packages/gamut/src/Form/Radio.tsx
@@ -28,16 +28,20 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
       htmlFor,
       onChange,
       required,
+      id,
       ...rest
     },
     ref
   ) => {
     const classNames = cx(s.Radio, className);
+
+    const inputId = id ? `${htmlFor}-${id}` : htmlFor;
+
     return (
       <div className={classNames}>
         <input
           className={s.radioInput}
-          id={htmlFor}
+          id={inputId}
           name={name}
           required={required}
           type="radio"

--- a/packages/gamut/src/Form/Select.tsx
+++ b/packages/gamut/src/Form/Select.tsx
@@ -7,12 +7,13 @@ export type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
   error?: boolean;
   htmlFor?: string;
   options?: string[] | Record<string, number | string>;
+  id?: string;
 };
 
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   (props, ref) => {
     const className = cx(s.Select, props.className, props.error && s.error);
-    const { options, error, ...propsToTransfer } = props;
+    const { options, error, id, ...rest } = props;
 
     let selectOptions: ReactNode[] = [];
 
@@ -41,10 +42,10 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           />
         </svg>
         <select
-          {...propsToTransfer}
+          {...rest}
           className={s.selectInput}
           defaultValue={props.defaultValue || ''}
-          id={props.htmlFor}
+          id={id || props.htmlFor}
           ref={ref}
         >
           {selectOptions}

--- a/packages/gamut/src/Form/TextArea.tsx
+++ b/packages/gamut/src/Form/TextArea.tsx
@@ -12,7 +12,7 @@ export type TextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 };
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ error, htmlFor, className, ...rest }, ref) => {
+  ({ error, htmlFor, className, id, ...rest }, ref) => {
     const classNames = cx(
       s.TextArea,
       {
@@ -21,7 +21,9 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
       className
     );
 
-    return <textarea {...rest} id={htmlFor} className={classNames} ref={ref} />;
+    return (
+      <textarea {...rest} id={id || htmlFor} className={classNames} ref={ref} />
+    );
   }
 );
 

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
@@ -1,0 +1,46 @@
+import GridFormCheckboxInput from '../index';
+import { mount } from 'enzyme';
+import React from 'react';
+
+describe('GridFormCheckboxInput', () => {
+  const type = 'checkbox';
+  const name = 'name';
+  const description = 'description';
+
+  describe('when an id is passed as a prop', () => {
+    it('renders an input with the same id', () => {
+      const id = 'mycoolid';
+
+      const textInput = mount(
+        <GridFormCheckboxInput
+          field={{
+            type: type,
+            name: name,
+            description: description,
+          }}
+          register={jest.fn()}
+          id={id}
+        />
+      );
+
+      expect(textInput.find('input#mycoolid').length).toBe(1);
+    });
+  });
+
+  describe('when no id is passed', () => {
+    it('renders an input with the id equal to the field name', () => {
+      const textInput = mount(
+        <GridFormCheckboxInput
+          field={{
+            type: type,
+            name: name,
+            description: description,
+          }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input#name').length).toBe(1);
+    });
+  });
+});

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
@@ -1,25 +1,16 @@
 import GridFormCheckboxInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
+import { stubCheckboxField } from '../../../__tests__/stubs';
 
 describe('GridFormCheckboxInput', () => {
-  const type = 'checkbox';
-  const name = 'name';
-  const description = 'description';
-
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const id = 'mycoolid';
-
       const textInput = mount(
         <GridFormCheckboxInput
-          field={{
-            type: type,
-            name: name,
-            description: description,
-          }}
+          field={stubCheckboxField}
           register={jest.fn()}
-          id={id}
+          id={'mycoolid'}
         />
       );
 
@@ -31,11 +22,7 @@ describe('GridFormCheckboxInput', () => {
     it('renders an input with the id equal to the field name', () => {
       const textInput = mount(
         <GridFormCheckboxInput
-          field={{
-            type: type,
-            name: name,
-            description: description,
-          }}
+          field={{ ...stubCheckboxField, name: 'name' }}
           register={jest.fn()}
         />
       );

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
@@ -8,12 +8,14 @@ export type GridFormCheckboxInputProps = {
   className?: string;
   field: GridFormCheckboxField;
   register: FormContextValues['register'];
+  id?: string;
 };
 
 export const GridFormCheckboxInput: React.FC<GridFormCheckboxInputProps> = ({
   className,
   field,
   register,
+  id,
 }) => {
   return (
     <Checkbox
@@ -25,6 +27,7 @@ export const GridFormCheckboxInput: React.FC<GridFormCheckboxInputProps> = ({
       label={field.description}
       multiline={field.multiline}
       ref={register(field.validation)}
+      id={id}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
@@ -9,6 +9,7 @@ export type GridFormCustomInputProps = {
   field: GridFormCustomField;
   register: FormContextValues['register'];
   setValue: (name: string, value: any) => void;
+  id?: string;
 };
 
 export const GridFormCustomInput: React.FC<GridFormCustomInputProps> = ({
@@ -17,6 +18,7 @@ export const GridFormCustomInput: React.FC<GridFormCustomInputProps> = ({
   field,
   register,
   setValue,
+  id,
 }) => {
   useEffect(() => {
     register(field.name, field.validation);

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
@@ -1,0 +1,43 @@
+import GridFormFileInput from '../index';
+import { mount } from 'enzyme';
+import React from 'react';
+
+describe('GridFormFileInput', () => {
+  const type = 'file';
+  const name = 'name';
+
+  describe('when an id is passed as a prop', () => {
+    it('renders an input with the same id', () => {
+      const id = 'mycoolid';
+
+      const textInput = mount(
+        <GridFormFileInput
+          field={{
+            type: type,
+            name: name,
+          }}
+          register={jest.fn()}
+          id={id}
+        />
+      );
+
+      expect(textInput.find('input#mycoolid').length).toBe(1);
+    });
+  });
+
+  describe('when no id is passed', () => {
+    it('renders an input with the id equal to the field name', () => {
+      const textInput = mount(
+        <GridFormFileInput
+          field={{
+            type: type,
+            name: name,
+          }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input#name').length).toBe(1);
+    });
+  });
+});

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
@@ -1,23 +1,16 @@
 import GridFormFileInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
+import { stubFileField } from '../../../__tests__/stubs';
 
 describe('GridFormFileInput', () => {
-  const type = 'file';
-  const name = 'name';
-
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const id = 'mycoolid';
-
       const textInput = mount(
         <GridFormFileInput
-          field={{
-            type: type,
-            name: name,
-          }}
+          field={stubFileField}
           register={jest.fn()}
-          id={id}
+          id={'mycoolid'}
         />
       );
 
@@ -29,10 +22,7 @@ describe('GridFormFileInput', () => {
     it('renders an input with the id equal to the field name', () => {
       const textInput = mount(
         <GridFormFileInput
-          field={{
-            type: type,
-            name: name,
-          }}
+          field={{ ...stubFileField, name: 'name' }}
           register={jest.fn()}
         />
       );

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/index.tsx
@@ -9,6 +9,7 @@ export type GridFormFileInputProps = {
   error?: boolean;
   field: Omit<GridFormFileField, 'label'>;
   register: FormContextValues['register'];
+  id?: string;
 };
 
 export const GridFormFileInput: React.FC<GridFormFileInputProps> = ({
@@ -16,6 +17,7 @@ export const GridFormFileInput: React.FC<GridFormFileInputProps> = ({
   error,
   field,
   register,
+  id,
 }) => {
   return (
     <Input
@@ -26,6 +28,7 @@ export const GridFormFileInput: React.FC<GridFormFileInputProps> = ({
       onChange={(event) => field.onUpdate?.(event.target.files)}
       ref={register(field.validation)}
       type="file"
+      id={id}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
@@ -1,0 +1,57 @@
+import GridFormRadioGroupInput from '../index';
+import { mount } from 'enzyme';
+import React from 'react';
+
+describe('GridFormRadioGroupInput', () => {
+  const type = 'radio-group';
+  const name = 'name';
+
+  describe('when an id is passed as a prop', () => {
+    it('renders an input with the same id', () => {
+      const id = 'mycoolid';
+
+      const textInput = mount(
+        <GridFormRadioGroupInput
+          field={{
+            type: type,
+            name: name,
+            options: [
+              {
+                label: 'label',
+                value: 'value',
+              },
+            ],
+          }}
+          setValue={jest.fn()}
+          register={jest.fn()}
+          id={id}
+        />
+      );
+
+      expect(textInput.find('input#name-0-mycoolid').length).toBe(1);
+    });
+  });
+
+  describe('when no id is passed', () => {
+    it('renders an input with the id equal to the field option value', () => {
+      const textInput = mount(
+        <GridFormRadioGroupInput
+          field={{
+            type: type,
+            name: name,
+            options: [
+              {
+                label: 'label',
+                value: 'value',
+              },
+            ],
+          }}
+          setValue={jest.fn()}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input#name-0').length).toBe(1);
+    });
+  });
+});

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
@@ -1,30 +1,17 @@
 import GridFormRadioGroupInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
+import { stubRadioGroupField } from '../../../__tests__/stubs';
 
 describe('GridFormRadioGroupInput', () => {
-  const type = 'radio-group';
-  const name = 'name';
-
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const id = 'mycoolid';
-
       const textInput = mount(
         <GridFormRadioGroupInput
-          field={{
-            type: type,
-            name: name,
-            options: [
-              {
-                label: 'label',
-                value: 'value',
-              },
-            ],
-          }}
+          field={{ ...stubRadioGroupField, name: 'name' }}
           setValue={jest.fn()}
           register={jest.fn()}
-          id={id}
+          id={'mycoolid'}
         />
       );
 
@@ -36,16 +23,7 @@ describe('GridFormRadioGroupInput', () => {
     it('renders an input with the id equal to the field option value', () => {
       const textInput = mount(
         <GridFormRadioGroupInput
-          field={{
-            type: type,
-            name: name,
-            options: [
-              {
-                label: 'label',
-                value: 'value',
-              },
-            ],
-          }}
+          field={{ ...stubRadioGroupField, name: 'name' }}
           setValue={jest.fn()}
           register={jest.fn()}
         />

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
@@ -9,6 +9,7 @@ export type GridFormRadioGroupInputProps = {
   field: Omit<GridFormRadioGroupField, 'label'>;
   register: FormContextValues['register'];
   setValue: (name: string, value: string) => void;
+  id?: string;
 };
 
 export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = ({
@@ -16,6 +17,7 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
   field,
   register,
   setValue,
+  id,
 }) => {
   return (
     <RadioGroup
@@ -34,6 +36,7 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
           label={label}
           ref={register(field.validation)}
           value={value}
+          id={id}
         />
       ))}
     </RadioGroup>

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
@@ -1,0 +1,44 @@
+import GridFormSelectInput from '../index';
+import { mount } from 'enzyme';
+import React from 'react';
+
+describe('GridFormSelectInput', () => {
+  const name = 'name';
+
+  describe('when an id is passed as a prop', () => {
+    it('renders a select with the same id', () => {
+      const id = 'mycoolid';
+
+      const textInput = mount(
+        <GridFormSelectInput
+          field={{
+            type: 'select',
+            name: name,
+            options: [],
+          }}
+          register={jest.fn()}
+          id={id}
+        />
+      );
+
+      expect(textInput.find('select#mycoolid').length).toBe(1);
+    });
+  });
+
+  describe('when no id is passed', () => {
+    it('renders a select with the id equal to the field name', () => {
+      const textInput = mount(
+        <GridFormSelectInput
+          field={{
+            type: 'select',
+            name: name,
+            options: [],
+          }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('select#name').length).toBe(1);
+    });
+  });
+});

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
@@ -1,23 +1,16 @@
 import GridFormSelectInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
+import { stubSelectField } from '../../../__tests__/stubs';
 
 describe('GridFormSelectInput', () => {
-  const name = 'name';
-
   describe('when an id is passed as a prop', () => {
     it('renders a select with the same id', () => {
-      const id = 'mycoolid';
-
       const textInput = mount(
         <GridFormSelectInput
-          field={{
-            type: 'select',
-            name: name,
-            options: [],
-          }}
+          field={stubSelectField}
           register={jest.fn()}
-          id={id}
+          id={'mycoolid'}
         />
       );
 
@@ -29,11 +22,7 @@ describe('GridFormSelectInput', () => {
     it('renders a select with the id equal to the field name', () => {
       const textInput = mount(
         <GridFormSelectInput
-          field={{
-            type: 'select',
-            name: name,
-            options: [],
-          }}
+          field={{ ...stubSelectField, name: 'name' }}
           register={jest.fn()}
         />
       );

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
@@ -9,6 +9,7 @@ export type GridFormSelectInputProps = {
   error?: boolean;
   field: Omit<GridFormSelectField, 'label'>;
   register: FormContextValues['register'];
+  id?: string;
 };
 
 export const GridFormSelectInput: React.FC<GridFormSelectInputProps> = ({
@@ -16,6 +17,7 @@ export const GridFormSelectInput: React.FC<GridFormSelectInputProps> = ({
   error,
   field,
   register,
+  id,
 }) => {
   return (
     <Select
@@ -27,6 +29,7 @@ export const GridFormSelectInput: React.FC<GridFormSelectInputProps> = ({
       onChange={(event) => field.onUpdate?.(event.target.value)}
       ref={register(field.validation)}
       options={field.options}
+      id={id}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
@@ -1,22 +1,16 @@
 import GridFormTextArea from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
+import { stubTextareaField } from '../../../__tests__/stubs';
 
 describe('GridFormTextArea', () => {
-  const name = 'name';
-
   describe('when an id is passed as a prop', () => {
     it('renders an textarea with the same id', () => {
-      const id = 'mycoolid';
-
       const textarea = mount(
         <GridFormTextArea
-          field={{
-            name: name,
-            type: 'textarea',
-          }}
+          field={stubTextareaField}
           register={jest.fn()}
-          id={id}
+          id={'mycoolid'}
         />
       );
 
@@ -28,10 +22,7 @@ describe('GridFormTextArea', () => {
     it('renders a textarea with the id equal to the field name', () => {
       const textarea = mount(
         <GridFormTextArea
-          field={{
-            type: 'textarea',
-            name: name,
-          }}
+          field={{ ...stubTextareaField, name: 'name' }}
           register={jest.fn()}
         />
       );

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
@@ -1,0 +1,42 @@
+import GridFormTextArea from '../index';
+import { mount } from 'enzyme';
+import React from 'react';
+
+describe('GridFormTextArea', () => {
+  const name = 'name';
+
+  describe('when an id is passed as a prop', () => {
+    it('renders an textarea with the same id', () => {
+      const id = 'mycoolid';
+
+      const textarea = mount(
+        <GridFormTextArea
+          field={{
+            name: name,
+            type: 'textarea',
+          }}
+          register={jest.fn()}
+          id={id}
+        />
+      );
+
+      expect(textarea.find('textarea#mycoolid').length).toBe(1);
+    });
+  });
+
+  describe('when no id is passed', () => {
+    it('renders a textarea with the id equal to the field name', () => {
+      const textarea = mount(
+        <GridFormTextArea
+          field={{
+            type: 'textarea',
+            name: name,
+          }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textarea.find('textarea#name').length).toBe(1);
+    });
+  });
+});

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/index.tsx
@@ -9,6 +9,7 @@ export type GridFormTextAreaProps = {
   error?: boolean;
   field: Omit<GridFormTextAreaField, 'label'>;
   register: FormContextValues['register'];
+  id?: string;
 };
 
 export const GridFormTextArea: React.FC<GridFormTextAreaProps> = ({
@@ -16,6 +17,7 @@ export const GridFormTextArea: React.FC<GridFormTextAreaProps> = ({
   error,
   field,
   register,
+  id,
 }) => {
   return (
     <TextArea
@@ -25,6 +27,7 @@ export const GridFormTextArea: React.FC<GridFormTextAreaProps> = ({
       name={field.name}
       onChange={(event) => field.onUpdate?.(event.target.value)}
       ref={register(field.validation)}
+      id={id}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
@@ -1,23 +1,16 @@
 import GridFormTextInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
+import { stubTextField } from '../../../__tests__/stubs';
 
 describe('GridFormTextInput', () => {
-  const type = 'text';
-  const name = 'name';
-
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const id = 'mycoolid';
-
       const textInput = mount(
         <GridFormTextInput
-          field={{
-            type: type,
-            name: name,
-          }}
+          field={stubTextField}
           register={jest.fn()}
-          id={id}
+          id={'mycoolid'}
         />
       );
 
@@ -29,10 +22,7 @@ describe('GridFormTextInput', () => {
     it('renders an input with the id equal to the field name', () => {
       const textInput = mount(
         <GridFormTextInput
-          field={{
-            type: type,
-            name: name,
-          }}
+          field={{ ...stubTextField, name: 'name' }}
           register={jest.fn()}
         />
       );

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
@@ -1,0 +1,43 @@
+import GridFormTextInput from '../index';
+import { mount } from 'enzyme';
+import React from 'react';
+
+describe('GridFormTextInput', () => {
+  const type = 'text';
+  const name = 'name';
+
+  describe('when an id is passed as a prop', () => {
+    it('renders an input with the same id', () => {
+      const id = 'mycoolid';
+
+      const textInput = mount(
+        <GridFormTextInput
+          field={{
+            type: type,
+            name: name,
+          }}
+          register={jest.fn()}
+          id={id}
+        />
+      );
+
+      expect(textInput.find('input#mycoolid').length).toBe(1);
+    });
+  });
+
+  describe('when no id is passed', () => {
+    it('renders an input with the id equal to the field name', () => {
+      const textInput = mount(
+        <GridFormTextInput
+          field={{
+            type: type,
+            name: name,
+          }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input#name').length).toBe(1);
+    });
+  });
+});

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
@@ -9,6 +9,7 @@ export type GridFormTextInputProps = {
   error?: boolean;
   field: Omit<GridFormTextField, 'label'>;
   register: FormContextValues['register'];
+  id?: string;
 };
 
 export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({
@@ -16,6 +17,7 @@ export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({
   error,
   field,
   register,
+  id,
 }) => {
   return (
     <Input
@@ -27,6 +29,7 @@ export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({
       name={field.name}
       ref={register(field.validation)}
       type={field.type}
+      id={id}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -111,7 +111,7 @@ describe('GridFormInputGroup', () => {
     expect(onUpdateSpy).toHaveBeenCalledWith(newVal);
   });
 
-  it('invokes onUpdate when the field type is textera and it gets changed', () => {
+  it('invokes onUpdate when the field type is textarea and it gets changed', () => {
     const onUpdateSpy = jest.fn();
     const newVal = 'foo';
 

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -16,6 +16,7 @@ const renderComponent = (overrides: Partial<GridFormInputGroupProps>) => {
     field: stubSelectField,
     setValue: jest.fn(),
     register: jest.fn(),
+    id: 'mycoolid',
     ...overrides,
   };
 
@@ -38,7 +39,7 @@ describe('GridFormInputGroup', () => {
       field: stubCheckboxField,
     });
 
-    expect(wrapped.find('input[type="checkbox"]')).toHaveLength(1);
+    expect(wrapped.find('input[type="checkbox"]#mycoolid')).toHaveLength(1);
   });
 
   it('renders a custom input when the field type is custom', () => {
@@ -60,6 +61,7 @@ describe('GridFormInputGroup', () => {
     });
 
     expect(wrapped.find('input[type="radio"]')).toHaveLength(2);
+    expect(wrapped.find('input#stub-radio-group-0-mycoolid')).toHaveLength(1);
   });
 
   it('renders a select when the field type is select', () => {
@@ -67,7 +69,7 @@ describe('GridFormInputGroup', () => {
       field: stubSelectField,
     });
 
-    expect(wrapped.find('select')).toHaveLength(1);
+    expect(wrapped.find('select#mycoolid')).toHaveLength(1);
   });
 
   it('renders a text input when the field type is text', () => {
@@ -75,7 +77,7 @@ describe('GridFormInputGroup', () => {
       field: stubTextField,
     });
 
-    expect(wrapped.find('input[type="text"]')).toHaveLength(1);
+    expect(wrapped.find('input[type="text"]#mycoolid')).toHaveLength(1);
   });
 
   it('renders a file input when the field type is file', () => {
@@ -83,7 +85,7 @@ describe('GridFormInputGroup', () => {
       field: stubFileField,
     });
 
-    expect(wrapped.find('input[type="file"]')).toHaveLength(1);
+    expect(wrapped.find('input[type="file"]#mycoolid')).toHaveLength(1);
   });
 
   it('renders a textarea when the field type is textarea', () => {
@@ -91,7 +93,7 @@ describe('GridFormInputGroup', () => {
       field: stubTextareaField,
     });
 
-    expect(wrapped.find('textarea')).toHaveLength(1);
+    expect(wrapped.find('textarea#mycoolid')).toHaveLength(1);
   });
 
   it('invokes onUpdate when the field type is text and it gets changed', () => {

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -18,6 +18,7 @@ export type GridFormInputGroupProps = {
   field: GridFormField;
   register: FormContextValues['register'];
   setValue: (value: any) => void;
+  id?: string;
 };
 
 export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
@@ -31,6 +32,7 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
             className={styles.gridFormInput}
             field={props.field}
             register={props.register}
+            id={props.id}
           />
         );
 
@@ -52,6 +54,7 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
             field={props.field}
             register={props.register}
             setValue={props.setValue}
+            id={props.id}
           />
         );
 
@@ -62,6 +65,7 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
             error={!!props.error}
             field={props.field}
             register={props.register}
+            id={props.id}
           />
         );
 
@@ -72,6 +76,7 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
             error={!!props.error}
             field={props.field}
             register={props.register}
+            id={props.id}
           />
         );
 
@@ -82,6 +87,7 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
             error={!!props.error}
             field={props.field}
             register={props.register}
+            id={props.id}
           />
         );
 
@@ -92,6 +98,7 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
             error={!!props.error}
             field={props.field}
             register={props.register}
+            id={props.id}
           />
         );
     }


### PR DESCRIPTION
## Overview

### PR Checklist
- [x] Related to JIRA ticket: EN-46
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description
This PR adds the ability to add an optional Id prop to GridFormInputGroups, in order to resolve accessibility issues that arise with pages with multiple grid forms. 

This initially surfaced on the Business Landing Page where there are two forms, each of which contains an "email" field. This causes the accessibility tests to break, since the ID of both these forms was created from the required name prop. Both of the forms on this page submit to HubSpot, which requires the name be related to the field name, thus locking us in this situation of duplicate ids.
