### PR TITLE
fix: accessibility changes

### DIFF
--- a/packages/gamut/src/Form/styles/FormError.module.scss
+++ b/packages/gamut/src/Form/styles/FormError.module.scss
@@ -1,5 +1,5 @@
 @import "variables";
 
 .formError {
-  color: $color-red-500;
+  color: $color-red-700;
 }

--- a/packages/gamut/src/Form/styles/Select.module.scss
+++ b/packages/gamut/src/Form/styles/Select.module.scss
@@ -7,9 +7,9 @@
 }
 
 .error {
-  border-color: $color-red-500;
+  border-color: $color-red-700;
   &:focus {
-    border-color: $color-red-200;
+    border-color: $color-red-500;
   }
 }
 

--- a/packages/gamut/src/Form/styles/TextArea.module.scss
+++ b/packages/gamut/src/Form/styles/TextArea.module.scss
@@ -21,5 +21,8 @@
 }
 
 .error {
-  border-color: $color-red-500;
+  border-color: $color-red-700;
+  &:focus {
+    border-color: $color-red-500;
+  }
 }

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
@@ -1,33 +1,22 @@
-import GridFormCheckboxInput from '../index';
-import { mount } from 'enzyme';
-import React from 'react';
-import { stubCheckboxField } from '../../../__tests__/stubs';
-import { itHandlesRequiredProps } from '../../TestHelper';
+import {
+  itHandlesRequiredProps,
+  renderGridFormCheckboxInput,
+} from '../../TestHelper';
 
 describe('GridFormCheckboxInput', () => {
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const textInput = mount(
-        <GridFormCheckboxInput
-          field={{ ...stubCheckboxField, id: 'mycoolid' }}
-          register={jest.fn()}
-        />
-      );
+      const checkboxInput = renderGridFormCheckboxInput({ id: 'mycoolid' });
 
-      expect(textInput.find('input#mycoolid').length).toBe(1);
+      expect(checkboxInput.find('input#mycoolid').length).toBe(1);
     });
   });
 
   describe('when no id is passed', () => {
     it('renders an input with the id equal to the field name', () => {
-      const textInput = mount(
-        <GridFormCheckboxInput
-          field={{ ...stubCheckboxField, name: 'name' }}
-          register={jest.fn()}
-        />
-      );
+      const checkboxInput = renderGridFormCheckboxInput({ name: 'name' });
 
-      expect(textInput.find('input#name').length).toBe(1);
+      expect(checkboxInput.find('input#name').length).toBe(1);
     });
   });
 

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/__tests__/GridFormCheckboxInput-test.tsx
@@ -2,6 +2,7 @@ import GridFormCheckboxInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
 import { stubCheckboxField } from '../../../__tests__/stubs';
+import { itHandlesRequiredProps } from '../../TestHelper';
 
 describe('GridFormCheckboxInput', () => {
   describe('when an id is passed as a prop', () => {
@@ -29,4 +30,6 @@ describe('GridFormCheckboxInput', () => {
       expect(textInput.find('input#name').length).toBe(1);
     });
   });
+
+  itHandlesRequiredProps('GridFormCheckboxInput', 'input');
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
@@ -26,6 +26,7 @@ export const GridFormCheckboxInput: React.FC<GridFormCheckboxInputProps> = ({
       multiline={field.multiline}
       ref={register(field.validation)}
       id={field.id}
+      required={field.validation && !!field.validation.required}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
@@ -2,31 +2,34 @@ import GridFormFileInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
 import { stubFileField } from '../../../__tests__/stubs';
+import { itHandlesRequiredProps } from '../../TestHelper';
 
 describe('GridFormFileInput', () => {
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const textInput = mount(
+      const fileInput = mount(
         <GridFormFileInput
           field={{ ...stubFileField, id: 'mycoolid' }}
           register={jest.fn()}
         />
       );
 
-      expect(textInput.find('input#mycoolid').length).toBe(1);
+      expect(fileInput.find('input#mycoolid').length).toBe(1);
     });
   });
 
   describe('when no id is passed', () => {
     it('renders an input with the id equal to the field name', () => {
-      const textInput = mount(
+      const fileInput = mount(
         <GridFormFileInput
           field={{ ...stubFileField, name: 'name' }}
           register={jest.fn()}
         />
       );
 
-      expect(textInput.find('input#name').length).toBe(1);
+      expect(fileInput.find('input#name').length).toBe(1);
     });
   });
+
+  itHandlesRequiredProps('GridFormFileInput', 'input');
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/__tests__/GridFormFileInput-test.tsx
@@ -1,18 +1,12 @@
-import GridFormFileInput from '../index';
-import { mount } from 'enzyme';
-import React from 'react';
-import { stubFileField } from '../../../__tests__/stubs';
-import { itHandlesRequiredProps } from '../../TestHelper';
+import {
+  itHandlesRequiredProps,
+  renderGridFormFileInput,
+} from '../../TestHelper';
 
 describe('GridFormFileInput', () => {
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const fileInput = mount(
-        <GridFormFileInput
-          field={{ ...stubFileField, id: 'mycoolid' }}
-          register={jest.fn()}
-        />
-      );
+      const fileInput = renderGridFormFileInput({ id: 'mycoolid' });
 
       expect(fileInput.find('input#mycoolid').length).toBe(1);
     });
@@ -20,12 +14,7 @@ describe('GridFormFileInput', () => {
 
   describe('when no id is passed', () => {
     it('renders an input with the id equal to the field name', () => {
-      const fileInput = mount(
-        <GridFormFileInput
-          field={{ ...stubFileField, name: 'name' }}
-          register={jest.fn()}
-        />
-      );
+      const fileInput = renderGridFormFileInput({ name: 'name' });
 
       expect(fileInput.find('input#name').length).toBe(1);
     });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/index.tsx
@@ -27,6 +27,7 @@ export const GridFormFileInput: React.FC<GridFormFileInputProps> = ({
       ref={register(field.validation)}
       type="file"
       id={field.id}
+      required={field.validation && !!field.validation.required}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
@@ -1,39 +1,25 @@
-import GridFormRadioGroupInput from '../index';
-import { mount } from 'enzyme';
-import React from 'react';
-import { stubRadioGroupField } from '../../../__tests__/stubs';
-import { itHandlesRequiredProps } from '../../TestHelper';
+import {
+  itHandlesRequiredProps,
+  renderGridFormRadioGroupInput,
+} from '../../TestHelper';
 
 describe('GridFormRadioGroupInput', () => {
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const textInput = mount(
-        <GridFormRadioGroupInput
-          field={{
-            ...stubRadioGroupField,
-            id: 'mycoolid',
-            name: 'name',
-          }}
-          setValue={jest.fn()}
-          register={jest.fn()}
-        />
-      );
+      const radioButtons = renderGridFormRadioGroupInput({
+        id: 'mycoolid',
+        name: 'name',
+      });
 
-      expect(textInput.find('input#name-0-mycoolid').length).toBe(1);
+      expect(radioButtons.find('input#name-0-mycoolid').length).toBe(1);
     });
   });
 
   describe('when no id is passed', () => {
     it('renders an input with the id equal to the field option value', () => {
-      const textInput = mount(
-        <GridFormRadioGroupInput
-          field={{ ...stubRadioGroupField, name: 'name' }}
-          setValue={jest.fn()}
-          register={jest.fn()}
-        />
-      );
+      const radioButtons = renderGridFormRadioGroupInput({ name: 'name' });
 
-      expect(textInput.find('input#name-0').length).toBe(1);
+      expect(radioButtons.find('input#name-0').length).toBe(1);
     });
   });
 

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
@@ -2,6 +2,7 @@ import GridFormRadioGroupInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
 import { stubRadioGroupField } from '../../../__tests__/stubs';
+import { itHandlesRequiredProps } from '../../TestHelper';
 
 describe('GridFormRadioGroupInput', () => {
   describe('when an id is passed as a prop', () => {
@@ -35,4 +36,7 @@ describe('GridFormRadioGroupInput', () => {
       expect(textInput.find('input#name-0').length).toBe(1);
     });
   });
+
+  itHandlesRequiredProps('GridFormRadioGroupInput', 'input#stub-radio-group-0');
+  itHandlesRequiredProps('GridFormRadioGroupInput', 'input#stub-radio-group-1');
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
@@ -35,6 +35,7 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
           ref={register(field.validation)}
           value={value}
           id={field.id}
+          required={field.validation && !!field.validation.required}
         />
       ))}
     </RadioGroup>

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
@@ -2,6 +2,7 @@ import GridFormSelectInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
 import { stubSelectField } from '../../../__tests__/stubs';
+import { itHandlesRequiredProps } from '../../TestHelper';
 
 describe('GridFormSelectInput', () => {
   describe('when an id is passed as a prop', () => {
@@ -29,4 +30,6 @@ describe('GridFormSelectInput', () => {
       expect(textInput.find('select#name').length).toBe(1);
     });
   });
+
+  itHandlesRequiredProps('GridFormSelectInput', 'select');
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/__tests__/GridFormSelectInput-test.tsx
@@ -1,33 +1,22 @@
-import GridFormSelectInput from '../index';
-import { mount } from 'enzyme';
-import React from 'react';
-import { stubSelectField } from '../../../__tests__/stubs';
-import { itHandlesRequiredProps } from '../../TestHelper';
+import {
+  itHandlesRequiredProps,
+  renderGridFormSelectInput,
+} from '../../TestHelper';
 
 describe('GridFormSelectInput', () => {
   describe('when an id is passed as a prop', () => {
     it('renders a select with the same id', () => {
-      const textInput = mount(
-        <GridFormSelectInput
-          field={{ ...stubSelectField, id: 'mycoolid' }}
-          register={jest.fn()}
-        />
-      );
+      const selectInput = renderGridFormSelectInput({ id: 'mycoolid' });
 
-      expect(textInput.find('select#mycoolid').length).toBe(1);
+      expect(selectInput.find('select#mycoolid').length).toBe(1);
     });
   });
 
   describe('when no id is passed', () => {
     it('renders a select with the id equal to the field name', () => {
-      const textInput = mount(
-        <GridFormSelectInput
-          field={{ ...stubSelectField, name: 'name' }}
-          register={jest.fn()}
-        />
-      );
+      const selectInput = renderGridFormSelectInput({ name: 'name' });
 
-      expect(textInput.find('select#name').length).toBe(1);
+      expect(selectInput.find('select#name').length).toBe(1);
     });
   });
 

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
@@ -28,6 +28,7 @@ export const GridFormSelectInput: React.FC<GridFormSelectInputProps> = ({
       ref={register(field.validation)}
       options={field.options}
       id={field.id}
+      required={field.validation && !!field.validation.required}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
@@ -2,6 +2,7 @@ import GridFormTextArea from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
 import { stubTextareaField } from '../../../__tests__/stubs';
+import { itHandlesRequiredProps } from '../../TestHelper';
 
 describe('GridFormTextArea', () => {
   describe('when an id is passed as a prop', () => {
@@ -30,52 +31,5 @@ describe('GridFormTextArea', () => {
     });
   });
 
-  describe('required fields', () => {
-    it('marks a field as required when a required validation boolean is passed', () => {
-      const textarea = mount(
-        <GridFormTextArea
-          field={{ ...stubTextareaField, validation: { required: true } }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textarea.find('textarea').props().required).toBeTruthy();
-    });
-
-    it('marks a field as required when a required message is passed', () => {
-      const textarea = mount(
-        <GridFormTextArea
-          field={{
-            ...stubTextareaField,
-            validation: { required: 'you _MUST_ fill me out' },
-          }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textarea.find('textarea').props().required).toBeTruthy();
-    });
-
-    it('does __not__ mark a field as required when `required: false` is passed', () => {
-      const textarea = mount(
-        <GridFormTextArea
-          field={{ ...stubTextareaField, validation: { required: false } }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textarea.find('textarea').props().required).toBeFalsy();
-    });
-
-    it('does __not__ mark a field as required when required is not passed', () => {
-      const textarea = mount(
-        <GridFormTextArea
-          field={{ ...stubTextareaField }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textarea.find('textarea').props().required).toBeFalsy();
-    });
-  });
+  itHandlesRequiredProps('GridFormTextArea', 'textarea');
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
@@ -29,4 +29,53 @@ describe('GridFormTextArea', () => {
       expect(textarea.find('textarea#name').length).toBe(1);
     });
   });
+
+  describe('required fields', () => {
+    it('marks a field as required when a required validation boolean is passed', () => {
+      const textInput = mount(
+        <GridFormTextArea
+          field={{ ...stubTextareaField, validation: { required: true } }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('textarea').props().required).toBeTruthy();
+    });
+
+    it('marks a field as required when a required message is passed', () => {
+      const textInput = mount(
+        <GridFormTextArea
+          field={{
+            ...stubTextareaField,
+            validation: { required: 'you _MUST_ fill me out' },
+          }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('textarea').props().required).toBeTruthy();
+    });
+
+    it('does __not__ mark a field as required when `required: false` is passed', () => {
+      const textInput = mount(
+        <GridFormTextArea
+          field={{ ...stubTextareaField, validation: { required: false } }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('textarea').props().required).toBeFalsy();
+    });
+
+    it('does __not__ mark a field as required when required is not passed', () => {
+      const textInput = mount(
+        <GridFormTextArea
+          field={{ ...stubTextareaField }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('textarea').props().required).toBeFalsy();
+    });
+  });
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
@@ -1,18 +1,12 @@
-import GridFormTextArea from '../index';
-import { mount } from 'enzyme';
-import React from 'react';
-import { stubTextareaField } from '../../../__tests__/stubs';
-import { itHandlesRequiredProps } from '../../TestHelper';
+import {
+  itHandlesRequiredProps,
+  renderGridFormTextArea,
+} from '../../TestHelper';
 
 describe('GridFormTextArea', () => {
   describe('when an id is passed as a prop', () => {
     it('renders an textarea with the same id', () => {
-      const textarea = mount(
-        <GridFormTextArea
-          field={{ ...stubTextareaField, id: 'mycoolid' }}
-          register={jest.fn()}
-        />
-      );
+      const textarea = renderGridFormTextArea({ id: 'mycoolid' });
 
       expect(textarea.find('textarea#mycoolid').length).toBe(1);
     });
@@ -20,12 +14,7 @@ describe('GridFormTextArea', () => {
 
   describe('when no id is passed', () => {
     it('renders a textarea with the id equal to the field name', () => {
-      const textarea = mount(
-        <GridFormTextArea
-          field={{ ...stubTextareaField, name: 'name' }}
-          register={jest.fn()}
-        />
-      );
+      const textarea = renderGridFormTextArea({ name: 'name' });
 
       expect(textarea.find('textarea#name').length).toBe(1);
     });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/__tests__/GridFormTextArea-test.tsx
@@ -32,18 +32,18 @@ describe('GridFormTextArea', () => {
 
   describe('required fields', () => {
     it('marks a field as required when a required validation boolean is passed', () => {
-      const textInput = mount(
+      const textarea = mount(
         <GridFormTextArea
           field={{ ...stubTextareaField, validation: { required: true } }}
           register={jest.fn()}
         />
       );
 
-      expect(textInput.find('textarea').props().required).toBeTruthy();
+      expect(textarea.find('textarea').props().required).toBeTruthy();
     });
 
     it('marks a field as required when a required message is passed', () => {
-      const textInput = mount(
+      const textarea = mount(
         <GridFormTextArea
           field={{
             ...stubTextareaField,
@@ -53,29 +53,29 @@ describe('GridFormTextArea', () => {
         />
       );
 
-      expect(textInput.find('textarea').props().required).toBeTruthy();
+      expect(textarea.find('textarea').props().required).toBeTruthy();
     });
 
     it('does __not__ mark a field as required when `required: false` is passed', () => {
-      const textInput = mount(
+      const textarea = mount(
         <GridFormTextArea
           field={{ ...stubTextareaField, validation: { required: false } }}
           register={jest.fn()}
         />
       );
 
-      expect(textInput.find('textarea').props().required).toBeFalsy();
+      expect(textarea.find('textarea').props().required).toBeFalsy();
     });
 
     it('does __not__ mark a field as required when required is not passed', () => {
-      const textInput = mount(
+      const textarea = mount(
         <GridFormTextArea
           field={{ ...stubTextareaField }}
           register={jest.fn()}
         />
       );
 
-      expect(textInput.find('textarea').props().required).toBeFalsy();
+      expect(textarea.find('textarea').props().required).toBeFalsy();
     });
   });
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/index.tsx
@@ -26,6 +26,7 @@ export const GridFormTextArea: React.FC<GridFormTextAreaProps> = ({
       onChange={(event) => field.onUpdate?.(event.target.value)}
       ref={register(field.validation)}
       id={field.id}
+      required={field.validation && !!field.validation.required}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
@@ -2,6 +2,7 @@ import GridFormTextInput from '../index';
 import { mount } from 'enzyme';
 import React from 'react';
 import { stubTextField } from '../../../__tests__/stubs';
+import { itHandlesRequiredProps } from '../../TestHelper';
 
 describe('GridFormTextInput', () => {
   describe('when an id is passed as a prop', () => {
@@ -30,57 +31,5 @@ describe('GridFormTextInput', () => {
     });
   });
 
-  describe('required fields', () => {
-    it('marks a field as required when a required validation boolean is passed', () => {
-      const textInput = mount(
-        <GridFormTextInput
-          field={{ ...stubTextField, validation: { required: true } }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textInput.find('input').props().required).toBeTruthy();
-    });
-
-    it('marks a field as required when a required message is passed', () => {
-      const textInput = mount(
-        <GridFormTextInput
-          field={{ ...stubTextField, validation: { required: 'Required' } }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textInput.find('input').props().required).toBeTruthy();
-    });
-
-    it('does __not__ mark a field as required when `required: false` is passed', () => {
-      const textInput = mount(
-        <GridFormTextInput
-          field={{ ...stubTextField, validation: { required: false } }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textInput.find('input').props().required).toBeFalsy();
-    });
-
-    it('does __not__ mark a field as required when required is not passed', () => {
-      const textInput = mount(
-        <GridFormTextInput
-          field={{
-            ...stubTextField,
-            validation: {
-              pattern: {
-                value: /[^@]+@[^@]+\.[^@]+/,
-                message: 'Email Invalid',
-              },
-            },
-          }}
-          register={jest.fn()}
-        />
-      );
-
-      expect(textInput.find('input').props().required).toBeFalsy();
-    });
-  });
+  itHandlesRequiredProps('GridFormTextInput', 'input');
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
@@ -1,18 +1,12 @@
-import GridFormTextInput from '../index';
-import { mount } from 'enzyme';
-import React from 'react';
-import { stubTextField } from '../../../__tests__/stubs';
-import { itHandlesRequiredProps } from '../../TestHelper';
+import {
+  itHandlesRequiredProps,
+  renderGridFormTextInput,
+} from '../../TestHelper';
 
 describe('GridFormTextInput', () => {
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const textInput = mount(
-        <GridFormTextInput
-          field={{ ...stubTextField, id: 'mycoolid' }}
-          register={jest.fn()}
-        />
-      );
+      const textInput = renderGridFormTextInput({ id: 'mycoolid' });
 
       expect(textInput.find('input#mycoolid').length).toBe(1);
     });
@@ -20,12 +14,7 @@ describe('GridFormTextInput', () => {
 
   describe('when no id is passed', () => {
     it('renders an input with the id equal to the field name', () => {
-      const textInput = mount(
-        <GridFormTextInput
-          field={{ ...stubTextField, name: 'name' }}
-          register={jest.fn()}
-        />
-      );
+      const textInput = renderGridFormTextInput({ name: 'name' });
 
       expect(textInput.find('input#name').length).toBe(1);
     });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
@@ -29,4 +29,58 @@ describe('GridFormTextInput', () => {
       expect(textInput.find('input#name').length).toBe(1);
     });
   });
+
+  describe('required fields', () => {
+    it('marks a field as required when a required validation boolean is passed', () => {
+      const textInput = mount(
+        <GridFormTextInput
+          field={{ ...stubTextField, validation: { required: true } }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input').props().required).toBeTruthy();
+    });
+
+    it('marks a field as required when a required message is passed', () => {
+      const textInput = mount(
+        <GridFormTextInput
+          field={{ ...stubTextField, validation: { required: 'Required' } }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input').props().required).toBeTruthy();
+    });
+
+    it('does __not__ mark a field as required when `required: false` is passed', () => {
+      const textInput = mount(
+        <GridFormTextInput
+          field={{ ...stubTextField, validation: { required: false } }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input').props().required).toBeFalsy();
+    });
+
+    it('does __not__ mark a field as required when required is not passed', () => {
+      const textInput = mount(
+        <GridFormTextInput
+          field={{
+            ...stubTextField,
+            validation: {
+              pattern: {
+                value: /[^@]+@[^@]+\.[^@]+/,
+                message: 'Email Invalid',
+              },
+            },
+          }}
+          register={jest.fn()}
+        />
+      );
+
+      expect(textInput.find('input').props().required).toBeFalsy();
+    });
+  });
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
@@ -8,7 +8,7 @@ export type GridFormTextInputProps = {
   className?: string;
   error?: boolean;
   field: Omit<GridFormTextField, 'label'>;
-  register?: FormContextValues['register'];
+  register: FormContextValues['register'];
 };
 
 export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
@@ -8,7 +8,7 @@ export type GridFormTextInputProps = {
   className?: string;
   error?: boolean;
   field: Omit<GridFormTextField, 'label'>;
-  register: FormContextValues['register'];
+  register?: FormContextValues['register'];
 };
 
 export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
@@ -28,6 +28,7 @@ export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({
       ref={register(field.validation)}
       type={field.type}
       id={field.id}
+      required={field.validation && !!field.validation.required}
     />
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
@@ -1,13 +1,15 @@
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 import GridFormTextInput from './GridFormTextInput';
 import {
+  stubRadioGroupField,
   stubSelectField,
   stubTextareaField,
   stubTextField,
 } from '../__tests__/stubs';
 import GridFormSelectInput from './GridFormSelectInput';
 import GridFormTextArea from './GridFormTextArea';
+import GridFormRadioGroupInput from './GridFormRadioGroupInput';
 
 export const itHandlesRequiredProps = (
   componentName: string,
@@ -33,17 +35,8 @@ export const isMarkedRequiredWithBoolean = (
   componentName: string,
   inputType: string
 ): void => {
-  let component;
   const requiredTrue = { validation: { required: true } };
-
-  switch (componentName) {
-    case 'GridFormTextInput':
-      component = renderGridFormTextInput(requiredTrue);
-    case 'GridFormSelectInput':
-      component = renderGridFormSelectInput(requiredTrue);
-    case 'GridFormTextArea':
-      component = renderGridFormTextArea(requiredTrue);
-  }
+  const component = getComponent(componentName, requiredTrue);
 
   expect(component.find(inputType).props().required).toBeTruthy();
 };
@@ -52,17 +45,8 @@ export const isMarkedRequiredWithMessage = (
   componentName: string,
   inputType: string
 ): void => {
-  let component;
   const requiredMessage = { validation: { required: 'Required' } };
-
-  switch (componentName) {
-    case 'GridFormTextInput':
-      component = renderGridFormTextInput(requiredMessage);
-    case 'GridFormSelectInput':
-      component = renderGridFormSelectInput(requiredMessage);
-    case 'GridFormTextArea':
-      component = renderGridFormTextArea(requiredMessage);
-  }
+  const component = getComponent(componentName, requiredMessage);
 
   expect(component.find(inputType).props().required).toBeTruthy();
 };
@@ -71,17 +55,8 @@ export const isMarkedNotRequiredWithBoolean = (
   componentName: string,
   inputType: string
 ): void => {
-  let component;
   const requiredFalse = { validation: { required: false } };
-
-  switch (componentName) {
-    case 'GridFormTextInput':
-      component = renderGridFormTextInput(requiredFalse);
-    case 'GridFormSelectInput':
-      component = renderGridFormSelectInput(requiredFalse);
-    case 'GridFormTextArea':
-      component = renderGridFormTextArea(requiredFalse);
-  }
+  const component = getComponent(componentName, requiredFalse);
 
   expect(component.find(inputType).props().required).toBeFalsy();
 };
@@ -90,19 +65,12 @@ export const isMarkedNotRequiredWhenNotPassedRequiredProp = (
   componentName: string,
   inputType: string
 ): void => {
-  let component;
-
-  switch (componentName) {
-    case 'GridFormTextInput':
-      component = renderGridFormTextInput({});
-    case 'GridFormSelectInput':
-      component = renderGridFormSelectInput({});
-    case 'GridFormTextArea':
-      component = renderGridFormTextArea({});
-  }
+  const component = getComponent(componentName, {});
 
   expect(component.find(inputType).props().required).toBeFalsy();
 };
+
+/* === renderers === */
 
 const renderGridFormTextInput = (extraProps: any = {}) => {
   return mount(
@@ -113,7 +81,7 @@ const renderGridFormTextInput = (extraProps: any = {}) => {
   );
 };
 
-const renderGridFormSelectInput = (extraProps: any = {}) => {
+const renderGridFormSelectInput = (extraProps: any = {}): ReactWrapper => {
   return mount(
     <GridFormSelectInput
       field={{ ...stubSelectField, ...extraProps }}
@@ -129,4 +97,31 @@ const renderGridFormTextArea = (extraProps: any = {}) => {
       register={jest.fn()}
     />
   );
+};
+
+const renderGridFormRadioGroupInput = (extraProps: any = {}) => {
+  return mount(
+    <GridFormRadioGroupInput
+      field={{ ...stubRadioGroupField, ...extraProps }}
+      setValue={jest.fn()}
+      register={jest.fn()}
+    />
+  );
+};
+
+const getComponent = (
+  componentName: string,
+  validationProps: any
+): ReactWrapper => {
+  switch (componentName) {
+    case 'GridFormTextInput':
+      return renderGridFormTextInput(validationProps);
+    case 'GridFormSelectInput':
+      return renderGridFormSelectInput(validationProps);
+    case 'GridFormTextArea':
+      return renderGridFormTextArea(validationProps);
+    case 'GridFormRadioGroupInput':
+      return renderGridFormRadioGroupInput(validationProps);
+    default:
+  }
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
@@ -10,64 +10,65 @@ import {
 import GridFormSelectInput from './GridFormSelectInput';
 import GridFormTextArea from './GridFormTextArea';
 import GridFormRadioGroupInput from './GridFormRadioGroupInput';
+import GridFormFileInput from './GridFormFileInput';
 
 export const itHandlesRequiredProps = (
   componentName: string,
-  inputType: string
+  selector: string
 ): void => {
   describe('required fields', () => {
     it('marks a field as required when a required validation boolean is passed', () => {
-      isMarkedRequiredWithBoolean(componentName, inputType);
+      isMarkedRequiredWithBoolean(componentName, selector);
     });
     it('marks a field as required when a required message is passed', () => {
-      isMarkedRequiredWithMessage(componentName, inputType);
+      isMarkedRequiredWithMessage(componentName, selector);
     });
     it('does __not__ mark a field as required when `required: false` is passed', () => {
-      isMarkedNotRequiredWithBoolean(componentName, inputType);
+      isMarkedNotRequiredWithBoolean(componentName, selector);
     });
     it('does __not__ mark a field as required when required is not passed', () => {
-      isMarkedNotRequiredWhenNotPassedRequiredProp(componentName, inputType);
+      isMarkedNotRequiredWhenNotPassedRequiredProp(componentName, selector);
     });
   });
 };
 
 export const isMarkedRequiredWithBoolean = (
   componentName: string,
-  inputType: string
+  selector: string
 ): void => {
   const requiredTrue = { validation: { required: true } };
   const component = getComponent(componentName, requiredTrue);
 
-  expect(component.find(inputType).props().required).toBeTruthy();
+  expect(component.find(selector).props().required).toBeTruthy();
 };
 
 export const isMarkedRequiredWithMessage = (
   componentName: string,
-  inputType: string
+  selector: string
 ): void => {
   const requiredMessage = { validation: { required: 'Required' } };
   const component = getComponent(componentName, requiredMessage);
 
-  expect(component.find(inputType).props().required).toBeTruthy();
+  expect(component.find(selector).props().required).toBeTruthy();
 };
 
 export const isMarkedNotRequiredWithBoolean = (
   componentName: string,
-  inputType: string
+  selector: string
 ): void => {
   const requiredFalse = { validation: { required: false } };
   const component = getComponent(componentName, requiredFalse);
 
-  expect(component.find(inputType).props().required).toBeFalsy();
+  expect(component.find(selector).props().required).toBeFalsy();
 };
 
 export const isMarkedNotRequiredWhenNotPassedRequiredProp = (
   componentName: string,
-  inputType: string
+  selector: string
 ): void => {
   const component = getComponent(componentName, {});
 
-  expect(component.find(inputType).props().required).toBeFalsy();
+  expect(component.find(selector).props().required).toBeFalsy();
 };
 
 /* === renderers === */
@@ -109,6 +110,15 @@ const renderGridFormRadioGroupInput = (extraProps: any = {}) => {
   );
 };
 
+const renderGridFormFileInput = (extraProps: any = {}): ReactWrapper => {
+  return mount(
+    <GridFormFileInput
+      field={{ ...stubSelectField, ...extraProps }}
+      register={jest.fn()}
+    />
+  );
+};
+
 const getComponent = (
   componentName: string,
   validationProps: any
@@ -122,6 +132,9 @@ const getComponent = (
       return renderGridFormTextArea(validationProps);
     case 'GridFormRadioGroupInput':
       return renderGridFormRadioGroupInput(validationProps);
+    case 'GridFormFileInput':
+      return renderGridFormFileInput(validationProps);
     default:
+      return null;
   }
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
@@ -1,0 +1,113 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import GridFormTextInput from './GridFormTextInput';
+import { stubSelectField, stubTextField } from '../__tests__/stubs';
+import GridFormSelectInput from './GridFormSelectInput';
+
+export const itHandlesRequiredProps = (
+  componentName: string,
+  inputType: string
+): void => {
+  describe('required fields', () => {
+    it('marks a field as required when a required validation boolean is passed', () => {
+      isMarkedRequiredWithBoolean(componentName, inputType);
+    });
+    it('marks a field as required when a required message is passed', () => {
+      isMarkedRequiredWithMessage(componentName, inputType);
+    });
+    it('does __not__ mark a field as required when `required: false` is passed', () => {
+      isMarkedNotRequiredWithBoolean(componentName, inputType);
+    });
+    it('does __not__ mark a field as required when required is not passed', () => {
+      isMarkedNotRequiredWhenNotPassedRequiredProp(componentName, inputType);
+    });
+  });
+};
+
+export const isMarkedRequiredWithBoolean = (
+  componentName: string,
+  inputType: string
+): void => {
+  let component;
+
+  switch (componentName) {
+    case 'GridFormTextInput':
+      component = renderGridFormTextInput({ validation: { required: true } });
+    case 'GridFormSelectInput':
+      component = renderGridFormSelectInput({ validation: { required: true } });
+  }
+
+  expect(component.find(inputType).props().required).toBeTruthy();
+};
+
+export const isMarkedRequiredWithMessage = (
+  componentName: string,
+  inputType: string
+): void => {
+  let component;
+
+  switch (componentName) {
+    case 'GridFormTextInput':
+      component = renderGridFormTextInput({
+        validation: { required: 'Required' },
+      });
+    case 'GridFormSelectInput':
+      component = renderGridFormSelectInput({
+        validation: { required: 'Required' },
+      });
+  }
+
+  expect(component.find(inputType).props().required).toBeTruthy();
+};
+
+export const isMarkedNotRequiredWithBoolean = (
+  componentName: string,
+  inputType: string
+): void => {
+  let component;
+
+  switch (componentName) {
+    case 'GridFormTextInput':
+      component = renderGridFormTextInput({ validation: { required: false } });
+    case 'GridFormSelectInput':
+      component = renderGridFormSelectInput({
+        validation: { required: false },
+      });
+  }
+
+  expect(component.find(inputType).props().required).toBeFalsy();
+};
+
+export const isMarkedNotRequiredWhenNotPassedRequiredProp = (
+  componentName: string,
+  inputType: string
+): void => {
+  let component;
+
+  switch (componentName) {
+    case 'GridFormTextInput':
+      component = renderGridFormTextInput({});
+    case 'GridFormSelectInput':
+      component = renderGridFormSelectInput({});
+  }
+
+  expect(component.find(inputType).props().required).toBeFalsy();
+};
+
+const renderGridFormTextInput = (extraProps: any = {}) => {
+  return mount(
+    <GridFormTextInput
+      field={{ ...stubTextField, ...extraProps }}
+      register={jest.fn()}
+    />
+  );
+};
+
+const renderGridFormSelectInput = (extraProps: any = {}) => {
+  return mount(
+    <GridFormSelectInput
+      field={{ ...stubSelectField, ...extraProps }}
+      register={jest.fn()}
+    />
+  );
+};

--- a/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
@@ -1,8 +1,13 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import GridFormTextInput from './GridFormTextInput';
-import { stubSelectField, stubTextField } from '../__tests__/stubs';
+import {
+  stubSelectField,
+  stubTextareaField,
+  stubTextField,
+} from '../__tests__/stubs';
 import GridFormSelectInput from './GridFormSelectInput';
+import GridFormTextArea from './GridFormTextArea';
 
 export const itHandlesRequiredProps = (
   componentName: string,
@@ -29,12 +34,15 @@ export const isMarkedRequiredWithBoolean = (
   inputType: string
 ): void => {
   let component;
+  const requiredTrue = { validation: { required: true } };
 
   switch (componentName) {
     case 'GridFormTextInput':
-      component = renderGridFormTextInput({ validation: { required: true } });
+      component = renderGridFormTextInput(requiredTrue);
     case 'GridFormSelectInput':
-      component = renderGridFormSelectInput({ validation: { required: true } });
+      component = renderGridFormSelectInput(requiredTrue);
+    case 'GridFormTextArea':
+      component = renderGridFormTextArea(requiredTrue);
   }
 
   expect(component.find(inputType).props().required).toBeTruthy();
@@ -45,16 +53,15 @@ export const isMarkedRequiredWithMessage = (
   inputType: string
 ): void => {
   let component;
+  const requiredMessage = { validation: { required: 'Required' } };
 
   switch (componentName) {
     case 'GridFormTextInput':
-      component = renderGridFormTextInput({
-        validation: { required: 'Required' },
-      });
+      component = renderGridFormTextInput(requiredMessage);
     case 'GridFormSelectInput':
-      component = renderGridFormSelectInput({
-        validation: { required: 'Required' },
-      });
+      component = renderGridFormSelectInput(requiredMessage);
+    case 'GridFormTextArea':
+      component = renderGridFormTextArea(requiredMessage);
   }
 
   expect(component.find(inputType).props().required).toBeTruthy();
@@ -65,14 +72,15 @@ export const isMarkedNotRequiredWithBoolean = (
   inputType: string
 ): void => {
   let component;
+  const requiredFalse = { validation: { required: false } };
 
   switch (componentName) {
     case 'GridFormTextInput':
-      component = renderGridFormTextInput({ validation: { required: false } });
+      component = renderGridFormTextInput(requiredFalse);
     case 'GridFormSelectInput':
-      component = renderGridFormSelectInput({
-        validation: { required: false },
-      });
+      component = renderGridFormSelectInput(requiredFalse);
+    case 'GridFormTextArea':
+      component = renderGridFormTextArea(requiredFalse);
   }
 
   expect(component.find(inputType).props().required).toBeFalsy();
@@ -89,6 +97,8 @@ export const isMarkedNotRequiredWhenNotPassedRequiredProp = (
       component = renderGridFormTextInput({});
     case 'GridFormSelectInput':
       component = renderGridFormSelectInput({});
+    case 'GridFormTextArea':
+      component = renderGridFormTextArea({});
   }
 
   expect(component.find(inputType).props().required).toBeFalsy();
@@ -107,6 +117,15 @@ const renderGridFormSelectInput = (extraProps: any = {}) => {
   return mount(
     <GridFormSelectInput
       field={{ ...stubSelectField, ...extraProps }}
+      register={jest.fn()}
+    />
+  );
+};
+
+const renderGridFormTextArea = (extraProps: any = {}) => {
+  return mount(
+    <GridFormTextArea
+      field={{ ...stubTextareaField, ...extraProps }}
       register={jest.fn()}
     />
   );

--- a/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
@@ -2,6 +2,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 import GridFormTextInput from './GridFormTextInput';
 import {
+  stubCheckboxField,
   stubRadioGroupField,
   stubSelectField,
   stubTextareaField,
@@ -11,6 +12,7 @@ import GridFormSelectInput from './GridFormSelectInput';
 import GridFormTextArea from './GridFormTextArea';
 import GridFormRadioGroupInput from './GridFormRadioGroupInput';
 import GridFormFileInput from './GridFormFileInput';
+import GridFormCheckboxInput from './GridFormCheckboxInput';
 
 export const itHandlesRequiredProps = (
   componentName: string,
@@ -119,6 +121,15 @@ const renderGridFormFileInput = (extraProps: any = {}): ReactWrapper => {
   );
 };
 
+const renderGridFormCheckboxInput = (extraProps: any = {}): ReactWrapper => {
+  return mount(
+    <GridFormCheckboxInput
+      field={{ ...stubCheckboxField, ...extraProps }}
+      register={jest.fn()}
+    />
+  );
+};
+
 const getComponent = (
   componentName: string,
   validationProps: any
@@ -134,6 +145,8 @@ const getComponent = (
       return renderGridFormRadioGroupInput(validationProps);
     case 'GridFormFileInput':
       return renderGridFormFileInput(validationProps);
+    case 'GridFormCheckboxInput':
+      return renderGridFormCheckboxInput(validationProps);
     default:
       return null;
   }

--- a/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
@@ -41,7 +41,7 @@ export const isMarkedRequiredWithBoolean = (
   const requiredTrue = { validation: { required: true } };
   const component = getComponent(componentName, requiredTrue);
 
-  expect(component.find(selector).props().required).toBeTruthy();
+  expect(component.find(selector).html()).toContain('required');
 };
 
 export const isMarkedRequiredWithMessage = (
@@ -51,7 +51,7 @@ export const isMarkedRequiredWithMessage = (
   const requiredMessage = { validation: { required: 'Required' } };
   const component = getComponent(componentName, requiredMessage);
 
-  expect(component.find(selector).props().required).toBeTruthy();
+  expect(component.find(selector).html()).toContain('required');
 };
 
 export const isMarkedNotRequiredWithBoolean = (
@@ -61,7 +61,7 @@ export const isMarkedNotRequiredWithBoolean = (
   const requiredFalse = { validation: { required: false } };
   const component = getComponent(componentName, requiredFalse);
 
-  expect(component.find(selector).props().required).toBeFalsy();
+  expect(component.find(selector).html()).not.toContain('required');
 };
 
 export const isMarkedNotRequiredWhenNotPassedRequiredProp = (
@@ -70,7 +70,7 @@ export const isMarkedNotRequiredWhenNotPassedRequiredProp = (
 ): void => {
   const component = getComponent(componentName, {});
 
-  expect(component.find(selector).props().required).toBeFalsy();
+  expect(component.find(selector).html()).not.toContain('required');
 };
 
 /* === renderers === */

--- a/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/TestHelper.tsx
@@ -75,7 +75,7 @@ export const isMarkedNotRequiredWhenNotPassedRequiredProp = (
 
 /* === renderers === */
 
-const renderGridFormTextInput = (extraProps: any = {}) => {
+export const renderGridFormTextInput = (extraProps: any = {}) => {
   return mount(
     <GridFormTextInput
       field={{ ...stubTextField, ...extraProps }}
@@ -84,7 +84,9 @@ const renderGridFormTextInput = (extraProps: any = {}) => {
   );
 };
 
-const renderGridFormSelectInput = (extraProps: any = {}): ReactWrapper => {
+export const renderGridFormSelectInput = (
+  extraProps: any = {}
+): ReactWrapper => {
   return mount(
     <GridFormSelectInput
       field={{ ...stubSelectField, ...extraProps }}
@@ -93,7 +95,7 @@ const renderGridFormSelectInput = (extraProps: any = {}): ReactWrapper => {
   );
 };
 
-const renderGridFormTextArea = (extraProps: any = {}) => {
+export const renderGridFormTextArea = (extraProps: any = {}) => {
   return mount(
     <GridFormTextArea
       field={{ ...stubTextareaField, ...extraProps }}
@@ -102,7 +104,7 @@ const renderGridFormTextArea = (extraProps: any = {}) => {
   );
 };
 
-const renderGridFormRadioGroupInput = (extraProps: any = {}) => {
+export const renderGridFormRadioGroupInput = (extraProps: any = {}) => {
   return mount(
     <GridFormRadioGroupInput
       field={{ ...stubRadioGroupField, ...extraProps }}
@@ -112,7 +114,7 @@ const renderGridFormRadioGroupInput = (extraProps: any = {}) => {
   );
 };
 
-const renderGridFormFileInput = (extraProps: any = {}): ReactWrapper => {
+export const renderGridFormFileInput = (extraProps: any = {}): ReactWrapper => {
   return mount(
     <GridFormFileInput
       field={{ ...stubSelectField, ...extraProps }}
@@ -121,7 +123,9 @@ const renderGridFormFileInput = (extraProps: any = {}): ReactWrapper => {
   );
 };
 
-const renderGridFormCheckboxInput = (extraProps: any = {}): ReactWrapper => {
+export const renderGridFormCheckboxInput = (
+  extraProps: any = {}
+): ReactWrapper => {
   return mount(
     <GridFormCheckboxInput
       field={{ ...stubCheckboxField, ...extraProps }}
@@ -130,23 +134,20 @@ const renderGridFormCheckboxInput = (extraProps: any = {}): ReactWrapper => {
   );
 };
 
-const getComponent = (
-  componentName: string,
-  validationProps: any
-): ReactWrapper => {
+const getComponent = (componentName: string, extraProps: any): ReactWrapper => {
   switch (componentName) {
     case 'GridFormTextInput':
-      return renderGridFormTextInput(validationProps);
+      return renderGridFormTextInput(extraProps);
     case 'GridFormSelectInput':
-      return renderGridFormSelectInput(validationProps);
+      return renderGridFormSelectInput(extraProps);
     case 'GridFormTextArea':
-      return renderGridFormTextArea(validationProps);
+      return renderGridFormTextArea(extraProps);
     case 'GridFormRadioGroupInput':
-      return renderGridFormRadioGroupInput(validationProps);
+      return renderGridFormRadioGroupInput(extraProps);
     case 'GridFormFileInput':
-      return renderGridFormFileInput(validationProps);
+      return renderGridFormFileInput(extraProps);
     case 'GridFormCheckboxInput':
-      return renderGridFormCheckboxInput(validationProps);
+      return renderGridFormCheckboxInput(extraProps);
     default:
       return null;
   }


### PR DESCRIPTION
## Overview
Darkens red error colour to be accessible on a white background. Passes the 'required' html attribute to input elements, so they can be rendered as such. 

### PR Checklist

- [x] Related to JIRA ticket: EN-117, EN-121
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
