### PR TITLE
fix: Used old ChevronDownIcon in AccordionButton

### DIFF
--- a/packages/gamut/src/Accordion/__tests__/Accordion-test.tsx
+++ b/packages/gamut/src/Accordion/__tests__/Accordion-test.tsx
@@ -62,7 +62,7 @@ describe('Accordion', () => {
     });
 
     expect(wrapper.text()).toEqual(
-      `header-${true}Arrow Chevron Down Iconchildren-${true}`
+      `header-${true}Chevron Down Iconchildren-${true}`
     );
   });
 });

--- a/packages/gamut/src/AccordionButton/index.tsx
+++ b/packages/gamut/src/AccordionButton/index.tsx
@@ -1,7 +1,7 @@
-import { ArrowChevronDownIcon } from '@codecademy/gamut-icons';
 import cx from 'classnames';
 import React from 'react';
 
+import { ChevronDownIcon } from '../Icon/icons/ChevronDownIcon';
 import Button from '../Button';
 import styles from './styles.module.scss';
 import ButtonBase from '../ButtonBase';
@@ -56,6 +56,7 @@ export const AccordionButton: React.FC<AccordionButtonProps> = ({
   theme,
 }) => {
   const { component: ButtonComponent, props } = buttonThemes[theme];
+  const iconSize = size === 'large' ? 30 : undefined;
 
   return (
     <ButtonComponent
@@ -71,12 +72,13 @@ export const AccordionButton: React.FC<AccordionButtonProps> = ({
       {...props}
     >
       <span className={styles.children}>{children}</span>
-      <ArrowChevronDownIcon
+      <ChevronDownIcon
         className={cx(
           styles.expansionIcon,
           expanded && styles.expansionIconExpanded
         )}
-        size={size === 'large' ? 30 : undefined}
+        height={iconSize}
+        width={iconSize}
       />
     </ButtonComponent>
   );


### PR DESCRIPTION
## Overview

### PR Checklist

- [ ] Related to Abstract designs:~
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

Unlike the fancy new gamut-icons package, it doesn't add an aria-labelledby with an automatic titleId -- so it won't violate aXe checks with multiple identicle IDs when used in multiple places on a page.

Sorry @codecaaron 😄  -- revert of just the one change from #870.
