### PR TITLE
style: set default red color for form errors

### DIFF
--- a/packages/gamut/src/Form/FormError.tsx
+++ b/packages/gamut/src/Form/FormError.tsx
@@ -1,7 +1,15 @@
 import React, { HTMLAttributes } from 'react';
+import cx from 'classnames';
+import s from './styles/FormError.module.scss';
 
 export const FormError: React.FC<HTMLAttributes<HTMLSpanElement>> = (props) => {
-  return <span aria-live="assertive" {...props} />;
+  return (
+    <span
+      aria-live="assertive"
+      className={cx(s.formError, props.className)}
+      {...props}
+    />
+  );
 };
 
 export default FormError;

--- a/packages/gamut/src/Form/styles/FormError.module.scss
+++ b/packages/gamut/src/Form/styles/FormError.module.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 .formError {
   color: $color-red-500;
 }

--- a/packages/gamut/src/Form/styles/FormError.module.scss
+++ b/packages/gamut/src/Form/styles/FormError.module.scss
@@ -1,0 +1,3 @@
+.formError {
+  color: $color-red-500;
+}


### PR DESCRIPTION
## Overview

### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: [GROW-1641](https://codecademy.atlassian.net/browse/GROW-1641)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

The Stride team had to do an override to get the form errors in checkout-v3 to be red. Design was on board to default all form errors to red. This pr does that. (and now we can remove the overrides from the monolith)