### PR TITLE
feat(Gamut): Allowed Alerts to not be passed an onClose callback

### DIFF
--- a/packages/gamut/src/Alert/__tests__/Alert-test.tsx
+++ b/packages/gamut/src/Alert/__tests__/Alert-test.tsx
@@ -16,6 +16,14 @@ describe('Alert', () => {
     expect(renderedAlert).toBeDefined();
   });
 
+  it('does not render a close button when there is no onClose callback', () => {
+    const renderedAlert = mount(<Alert>Hello</Alert>);
+
+    const buttons = renderedAlert.find('button');
+
+    expect(buttons).toHaveLength(0);
+  });
+
   it('calls the onClose callback when the close button is clicked', () => {
     const onClose = jest.fn();
     const renderedAlert = mount(<Alert onClose={onClose}>Hello</Alert>);

--- a/packages/gamut/src/Alert/index.tsx
+++ b/packages/gamut/src/Alert/index.tsx
@@ -25,7 +25,7 @@ export type AlertProps = {
   /** Toggle the display of the theme's icon */
   showIcon?: boolean;
   /** On close callback */
-  onClose: () => void;
+  onClose?: () => void;
   /** Call to action configuration { text, href, onClick } */
   cta?: BannerCTA;
   /** Remove the max-width on the Alert container */
@@ -110,16 +110,18 @@ export const Alert: React.FC<AlertProps> = ({
             </Container>
           )}
         </Container>
-        <Container className={s.section} shrink={1} center>
-          <ButtonBase
-            className={cx(s.iconButton, {
-              [s[`iconButton__${type}`]]: type,
-            })}
-            onClick={onClose}
-          >
-            <CloseIcon size={12} />
-          </ButtonBase>
-        </Container>
+        {onClose && (
+          <Container className={s.section} shrink={1} center>
+            <ButtonBase
+              className={cx(s.iconButton, {
+                [s[`iconButton__${type}`]]: type,
+              })}
+              onClick={onClose}
+            >
+              <CloseIcon size={12} />
+            </ButtonBase>
+          </Container>
+        )}
       </Container>
     </CardShell>
   );

--- a/packages/styleguide/stories/Core/Molecules/Alert.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Alert.stories.mdx
@@ -188,6 +188,21 @@ without restriction. This will automatically truncate and add a toggle button.
   </Story>
 </Preview>
 
+### Permanent Alert
+
+If your alert should always stay on the page, you can skip giving it a close button on the right.
+Please remember that most of these are rather frustrating for users.
+
+<Preview>
+  <Story name="Permanent">
+    <Alert showIcon={false} type={BannerType.Notice} lines={1}>
+      Lorem ipsum dolor sit amet, blandit detracto vis an, purto latine
+      torquatos eam ut. Dicta dolores adversarium mei in. Ius ei ridens mentitum
+      consequat. Amet intellegam in nec. Pro duis novum ludus ad.
+    </Alert>
+  </Story>
+</Preview>
+
 ### All Options
 
 <Preview>


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to Abstract designs:~
- [x] Related to JIRA ticket: GM-29
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

I'd like to use one on the /forum_requestions/ Rails-to-React port for the permanent 'go away' message on the top of the page.
