### PR TITLE
fix(Button): Add back fitText classname mapping

### DIFF
--- a/packages/gamut/src/Button/index.tsx
+++ b/packages/gamut/src/Button/index.tsx
@@ -105,7 +105,9 @@ export type ButtonProps = HTMLAttributes<HTMLButtonElement> & {
    * Variant that underlines the text of the button.
    */
   underline?: boolean;
-  /** @deprecated This is a no-op prop */
+  /**
+   *  Determines whether button dimensions should be determined by the content
+   */
   fitText?: boolean;
 };
 
@@ -132,6 +134,7 @@ export const Button: React.FC<ButtonProps> = (props) => {
       [s.round]: props.round,
       [s.square]: props.square,
       [s.flat]: props.flat,
+      [s['fit-text']]: props.fitText,
     },
     props.className
   );


### PR DESCRIPTION
## Overview
Buttons with `fitText` are broken on this version.  I thought I had this as a noop but apparently I didn't delete some code.
