### PR TITLE
Switched storyshot test renderer to Enzyme mounting

### DIFF
--- a/packages/styleguide/__tests__/storybook-test.ts
+++ b/packages/styleguide/__tests__/storybook-test.ts
@@ -1,10 +1,11 @@
+import { mount } from 'enzyme';
 import path from 'path';
-import initStoryshots, { renderOnly } from '@storybook/addon-storyshots';
-
-jest.mock('react-truncate-markup', () => (props: any) => props.children);
+import initStoryshots, { renderWithOptions } from '@storybook/addon-storyshots';
 
 initStoryshots({
   framework: 'react',
-  test: renderOnly,
+  test: renderWithOptions({
+    renderer: mount,
+  }),
   configPath: path.join(__dirname, '../.storybook'),
 });


### PR DESCRIPTION
## Overview

### PR Checklist

- [x] Related to Abstract designs:
- [x] Related to JIRA ticket: WEB-908
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

#826 has some test failures from framer-motion: https://app.circleci.com/pipelines/github/Codecademy/client-modules/4853/workflows/d7c9f7f2-1b76-4e13-a4ea-0af6a38b44b3/jobs/27406/steps

This switches from the default `react-test-renderer` to Enzyme, which is what we use for most unit tests. 

Eventually I'd love to switch this and other tests back or to `@testing-library/react`... but perhaps that's a fight for another day.