### PR TITLE
ci: make changelog generation more explicit [WEB-939]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
     working_directory: ~/repo
     environment:
       GITHUB_BOT_USERNAME: codecademydev
-      NODE_OPTIONS: '--max_old_space_size=4096'
+      NODE_OPTIONS: "--max_old_space_size=4096"
       CIRCLE_TEST_REPORTS: /tmp/test-results
 
   repo_cache_key_1: &repo_cache_key_1 v1-repo-{{ arch}}-{{ .Branch }}-{{ .Revision }}
@@ -73,7 +73,7 @@ references:
   add_github_ssh_key: &add_github_ssh_key
     add_ssh_keys:
       fingerprints:
-        - 'c9:c4:75:c4:3e:f9:1f:09:1e:bd:95:da:2d:79:2f:f7'
+        - "c9:c4:75:c4:3e:f9:1f:09:1e:bd:95:da:2d:79:2f:f7"
 
 jobs:
   checkout_code:
@@ -148,8 +148,25 @@ jobs:
       - checkout
       - *set_npm_token
       - run:
-          name: lerna publish
-          command: yarn lerna publish --yes --conventional-commits --changelog-preset conventionalcommits --include-merged-tags --create-release=github
+          name: Lerna Publish
+          command: yarn lerna publish --yes --conventional-commits --changelog-preset conventionalcommits --no-changelog --include-merged-tags --create-release=github
+
+  update_changelogs:
+    <<: *default_env
+    steps:
+      - *add_github_ssh_key
+      - *set_git_user
+      - *restore_repo
+      - checkout
+      - run:
+          name: Update Changelogs
+          command: |
+            yarn lerna regenerate-changelog
+            if [ -n "$(git status --porcelain)" ]; then
+              git add -A
+              git commit -am "chore: update changelogs"
+              git push
+            fi
 
   deploy:
     <<: *default_env
@@ -277,6 +294,12 @@ workflows:
       - publish:
           requires:
             - checkout_code
+          filters:
+            branches:
+              only: master
+      - update_changelogs:
+          requires:
+            - publish
           filters:
             branches:
               only: master

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
   "lint-staged": {
     "**/*.{mdx,js,ts,tsx,json,css,scss}": [
       "prettier --ignore-path .prettierignore --write"
-    ],
-    "**/CHANGELOG.md": [
-      "yarn regenerate-changelog"
     ]
   },
   "repository": {


### PR DESCRIPTION
## Overview

1. removes changelog generation from `lerna publish`
2. adds a separate changelog generation task after publish in CircleCI

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: [WEB-939]
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

---

## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
