### PR TITLE
fix(Video): check if onReady exists

### DIFF
--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -53,7 +53,7 @@ export const Video: React.FC<VideoProps> = ({
         muted={muted}
         playIcon={<OverlayPlayButton />}
         onReady={(player: ReactPlayer) => {
-          onReady(player);
+          onReady && onReady(player);
           setLoading(false);
         }}
         onPlay={onPlay}

--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -53,7 +53,7 @@ export const Video: React.FC<VideoProps> = ({
         muted={muted}
         playIcon={<OverlayPlayButton />}
         onReady={(player: ReactPlayer) => {
-          onReady && onReady(player);
+          onReady?.(player);
           setLoading(false);
         }}
         onPlay={onPlay}


### PR DESCRIPTION
## Overview
fix Video component - it is trying to call onReady(player) when there is no onReady prop which causes an error

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
