### PR TITLE
feat(Gamut)!: :fire: removed register from custom input useEffect

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { FormContextValues } from 'react-hook-form';
 
 import { GridFormCustomField } from '../../types';
@@ -9,7 +9,6 @@ export type GridFormCustomInputProps = {
   field: GridFormCustomField;
   register: FormContextValues['register'];
   setValue: (name: string, value: any) => void;
-  id?: string;
 };
 
 export const GridFormCustomInput: React.FC<GridFormCustomInputProps> = ({
@@ -18,12 +17,7 @@ export const GridFormCustomInput: React.FC<GridFormCustomInputProps> = ({
   field,
   register,
   setValue,
-  id,
 }) => {
-  useEffect(() => {
-    register(field.name, field.validation);
-  }, [field.name, field.validation, register]);
-
   return (
     <>
       {field.render({


### PR DESCRIPTION
## Overview
Related to https://codecademy.atlassian.net/browse/GROW-1628
We need more control in the consumer over how refs get built for GridForm custom inputs. This change makes it so that the consumer of gamut will have to set up a ref on the html element within the field's render method.

### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: ABC-123(https://codecademy.atlassian.net/browse/GROW-1628)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
