### PR TITLE
chore(Styleguide): Fixes bad prefix on brand colors [GM-50]

### DIFF
--- a/packages/styleguide/stories/Core/Foundations/Colors/Colors.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Colors/Colors.stories.mdx
@@ -53,7 +53,7 @@ buttons and as vibrant background colors.
             Brand {startCase(color)}
           </Heading>
           <Swatch
-            name={`$color-${parseCamelCase(color)}`}
+            name={`$brand-${parseCamelCase(color)}`}
             hex={brandColors[color]}
           />
         </Container>


### PR DESCRIPTION
## Overview

I think I screwed up the SCSS variable prefix when I reworked these, this fixes that.

JIRA: GM-50
