### PR TITLE
feat(Gamut): Add color options to HighlightedText

### DIFF
--- a/packages/gamut/src/HighlightedText/__tests__/HighlightedText-test.tsx
+++ b/packages/gamut/src/HighlightedText/__tests__/HighlightedText-test.tsx
@@ -11,4 +11,19 @@ describe('HighlightedText', () => {
 
     expect(wrapped.text()).toEqual(text);
   });
+
+  it('defaults text color to yellow', () => {
+    const text = 'highlighted';
+    const wrapped = mount(<HighlightedText>{text}</HighlightedText>);
+    expect(wrapped.find('.yellow')).toHaveLength(1);
+  });
+
+  it('allows selecting a specific other color', () => {
+    const text = 'highlighted';
+    const wrapped = mount(
+      <HighlightedText color="blue">{text}</HighlightedText>
+    );
+    expect(wrapped.find('.blue')).toHaveLength(1);
+    expect(wrapped.find('.yellow')).toHaveLength(0);
+  });
 });

--- a/packages/gamut/src/HighlightedText/index.tsx
+++ b/packages/gamut/src/HighlightedText/index.tsx
@@ -18,7 +18,7 @@ export type HighlightedTextProps = {
   /** String to transform into the contents of the highlighted text */
   children?: string;
 
-  /** Standard element properties that should be applied to the indivudual words that are being highlighted */
+  /** Standard element properties that should be applied to the individual words that are being highlighted */
   wordProps?: HTMLAttributes<HTMLSpanElement>;
 
   /** Standard element properties that should be applied to the entire set of words */

--- a/packages/gamut/src/HighlightedText/index.tsx
+++ b/packages/gamut/src/HighlightedText/index.tsx
@@ -3,19 +3,39 @@ import React, { HTMLAttributes } from 'react';
 
 import styles from './styles.module.scss';
 
+export type HighlightColors =
+  | 'red'
+  | 'orange'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'beige'
+  | 'gray';
+
 export type HighlightedTextProps = {
+  /** String to transform into the contents of the highlighted text; cannot nest other elements */
   children?: string;
+
+  /** Standard element properties that should be applied to the indivudual words that are being highlighted */
   wordProps?: HTMLAttributes<HTMLSpanElement>;
+
+  /** Standard element properties that should be applied to the entire set of words */
   textProps?: HTMLAttributes<HTMLElement>;
+
+  /** The color that should display behind the text; if not provided, defaults to yellow */
+  color?: HighlightColors;
 };
 
 export const HighlightedText: React.FC<HighlightedTextProps> = ({
   children = '',
   textProps = {},
+  color = 'yellow',
 }) => {
   const combinedProps = {
     ...textProps,
-    className: cx(styles.highlightedText, textProps.className),
+    className: cx(styles.highlightedText, textProps.className, styles[color]),
   };
 
   const words = children

--- a/packages/gamut/src/HighlightedText/index.tsx
+++ b/packages/gamut/src/HighlightedText/index.tsx
@@ -15,7 +15,7 @@ export type HighlightColors =
   | 'gray';
 
 export type HighlightedTextProps = {
-  /** String to transform into the contents of the highlighted text; cannot nest other elements */
+  /** String to transform into the contents of the highlighted text */
   children?: string;
 
   /** Standard element properties that should be applied to the indivudual words that are being highlighted */

--- a/packages/gamut/src/HighlightedText/styles.module.scss
+++ b/packages/gamut/src/HighlightedText/styles.module.scss
@@ -10,7 +10,6 @@
 }
 
 .word::after {
-  background: $color-yellow-400;
   content: " ";
   display: block;
   height: 32.5%;
@@ -20,4 +19,40 @@
   top: 50%;
   width: calc(100% + 0.4rem);
   z-index: -1;
+}
+
+.red .word::after {
+  background: $color-red-300;
+}
+
+.orange .word::after {
+  background: $color-orange-400;
+}
+
+.yellow .word::after {
+  background: $color-yellow-400;
+}
+
+.purple .word::after {
+  background: $color-purple-300;
+}
+
+.pink .word::after {
+  background: $color-pink-400;
+}
+
+.green .word::after {
+  background: $color-green-300;
+}
+
+.beige .word::after {
+  background: $color-beige;
+}
+
+.blue .word::after {
+  background: $color-blue-300;
+}
+
+.gray .word::after {
+  background: $color-gray-300;
 }

--- a/packages/gamut/src/HighlightedText/styles.module.scss
+++ b/packages/gamut/src/HighlightedText/styles.module.scss
@@ -22,11 +22,11 @@
 }
 
 .red .word::after {
-  background: $color-red-300;
+  background: $color-red-200;
 }
 
 .orange .word::after {
-  background: $color-orange-400;
+  background: $color-orange-300;
 }
 
 .yellow .word::after {
@@ -34,11 +34,11 @@
 }
 
 .purple .word::after {
-  background: $color-purple-300;
+  background: $color-purple-200;
 }
 
 .pink .word::after {
-  background: $color-pink-400;
+  background: $color-pink-300;
 }
 
 .green .word::after {
@@ -50,7 +50,7 @@
 }
 
 .blue .word::after {
-  background: $color-blue-300;
+  background: $color-blue-200;
 }
 
 .gray .word::after {

--- a/packages/styleguide/stories/Core/Atoms/HighlightedText.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/HighlightedText.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/dist/blocks';
 import { StoryStatus } from '../../../Blocks';
 import { HighlightedText, Text } from '@codecademy/gamut/src';
-import { text } from '@storybook/addon-knobs';
+import { text, select } from '@storybook/addon-knobs';
 
 <Meta title="Core|Atoms/HighlightedText" component={HighlightedText} />
 
@@ -16,7 +16,22 @@ showcase important words in a sentence.
   <Story name="HighlightedText">
     <Text fontSize="md">
       Would you like to have{' '}
-      <HighlightedText>{text('text', 'superpowers')}</HighlightedText>?
+      <HighlightedText
+        color={select('color', [
+          'red',
+          'orange',
+          'yellow',
+          'green',
+          'blue',
+          'purple',
+          'pink',
+          'beige',
+          'gray',
+        ])}
+      >
+        {text('text', 'superpowers')}
+      </HighlightedText>
+      ?
     </Text>
   </Story>
 </Preview>

--- a/packages/styleguide/stories/Core/Atoms/HighlightedText.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/HighlightedText.stories.mdx
@@ -18,9 +18,9 @@ showcase important words in a sentence.
       Would you like to have{' '}
       <HighlightedText
         color={select('color', [
+          'yellow',
           'red',
           'orange',
-          'yellow',
           'green',
           'blue',
           'purple',


### PR DESCRIPTION
## Overview

### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: WEB-921
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

Currently, the highlighted text component only supports highlighting with a yellow background & requires knowledge of the structure of the component to recolor; this makes it challenging for users of the component to match designs that use the Highlighted Text effect.

This change adds a standard property for setting the color of the text. It is tied to the standard brand colors.

### Notes
The colors for highlighted text are designed to meet A11Y standards as they show in Gamut, but I will also be soliciting design feedback about the levels, particularly for the more faded values.

### Testing Instructions
1. Open the alpha branch for this PR (or run locally)
1. Verify that the default highlighted text shows in yellow
1. Use the knobs (available on the **Canvas** tab) to show the other colors
1. Verify there are no accessibility problems with contrast with any of the settings
1. Verify there is now documentation for the other properties
