### PR TITLE
feat(Accordion): Accordion alignment: 'large' size; no outline in plain

### DIFF
--- a/packages/gamut/src/Accordion/__tests__/Accordion-test.tsx
+++ b/packages/gamut/src/Accordion/__tests__/Accordion-test.tsx
@@ -62,7 +62,7 @@ describe('Accordion', () => {
     });
 
     expect(wrapper.text()).toEqual(
-      `header-${true}Chevron Down Iconchildren-${true}`
+      `header-${true}Arrow Chevron Down Iconchildren-${true}`
     );
   });
 });

--- a/packages/gamut/src/Accordion/index.tsx
+++ b/packages/gamut/src/Accordion/index.tsx
@@ -23,7 +23,9 @@ export type AccordionProps = {
   /**
    * Called when the header is activated to toggle whether the accordion is expanded.
    */
-  onChange: (expanded: boolean) => void;
+  onChange?: (expanded: boolean) => void;
+
+  size?: 'normal' | 'large';
 
   /**
    * Visual theme for the clickable header button.
@@ -44,6 +46,7 @@ export const Accordion: React.FC<AccordionProps> = ({
   header,
   initiallyExpanded,
   onChange,
+  size = 'normal',
   theme,
 }) => {
   const [expanded, setExpanded] = useState(initiallyExpanded);
@@ -60,12 +63,17 @@ export const Accordion: React.FC<AccordionProps> = ({
 
   const onClick = () => {
     setExpanded(!expanded);
-    onChange(!expanded);
+    onChange?.(!expanded);
   };
 
   return (
     <div className={className}>
-      <AccordionButton expanded={expanded} onClick={onClick} theme={theme}>
+      <AccordionButton
+        expanded={expanded}
+        onClick={onClick}
+        size={size}
+        theme={theme}
+      >
         {header instanceof Function ? header(expanded) : header}
       </AccordionButton>
       <motion.div

--- a/packages/gamut/src/AccordionButton/index.tsx
+++ b/packages/gamut/src/AccordionButton/index.tsx
@@ -10,6 +10,7 @@ export type AccordionButtonProps = {
   className?: string;
   expanded?: boolean;
   onClick: () => void;
+  size?: 'normal' | 'large';
   theme: 'blue' | 'plain' | 'yellow';
 };
 
@@ -25,7 +26,6 @@ const buttonThemes = {
     component: Button,
     props: {
       flat: true,
-      outline: true,
       theme: 'brand-dark-blue',
     },
   },
@@ -40,23 +40,33 @@ export const AccordionButton: React.FC<AccordionButtonProps> = ({
   className,
   expanded,
   onClick,
+  size,
   theme,
 }) => {
   const { component: ButtonComponent, props } = buttonThemes[theme];
+  const iconSize = size === 'large' ? 30 : undefined;
 
   return (
     <ButtonComponent
       aria-expanded={expanded}
-      className={cx(styles.accordionButton, styles[theme], className)}
+      className={cx(
+        styles.accordionButton,
+        styles[theme],
+        styles[size],
+        className
+      )}
       onClick={onClick}
+      flat
       {...props}
     >
-      {children}
+      <span className={styles.children}>{children}</span>
       <ChevronDownIcon
         className={cx(
           styles.expansionIcon,
           expanded && styles.expansionIconExpanded
         )}
+        height={iconSize}
+        width={iconSize}
       />
     </ButtonComponent>
   );

--- a/packages/gamut/src/AccordionButton/index.tsx
+++ b/packages/gamut/src/AccordionButton/index.tsx
@@ -1,8 +1,8 @@
+import { ArrowChevronDownIcon } from '@codecademy/gamut-icons';
 import cx from 'classnames';
 import React from 'react';
 
 import Button from '../Button';
-import ChevronDownIcon from '../Icon/icons/ChevronDownIcon';
 import styles from './styles.module.scss';
 import ButtonBase from '../ButtonBase';
 
@@ -44,7 +44,6 @@ export const AccordionButton: React.FC<AccordionButtonProps> = ({
   theme,
 }) => {
   const { component: ButtonComponent, props } = buttonThemes[theme];
-  const iconSize = size === 'large' ? 30 : undefined;
 
   return (
     <ButtonComponent
@@ -60,13 +59,12 @@ export const AccordionButton: React.FC<AccordionButtonProps> = ({
       {...props}
     >
       <span className={styles.children}>{children}</span>
-      <ChevronDownIcon
+      <ArrowChevronDownIcon
         className={cx(
           styles.expansionIcon,
           expanded && styles.expansionIconExpanded
         )}
-        height={iconSize}
-        width={iconSize}
+        size={size === 'large' ? 30 : undefined}
       />
     </ButtonComponent>
   );

--- a/packages/gamut/src/AccordionButton/styles.module.scss
+++ b/packages/gamut/src/AccordionButton/styles.module.scss
@@ -48,6 +48,7 @@
 }
 
 .expansionIcon {
+  margin-left: 0.75rem;
   transition: transform 0.35s ease-out;
 }
 

--- a/packages/gamut/src/AccordionButton/styles.module.scss
+++ b/packages/gamut/src/AccordionButton/styles.module.scss
@@ -27,6 +27,24 @@
       background-color: $color-yellow-300;
     }
   }
+
+  &.large {
+    border-radius: 2px;
+    font-size: 1.5rem;
+    font-family: $font-family-headings;
+
+    .children {
+      padding-top: 0.2rem;
+    }
+
+    .expansionIcon {
+      margin-left: 1rem;
+    }
+
+    @include md-viewport {
+      font-size: 1.75rem;
+    }
+  }
 }
 
 .expansionIcon {

--- a/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
@@ -25,7 +25,8 @@ conditionally rendered based on whether the accordion is expanded.
     <Accordion
       header="Click to Toggle Me!"
       onChange={action('Changed')}
-      theme={select('Theme', ['blue', 'plain', 'yellow'], 'yellow')}
+      size={select('Size', ['normal', 'large'], 'normal')}
+      theme={select('Theme', ['blue', 'plain', 'yellow'], 'plain')}
     >
       Wow, hidden treasure!
     </Accordion>
@@ -36,6 +37,9 @@ conditionally rendered based on whether the accordion is expanded.
 
 > Note that accordions will fit to `100%` of the the height of their parent container.
 > If you need a fixed height container, wrap the accordion in a `<div>`.
+
+Accordions can be used for a variety of content, including big flashy subsections.
+Pass the `size` prop as `large` to create a bigger accordion.
 
 An `AccordionButton` component also exists if you just want the controlled heading behavior.
 We'll likely remove it soon, as all consumers are meant to switch to `Accordion`.


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to Abstract designs:~
- [x] Related to JIRA ticket: WEB-908
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

A few scattered additions / improvements to `<Accordion>`:
* We don't use the `"plain"` theme yet anywhere in the monolith, but its primary consumer in [/about/careers](https://codecademy.com/about/careers) doesn't set `outline`. Removed it here.
    * Added font size adjustments to match what's in the careers page too...
* Added a `size` prop that defaults to `"normal"` but can be set to `"large"` to make the thing increase font and icon size.
    * Large accordions use the heading font with different line-height than body - hence the `padding-top`...
* Marked `onChange` as optional, since it is.
