### PR TITLE
feat(SkipToContent): Allow preventScroll prop for focus() param options

### DIFF
--- a/packages/gamut/src/SkipToContent/index.tsx
+++ b/packages/gamut/src/SkipToContent/index.tsx
@@ -7,14 +7,17 @@ import { ArrowDownIcon } from '@codecademy/gamut-icons';
 export type SkipToContentProps = {
   className?: string;
   contentId: string;
+  preventScroll?: boolean;
 };
 
 export const SkipToContent: React.FC<SkipToContentProps> = ({
   className,
   contentId,
+  preventScroll,
 }) => {
   const href = `#${contentId}`;
-  const onClick = () => document.querySelector<HTMLElement>(href)!.focus();
+  const onClick = () =>
+    document.querySelector<HTMLElement>(href)!.focus({ preventScroll });
 
   return (
     <a

--- a/packages/gamut/src/SkipToContent/index.tsx
+++ b/packages/gamut/src/SkipToContent/index.tsx
@@ -7,6 +7,9 @@ import { ArrowDownIcon } from '@codecademy/gamut-icons';
 export type SkipToContentProps = {
   className?: string;
   contentId: string;
+  /**
+   * A Boolean value indicating whether or not the browser should scroll the document to bring the newly-focused element into view.
+   */
   preventScroll?: boolean;
 };
 
@@ -16,8 +19,10 @@ export const SkipToContent: React.FC<SkipToContentProps> = ({
   preventScroll,
 }) => {
   const href = `#${contentId}`;
-  const onClick = () =>
-    document.querySelector<HTMLElement>(href)!.focus({ preventScroll });
+  const onClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    return document.querySelector<HTMLElement>(href)!.focus({ preventScroll });
+  };
 
   return (
     <a


### PR DESCRIPTION
## Overview
Allows an optional `preventScroll` prop to be passed to `SkipToContent`, so that the user can specify whether they want the window to scroll or not. So the skip behavior will just be keyboard focus to the element with the associated `contentId` - without the scrolling.

See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus#Syntax
### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

![Jul-23-2020 19-39-08](https://user-images.githubusercontent.com/17210163/88348783-5827c080-cd1c-11ea-91d0-049f5f50947d.gif)


<!--
## Merging your changes

When you are ready to merge to master and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
