### PR TITLE
fix: set Input border color for accessibility

### DIFF
--- a/packages/gamut/src/Form/styles/Input.module.scss
+++ b/packages/gamut/src/Form/styles/Input.module.scss
@@ -22,7 +22,7 @@
 }
 
 .error {
-  border-color: $color-red-500;
+  border-color: $color-red-700;
   &:focus {
     border-color: $color-red-200;
   }


### PR DESCRIPTION
## Overview
Updated the border-color of the Form Input component to $color-red-700.

### PR Checklist

- [ ] Related to Abstract designs:
- [X] Related to JIRA ticket: LX-3974
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description
While working on [this](https://codecademy.atlassian.net/browse/LX-3930) ticket, accessibility errors arose on the homepage. In order to address these accessibility issues, the validation text color was changed to $color-red-700. Thus, the color of the input border has been updated to match the text color.
