### PR TITLE
feat(Styleguide): Simplify indicator story status pills

### DIFF
--- a/packages/styleguide/Blocks/StoryStatus.tsx
+++ b/packages/styleguide/Blocks/StoryStatus.tsx
@@ -3,9 +3,9 @@ import { styled } from '@storybook/theming';
 import { colors } from '@codecademy/gamut-styles/utils/variables';
 
 const STATUS_COLORS = {
-  stable: colors.green[500],
-  volatile: colors.yellow[500],
-  deprecated: colors.red[500],
+  stable: colors.green[800],
+  volatile: colors.yellow[700],
+  deprecated: colors.red[700],
 };
 
 const StatusWrapper = styled.div`

--- a/packages/styleguide/Blocks/StoryStatus.tsx
+++ b/packages/styleguide/Blocks/StoryStatus.tsx
@@ -2,54 +2,28 @@ import React from 'react';
 import { styled } from '@storybook/theming';
 import { colors } from '@codecademy/gamut-styles/utils/variables';
 
-const Statuses = {
-  ready: { message: 'Production Ready', color: colors.green[500] },
-  inProgress: { message: 'Use with Caution (WIP)', color: colors.yellow[500] },
-  deprecated: { message: 'Do not use (Deprecated)', color: colors.red[500] },
+const STATUS_COLORS = {
+  stable: colors.green[500],
+  volatile: colors.yellow[500],
+  deprecated: colors.red[500],
 };
 
 const StatusWrapper = styled.div`
-  margin: 1rem 0;
-  font-size: 1.4rem;
-  display: grid;
-  grid-template-columns: max-content max-content 1fr;
-  grid-gap: 0.5rem;
+  display: inline-flex;
   align-items: center;
-`;
-
-const StatusIndicator = styled.div<{ color: string }>`
-  display: inline-block;
-  position: relative;
-  font-size: 1.2rem;
-  font-weight: 400;
-  width: 1rem;
-  height: 1rem;
-  border-radius: 50%;
-  margin-top: 0.2rem;
+  padding: 0 0.75rem;
+  height: 1.75rem;
+  margin: 1rem 0;
+  font-size: 0.8rem;
+  font-weight: 900;
+  border-radius: 1rem;
+  text-transform: uppercase;
+  color: ${colors.white};
   background-color: ${({ color }) => color};
-
-  &:focus,
-  &:hover {
-    & + * {
-      opacity: 1;
-    }
-  }
 `;
 
-const StatusMessage = styled.div`
-  opacity: 0;
-  transition: 0.25s opacity;
-  font-size: 1rem;
-`;
-
-export const StoryStatus: React.FC<{ status: keyof typeof Statuses }> = ({
+export const StoryStatus: React.FC<{ status: keyof typeof STATUS_COLORS }> = ({
   status,
 }) => {
-  const { message, color } = Statuses[status];
-  return (
-    <StatusWrapper>
-      Usage - <StatusIndicator color={color} />
-      <StatusMessage>{message}</StatusMessage>
-    </StatusWrapper>
-  );
+  return <StatusWrapper color={STATUS_COLORS[status]}>{status}</StatusWrapper>;
 };

--- a/packages/styleguide/stories/Core/Atoms/Badge.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Badge.stories.mdx
@@ -7,7 +7,7 @@ import { StoryStatus } from '~styleguide/blocks';
 
 # Badges
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Small blue indicator of some unusual text
 

--- a/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
@@ -23,7 +23,7 @@ import {
 
 # Buttons
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Primary versions of buttons and links. Approximately all focusable,
 interactive elements should use some form of a `Button` (if

--- a/packages/styleguide/stories/Core/Atoms/FormDecorations.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/FormDecorations.stories.mdx
@@ -9,7 +9,7 @@ import { FormGroupDescription, FormGroupLabel } from '@codecademy/gamut/src';
 
 # Form Decorations
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Ancillary descriptions for input atoms tied 1:1 with values to
 be submitted in a form.

--- a/packages/styleguide/stories/Core/Atoms/FormInputs/FormInputs.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/FormInputs/FormInputs.stories.mdx
@@ -22,7 +22,7 @@ import {
 
 # Form Inputs
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Input atoms tied 1:1 with values to be submitted in a form.
 

--- a/packages/styleguide/stories/Core/Atoms/HighlightedText.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/HighlightedText.stories.mdx
@@ -7,7 +7,7 @@ import { text } from '@storybook/addon-knobs';
 
 # HighlightedText
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Emphasized (bold) text with a light background color behind it. Use to
 showcase important words in a sentence.

--- a/packages/styleguide/stories/Core/Atoms/Icons/Icons.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Icons/Icons.stories.mdx
@@ -18,7 +18,7 @@ import { selectableColors } from '../../../../helpers';
 
 # Icons
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 <Preview>
   <Story name="Editable Icon">

--- a/packages/styleguide/stories/Core/Atoms/InputStepper.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/InputStepper.stories.mdx
@@ -8,7 +8,7 @@ import { useState } from '@storybook/addons';
 
 # Input Stepper
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Input Steppers allow for finetuned control over numeric values. They
 override the default styles for numeric inputs.

--- a/packages/styleguide/stories/Core/Atoms/Markdown/Markdown.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Markdown/Markdown.stories.mdx
@@ -13,7 +13,7 @@ import { customText } from './helpers';
 
 # Markdown
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Markdown renderer for all your markdown needs.
 

--- a/packages/styleguide/stories/Core/Atoms/Overlay.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Overlay.stories.mdx
@@ -8,7 +8,7 @@ import { useState } from '@storybook/addons';
 
 # Overlay
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Overlay primitives are controlled components that are told whether
 they're open by their parent. They're very basic and

--- a/packages/styleguide/stories/Core/Atoms/ProgressBar/ProgressBar.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/ProgressBar/ProgressBar.stories.mdx
@@ -9,7 +9,7 @@ import { bars } from './constants';
 
 # ProgressBar
 
-<StoryStatus status="inProgress" />
+<StoryStatus status="volatile" />
 
 ProgressBars are to be used when you would like to indicate a known or
 somewhat-known amount of progress along a fixed course. For example, you

--- a/packages/styleguide/stories/Core/Atoms/RadialProgress.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/RadialProgress.stories.mdx
@@ -14,7 +14,7 @@ import { selectableColors } from '../../../helpers';
 
 # Radial Progress
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 A circular display of progress without a number inside, meant to convey a
 percentage out of a whole.

--- a/packages/styleguide/stories/Core/Atoms/SkipToContent.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/SkipToContent.stories.mdx
@@ -7,7 +7,7 @@ import { SkipToContent } from '@codecademy/gamut/src';
 
 # SkipToContent
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 A hidden-by-default link that becomes visible when the user ~Tab~
 s over it (gives it focus). This type of control is necessary for pages

--- a/packages/styleguide/stories/Core/Atoms/Spinner.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Spinner.stories.mdx
@@ -7,7 +7,7 @@ import { Spinner } from '@codecademy/gamut/src';
 
 # Spinner
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Perpetually spinning circle, such as for a loading indicator. Similar to a
 `ProgressBar`.

--- a/packages/styleguide/stories/Core/Atoms/Toggle.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Toggle.stories.mdx
@@ -8,7 +8,7 @@ import { Toggle } from '@codecademy/gamut/src';
 
 # Toggle
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Controlled atom component indicating a user-selectable boolean value.
 Receives its `checked` prop from its parent.

--- a/packages/styleguide/stories/Core/Atoms/ToolTip.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/ToolTip.stories.mdx
@@ -12,7 +12,7 @@ import { Icon, ToolTip, ToolTipPosition } from '@codecademy/gamut/src';
 
 # ToolTip
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Small piece of extra information triggered on the focus or hover of a button or icon,
 such as extra requirements for a form surfaced from an informative (i) icon. They

--- a/packages/styleguide/stories/Core/Foundations/Colors/Colors.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Colors/Colors.stories.mdx
@@ -30,7 +30,7 @@ import { excludedColors, baseColors } from './constants';
 
 # Colors
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 These are the color palettes used by both design and engineering.
 

--- a/packages/styleguide/stories/Core/Foundations/Layouts/ContentContainer.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Layouts/ContentContainer.stories.mdx
@@ -9,7 +9,7 @@ import { ContentContainer } from '@codecademy/gamut/src';
 
 # Content Container
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 ContentContainer can used when creating page layouts to contain content
 within a maximum width, as well as centering that content and providing

--- a/packages/styleguide/stories/Core/Foundations/Layouts/FlexContainer.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Layouts/FlexContainer.stories.mdx
@@ -12,7 +12,7 @@ import { select, boolean, number } from '@storybook/addon-knobs';
 
 # Container
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 A flex box primitive that allows you create markup configurable flex containers
 

--- a/packages/styleguide/stories/Core/Foundations/Layouts/FlexGrid.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Layouts/FlexGrid.stories.mdx
@@ -11,7 +11,7 @@ import { Box, defaultGridProps } from './Elements';
 
 # FlexGrid
 
-<StoryStatus status="inProgress" />
+<StoryStatus status="volatile" />
 
 The grid layout is composed of rows of columns. A row is 12 units wide. A
 column specifies its width in units at various breakpoints via props: xs

--- a/packages/styleguide/stories/Core/Foundations/Layouts/LayoutGrid.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Layouts/LayoutGrid.stories.mdx
@@ -12,6 +12,8 @@ import { withKnobs, select } from '@storybook/addon-knobs';
 
 # LayoutGrid
 
+<StoryStatus status="stable" />
+
 A flexible grid that can support arbitrary rows of content, each of
 which snaps to assuming 12 "units" of width. Cells in the rows are
 stored as `Column`s that have a grid-specified gap

--- a/packages/styleguide/stories/Core/Foundations/Typography/Typography.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Typography/Typography.stories.mdx
@@ -19,7 +19,7 @@ import { colors } from '@codecademy/gamut-styles/utils/variables';
 
 # 📝 Typography
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Responsive Typography primitives for all your textual needs.
 

--- a/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
@@ -12,7 +12,7 @@ import { boolean, select } from '@storybook/addon-knobs';
 
 # Accordion
 
-<StoryStatus status="inProgress" />
+<StoryStatus status="volatile" />
 
 A molecule consisting of a clickable header that animates show or hide its children,
 such as a "hint" section in the LE or a list of department jobs on a careers page.

--- a/packages/styleguide/stories/Core/Molecules/Alert.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Alert.stories.mdx
@@ -7,7 +7,7 @@ import { Alert, BannerType } from '@codecademy/gamut/src';
 
 # Alert
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Alerts can be used to asynchronously display feedback or interactions
 with the user with various connotations.

--- a/packages/styleguide/stories/Core/Molecules/AppBar.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/AppBar.stories.mdx
@@ -11,6 +11,8 @@ import { AppBar, AppBarSection } from '@codecademy/gamut/src';
 
 # AppBar
 
+<StoryStatus status="volatile" />
+
 This is an example of an AppBar component that contains one left-oriented
 AppBarSection that holds one AppBar Tab. These components mostly provide
 spacing and layout help that you can use for something like a footer or

--- a/packages/styleguide/stories/Core/Molecules/Banner.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Banner.stories.mdx
@@ -9,7 +9,7 @@ import { StoryStatus } from '~styleguide/blocks';
 
 # Banner
 
-<StoryStatus status="inProgress" />
+<StoryStatus status="volatile" />
 
 Full-width banner to indicate important messaging at the top of a page or section.
 

--- a/packages/styleguide/stories/Core/Molecules/Card.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Card.stories.mdx
@@ -17,7 +17,7 @@ import { StoryStatus } from '~styleguide/blocks';
 
 # Card
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Default shell with white background that can include some subtly
 emphasized content.

--- a/packages/styleguide/stories/Core/Molecules/Interstitial.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Interstitial.stories.mdx
@@ -7,7 +7,7 @@ import { Truncate } from '@codecademy/gamut/src';
 
 # Interstitial
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Large content area used as a break between focused content, such as within
 a full-screen <code>Overlay</code> in the LE between lessons.

--- a/packages/styleguide/stories/Core/Molecules/Modal.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Modal.stories.mdx
@@ -11,6 +11,8 @@ import { Button, Modal, Text, Overlay } from '@codecademy/gamut/src';
 
 # Modal
 
+<StoryStatus status="stable" />
+
 Simple Modal portal to escape current DOM Context.
 
 <Preview>

--- a/packages/styleguide/stories/Core/Molecules/NotificationList.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/NotificationList.stories.mdx
@@ -14,7 +14,7 @@ import { StoryStatus } from '~styleguide/blocks';
 
 # NotificationList
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 List of time-sensitive user notifications, such as in a top-right dropdown
 menu from a header.

--- a/packages/styleguide/stories/Core/Molecules/SplitInterstitial/SplitInterstitial.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/SplitInterstitial/SplitInterstitial.stories.mdx
@@ -8,7 +8,7 @@ import Stairs from './assets/Stairs.svg';
 
 # SplitInterstitial
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Large, 50% split content area used for information that has two facets,
 such as for a payment page with an advertisement on one side and payment

--- a/packages/styleguide/stories/Core/Molecules/Tabs/Tabs.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Tabs/Tabs.stories.mdx
@@ -13,7 +13,7 @@ import { Controlled, Uncontrolled } from './Examples';
 
 # Tabs
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Use a series of tabbed areas for when you have multiple potential sections
 to show, but only one should be visible at a time.

--- a/packages/styleguide/stories/Core/Molecules/Truncate.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Truncate.stories.mdx
@@ -8,7 +8,7 @@ import { Truncate, Text } from '@codecademy/gamut/src';
 
 # Truncate
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Truncates can be used to asynchronously display feedback or interactions
 with the user with various connotations.

--- a/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Video.stories.mdx
@@ -1,9 +1,12 @@
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/dist/blocks';
 import { Video } from '@codecademy/gamut/src';
+import { StoryStatus } from '~styleguide/blocks';
 
 <Meta title="Core/Molecules/Video" component={Video} />
 
 # Video
+
+<StoryStatus status="stable" />
 
 This is an example video player that can play both youtube and vimeo videos
 given a video URL

--- a/packages/styleguide/stories/Core/Organisms/GridForm.stories.mdx
+++ b/packages/styleguide/stories/Core/Organisms/GridForm.stories.mdx
@@ -10,7 +10,7 @@ import { useState } from '@storybook/addons';
 
 # GridForm
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 This organism takes in plain JSON-like props and uses them to string
 together a validated form composed of:

--- a/packages/styleguide/stories/Labs/Brand/Atoms/Avatar.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/Avatar.stories.mdx
@@ -8,7 +8,7 @@ import { Avatar } from '@codecademy/gamut-labs/src';
 
 # Avatar
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Small, circular profile photo that includes a colored drop shadow.
 Commonly paired with a `Byline`.with the user with various connotations.

--- a/packages/styleguide/stories/Labs/Brand/Atoms/BrandMonospace/BrandMonospace.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/BrandMonospace/BrandMonospace.stories.mdx
@@ -11,7 +11,7 @@ import styles from './styles.module.scss';
 
 # BrandMonospace
 
-<StoryStatus status="inProgress" />
+<StoryStatus status="volatile" />
 
 A wrapper component that will style text with the `Robot Mono`
 font. Currently, Codecademy uses `Monaco` as our default monospaced

--- a/packages/styleguide/stories/Labs/Brand/Atoms/Loading.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/Loading.stories.mdx
@@ -5,7 +5,7 @@ import { Meta, Preview, Props, Story } from '@storybook/addon-docs/dist/blocks';
 
 # Loading
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Our standard-use loading icon. Use this to indicate a major part of the page is
 still coming.

--- a/packages/styleguide/stories/Labs/Brand/Atoms/Loading.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/Loading.stories.mdx
@@ -1,4 +1,5 @@
 import { Loading } from '@codecademy/gamut-labs/src';
+import { StoryStatus } from '~styleguide/blocks';
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs/dist/blocks';
 
 <Meta title="Labs/Brand/Atoms/Loading" component={Loading} />

--- a/packages/styleguide/stories/Labs/Brand/Atoms/Logo.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/Logo.stories.mdx
@@ -9,7 +9,7 @@ import { selectableColors } from '../../../../helpers';
 
 # Logo
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Our proud logo. There is no a in the middle. Use sparingly, and make sure
 it has a lot of visual distinction to stand out appropriately.

--- a/packages/styleguide/stories/Labs/Brand/Atoms/Quote.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/Quote.stories.mdx
@@ -7,7 +7,7 @@ import { Quote } from '@codecademy/gamut-labs/src';
 
 # Quote
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Emphasized text intended to be a direct quote, such as from a learner.
 Often with an `Avatar` or `Testimonial`.

--- a/packages/styleguide/stories/Labs/Brand/Molecules/Byline.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Molecules/Byline.stories.mdx
@@ -8,7 +8,7 @@ import { Byline } from '@codecademy/gamut-labs/src';
 
 # Byline
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 Marketing display of a person's information, such as for a testimonial.
 Commonly paired with an `Avatar`.

--- a/packages/styleguide/stories/Labs/Brand/Molecules/EditorialImage.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Molecules/EditorialImage.stories.mdx
@@ -8,7 +8,7 @@ import { EditorialImage } from '@codecademy/gamut-labs/src';
 
 # EditorialImage
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 An image used for editorial pages with an optional caption.
 

--- a/packages/styleguide/stories/Labs/Brand/Molecules/EditorialQuote.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Molecules/EditorialQuote.stories.mdx
@@ -8,7 +8,7 @@ import { EditorialQuote } from '@codecademy/gamut-labs/src';
 
 # EditorialQuote
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 A pull quote for use in an editorial page.
 

--- a/packages/styleguide/stories/Labs/Brand/Molecules/Testimonial.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Molecules/Testimonial.stories.mdx
@@ -9,7 +9,7 @@ import { VisualTheme } from '@codecademy/gamut/src';
 
 # Testimonial
 
-<StoryStatus status="ready" />
+<StoryStatus status="stable" />
 
 A pull quote for use in an editorial page.
 

--- a/packages/styleguide/stories/Labs/Experimental/Molecules/Header.stories.mdx
+++ b/packages/styleguide/stories/Labs/Experimental/Molecules/Header.stories.mdx
@@ -10,7 +10,7 @@ import { HeaderContainer, HeaderTab } from '@codecademy/gamut-labs/src';
 
 # Header
 
-<StoryStatus status="inProgress" />
+<StoryStatus status="volatile" />
 
 Header navigation bar and tabs with configurable areas.
 


### PR DESCRIPTION
## Overview
Inspired by: https://circuit.sumup.com/?path=/docs/typography-subheading--base

Makes `StoryStatus` less complicated:
- No longer requires a hover.
- Stable/Volatile/Deprecated are the tags.

Adds a few missing indicators

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

