### PR TITLE
fix(Tab): Used default outline for active and focused Tabs

### DIFF
--- a/packages/gamut/src/Tabs/Tab/index.tsx
+++ b/packages/gamut/src/Tabs/Tab/index.tsx
@@ -3,8 +3,6 @@ import React, { ReactNode, FunctionComponent } from 'react';
 
 import omitProps from '../../utils/omitProps';
 
-import ButtonBase from '../../ButtonBase';
-
 import s from './styles.module.scss';
 
 export type TabProps = {
@@ -41,7 +39,7 @@ export const Tab: FunctionComponent<TabProps> = ({
   const dataPropsToTransfer = omitProps([], rest);
 
   return (
-    <ButtonBase
+    <button
       id={id}
       className={tabClasses}
       aria-selected={active}
@@ -68,10 +66,11 @@ export const Tab: FunctionComponent<TabProps> = ({
       }}
       role="tab"
       tabIndex={disabled ? -1 : 0}
+      type="button"
       {...dataPropsToTransfer}
     >
       {children}
-    </ButtonBase>
+    </button>
   );
 };
 

--- a/packages/gamut/src/Tabs/Tab/styles.module.scss
+++ b/packages/gamut/src/Tabs/Tab/styles.module.scss
@@ -1,9 +1,9 @@
 @import "~@codecademy/gamut-styles/utils";
 
-$tab-color: $color-blue-500;
 $tab-border-radius: 2px;
 
 .tab {
+  background-color: $color-white;
   flex: 1 1;
   outline: none;
   cursor: pointer;
@@ -22,7 +22,7 @@ $tab-border-radius: 2px;
   overflow: hidden;
   white-space: nowrap;
   color: $color-black;
-  border: 1px solid $tab-color;
+  border: 1px solid $color-blue-500;
   padding: 0.5rem;
   border-left: 0;
   display: block;
@@ -40,7 +40,7 @@ $tab-border-radius: 2px;
   &:first-of-type {
     border-top-left-radius: $tab-border-radius;
     border-bottom-left-radius: $tab-border-radius;
-    border-left: 1px solid $tab-color;
+    border-left: 1px solid $color-blue-500;
   }
   &:last-of-type {
     border-top-right-radius: $tab-border-radius;
@@ -50,11 +50,11 @@ $tab-border-radius: 2px;
 
 .tab_default__active {
   color: $color-white;
-  background-color: $tab-color;
+  background-color: $color-blue-500;
 
   &:hover,
   &:focus {
-    background-color: $tab-color;
+    background-color: $color-blue-500;
     color: $color-white;
   }
 }

--- a/packages/gamut/src/Tabs/TabList/styles.module.scss
+++ b/packages/gamut/src/Tabs/TabList/styles.module.scss
@@ -1,7 +1,6 @@
 .tabList {
   display: flex;
   margin: 0 0 1rem;
-  overflow: auto;
   padding: 0;
 }
 


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to Abstract designs:~ _(informal conversation with Yassine)_
- [x] Related to JIRA ticket: A11Y-283 A11Y-284
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

`ButtonBase` removes the default `outline` from active/focused buttons, which is not a behavior we want here. The only button style I can tell was being used from it was the white background.