### PR TITLE
fix: Automatically add display names to anonymous function components

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     ]
   },
   "dependencies": {
+    "babel-plugin-react-anonymous-display-name": "^0.0.1",
     "conventional-changelog-cli": "^2.0.34",
     "conventional-changelog-conventionalcommits": "^4.2.3",
     "gh-pages": "^2.2.0",

--- a/packages/gamut-icons/babel.config.js
+++ b/packages/gamut-icons/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
+  plugins: ['react-anonymous-display-name'],
   include: ['./src/**/*'],
   ignore: ['__tests__', './**/*.d.ts'],
 };

--- a/packages/gamut-labs/babel.config.js
+++ b/packages/gamut-labs/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
+  plugins: ['react-anonymous-display-name'],
   include: ['./src/**/*'],
   ignore: ['__tests__', './**/*.d.ts'],
 };

--- a/packages/gamut/babel.config.js
+++ b/packages/gamut/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
+  plugins: ['react-anonymous-display-name'],
   include: ['./src/**/*'],
   ignore: ['__tests__', './**/*.d.ts'],
 };

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -47,6 +47,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "onchange": "^7.0.2"
+    "onchange": "^7.0.2",
+    "babel-plugin-react-anonymous-display-name": "^0.0.1"
   }
 }

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -47,7 +47,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "onchange": "^7.0.2",
-    "babel-plugin-react-anonymous-display-name": "^0.0.1"
+    "onchange": "^7.0.2"
   }
 }

--- a/packages/gamut/src/Card/CardShell.tsx
+++ b/packages/gamut/src/Card/CardShell.tsx
@@ -32,6 +32,5 @@ export const CardShell = React.forwardRef<HTMLDivElement, CardShellProps>(
 );
 
 CardShell.defaultProps = defaultProps;
-CardShell.displayName = 'CardShell';
 
 export default CardShell;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5689,6 +5689,11 @@ babel-plugin-named-asset-import@^0.3.1:
   resolved "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.5.tgz#d3fa1a7f1f4babd4ed0785b75e2f926df0d70d0d"
   integrity sha512-sGhfINU+AuMw9oFAdIn/nD5sem3pn/WgxAfDZ//Q3CnF+5uaho7C7shh2rKLk6sKE/XkfmyibghocwKdVjLIKg==
 
+babel-plugin-react-anonymous-display-name@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/babel-plugin-react-anonymous-display-name/-/babel-plugin-react-anonymous-display-name-0.0.1.tgz#1ead71540b71d4024bd26c214b7a3a3d0d67bb93"
+  integrity sha512-VDPjkWaKY94V3tDPfHCCI/16MBeuMjiPH0cIihS+LVl53jGo1zF/pOkiqfXcxn8D44mGw2om+sIzlsLBUEMQnA==
+
 babel-plugin-react-docgen@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-4.1.0.tgz#1dfa447dac9ca32d625a123df5733a9e47287c26"


### PR DESCRIPTION
## Overview

Added a babel plugin that will automatically change the code for anonymous function components so they get display names.

Plugin link: https://github.com/patrykkopycinski/babel-plugin-react-anonymous-display-name#readme

Example:

```js
const MyComponent = React.memo((props) => {
  return (
    <div>{props.children}</div>
  )
})

// becomes:

const MyComponent = React.memo(function MyComponent(props) {
  return (
    <div>{props.children}</div>
  )
})
```

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

<!--
## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
