### PR TITLE
fix(Video): add onReady prop

### DIFF
--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -21,7 +21,7 @@ export type VideoProps = {
   loop?: boolean;
   muted?: boolean;
   className?: string;
-  modal?: boolean;
+  onReady?: () => void;
   onPlay?: () => void;
 };
 
@@ -34,7 +34,7 @@ export const Video: React.FC<VideoProps> = ({
   loop,
   muted,
   className,
-  modal,
+  onReady,
   onPlay,
 }) => {
   const [loading, setLoading] = useState(true);
@@ -53,9 +53,7 @@ export const Video: React.FC<VideoProps> = ({
         muted={muted}
         playIcon={<OverlayPlayButton />}
         onReady={() => {
-          if (modal) {
-            document.getElementsByTagName('iframe')[0].tabIndex = 0;
-          }
+          onReady();
           setLoading(false);
         }}
         onPlay={onPlay}

--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -21,6 +21,7 @@ export type VideoProps = {
   loop?: boolean;
   muted?: boolean;
   className?: string;
+  modal?: boolean;
   onPlay?: () => void;
 };
 
@@ -33,6 +34,7 @@ export const Video: React.FC<VideoProps> = ({
   loop,
   muted,
   className,
+  modal,
   onPlay,
 }) => {
   const [loading, setLoading] = useState(true);
@@ -50,7 +52,12 @@ export const Video: React.FC<VideoProps> = ({
         loop={loop}
         muted={muted}
         playIcon={<OverlayPlayButton />}
-        onReady={() => setLoading(false)}
+        onReady={() => {
+          if (modal) {
+            document.getElementsByTagName('iframe')[0].tabIndex = 0;
+          }
+          setLoading(false);
+        }}
         onPlay={onPlay}
       />
     </div>

--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -21,6 +21,7 @@ export type VideoProps = {
   loop?: boolean;
   muted?: boolean;
   className?: string;
+  id?: string;
   onReady?: () => void;
   onPlay?: () => void;
 };
@@ -34,6 +35,7 @@ export const Video: React.FC<VideoProps> = ({
   loop,
   muted,
   className,
+  id,
   onReady,
   onPlay,
 }) => {
@@ -50,6 +52,7 @@ export const Video: React.FC<VideoProps> = ({
         className={styles.iframe}
         controls={controls === undefined ? true : controls}
         loop={loop}
+        id={id}
         muted={muted}
         playIcon={<OverlayPlayButton />}
         onReady={() => {

--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -21,7 +21,7 @@ export type VideoProps = {
   loop?: boolean;
   muted?: boolean;
   className?: string;
-  onReady?: (el: HTMLElement) => void;
+  onReady?: (player: ReactPlayer) => void;
   onPlay?: () => void;
 };
 
@@ -52,8 +52,8 @@ export const Video: React.FC<VideoProps> = ({
         loop={loop}
         muted={muted}
         playIcon={<OverlayPlayButton />}
-        onReady={(e: ReactPlayer & { wrapper: HTMLElement }) => {
-          onReady(e.wrapper.querySelector('iframe'));
+        onReady={(player: ReactPlayer) => {
+          onReady(player);
           setLoading(false);
         }}
         onPlay={onPlay}

--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -21,8 +21,7 @@ export type VideoProps = {
   loop?: boolean;
   muted?: boolean;
   className?: string;
-  id?: string;
-  onReady?: () => void;
+  onReady?: (el: HTMLElement) => void;
   onPlay?: () => void;
 };
 
@@ -35,7 +34,6 @@ export const Video: React.FC<VideoProps> = ({
   loop,
   muted,
   className,
-  id,
   onReady,
   onPlay,
 }) => {
@@ -52,11 +50,10 @@ export const Video: React.FC<VideoProps> = ({
         className={styles.iframe}
         controls={controls === undefined ? true : controls}
         loop={loop}
-        id={id}
         muted={muted}
         playIcon={<OverlayPlayButton />}
-        onReady={() => {
-          onReady();
+        onReady={(e: ReactPlayer & { wrapper: HTMLElement }) => {
+          onReady(e.wrapper.querySelector('iframe'));
           setLoading(false);
         }}
         onPlay={onPlay}

--- a/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
@@ -13,8 +13,8 @@ given a video URL
     <Video
       videoUrl="https://vimeo.com/145702525"
       videoTitle="Super Science Friends"
-      onReady={(e) => {
-        e.tabIndex = 0;
+      onReady={(player) => {
+        player.wrapper.querySelector('iframe').tabIndex = 0;
       }}
     />
   </Story>

--- a/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
@@ -11,9 +11,11 @@ given a video URL
 <Preview>
   <Story name="Video">
     <Video
-      id="hello-there"
       videoUrl="https://vimeo.com/145702525"
       videoTitle="Super Science Friends"
+      onReady={(e) => {
+        e.tabIndex = 0;
+      }}
     />
   </Story>
 </Preview>
@@ -25,7 +27,6 @@ given a video URL
 <Preview>
   <Story name="Video with PlaceholderImage">
     <Video
-      id="rick"
       videoUrl="https://www.youtube.com/watch?v=Yl8yy5tpVIM"
       videoTitle="Workout with Rick Sanchez"
       placeholderImage="https://placekitten.com/400/300"

--- a/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
@@ -11,6 +11,7 @@ given a video URL
 <Preview>
   <Story name="Video">
     <Video
+      id="hello-there"
       videoUrl="https://vimeo.com/145702525"
       videoTitle="Super Science Friends"
     />
@@ -24,6 +25,7 @@ given a video URL
 <Preview>
   <Story name="Video with PlaceholderImage">
     <Video
+      id="rick"
       videoUrl="https://www.youtube.com/watch?v=Yl8yy5tpVIM"
       videoTitle="Workout with Rick Sanchez"
       placeholderImage="https://placekitten.com/400/300"


### PR DESCRIPTION
## Overview
videos that are in the VideoModal component don't let you tab into them unless you manually set the iframe's tabindex to 0

this PR adds an optional onReady prop where for VideoModals the Video can pass in a function like this `document.getElementsByTagName('iframe')[0].tabIndex = 0;` to fix the accessibility issue


### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
