### PR TITLE
fix(Button): Added align-items: center to Button styles

### DIFF
--- a/packages/gamut/src/Button/styles/index.module.scss
+++ b/packages/gamut/src/Button/styles/index.module.scss
@@ -6,6 +6,7 @@
 //
 
 .btn {
+  align-items: center;
   display: inline-flex;
   justify-content: center;
   font-weight: $btn-font-weight;


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to Abstract designs:~
- [x] Related to JIRA ticket: TR2-298
- [x] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

### Description

When buttons are given a custom `height`, they should still center text.
codecademy.explore/try has a weird big button right now. 😢 