### PR TITLE
fix(Toggle): Convert rem to px-rem()

### DIFF
--- a/packages/gamut/src/Toggle/index.tsx
+++ b/packages/gamut/src/Toggle/index.tsx
@@ -5,7 +5,6 @@ import s from './styles/index.module.scss';
 export type ToggleProps = {
   checked?: boolean;
   onChange?: (...args: any[]) => any;
-  onClick?: (...args: any[]) => any;
   label?: string;
   disabled?: boolean;
   theme?: 'gray-blue' | 'purple';
@@ -17,7 +16,6 @@ export class Toggle extends Component<ToggleProps, {}> {
     const {
       checked,
       onChange,
-      onClick,
       label,
       disabled,
       theme = 'gray-blue',
@@ -39,7 +37,6 @@ export class Toggle extends Component<ToggleProps, {}> {
           id={label}
           disabled={disabled}
           onChange={onChange}
-          onClick={onClick}
         />
         <span className={s.invisible}>{label}</span>
         <div className={cx(s.track, s[theme], s[`track-${size}`])} />

--- a/packages/gamut/src/Toggle/index.tsx
+++ b/packages/gamut/src/Toggle/index.tsx
@@ -5,6 +5,7 @@ import s from './styles/index.module.scss';
 export type ToggleProps = {
   checked?: boolean;
   onChange?: (...args: any[]) => any;
+  onClick?: (...args: any[]) => any;
   label?: string;
   disabled?: boolean;
   theme?: 'gray-blue' | 'purple';
@@ -16,6 +17,7 @@ export class Toggle extends Component<ToggleProps, {}> {
     const {
       checked,
       onChange,
+      onClick,
       label,
       disabled,
       theme = 'gray-blue',
@@ -37,6 +39,7 @@ export class Toggle extends Component<ToggleProps, {}> {
           id={label}
           disabled={disabled}
           onChange={onChange}
+          onClick={onClick}
         />
         <span className={s.invisible}>{label}</span>
         <div className={cx(s.track, s[theme], s[`track-${size}`])} />

--- a/packages/gamut/src/Toggle/styles/index.module.scss
+++ b/packages/gamut/src/Toggle/styles/index.module.scss
@@ -30,13 +30,13 @@
 }
 
 .track-medium {
-  width: px-rem(60);
-  height: px-rem(29);
+  width: px-rem(60px);
+  height: px-rem(29px);
 }
 
 .track-small {
-  width: px-rem(28);
-  height: px-rem(15);
+  width: px-rem(28px);
+  height: px-rem(15px);
 }
 
 .toggled .track {
@@ -56,27 +56,27 @@
 }
 
 .thumb-medium {
-  top: px-rem(3.5);
-  left: px-rem(3.5);
-  width: px-rem(22);
-  height: px-rem(22);
+  top: px-rem(3.5px);
+  left: px-rem(3.5px);
+  width: px-rem(22px);
+  height: px-rem(22px);
   border-radius: 99rem;
 }
 
 .thumb-small {
-  top: px-rem(1);
-  left: px-rem(1.5);
-  width: px-rem(13);
-  height: px-rem(12.5);
-  border-radius: px-rem(12);
+  top: px-rem(1px);
+  left: px-rem(1px);
+  width: px-rem(13px);
+  height: px-rem(13px);
+  border-radius: px-rem(12px);
 }
 
 .toggled .thumb-medium {
-  left: px-rem(34.5);
+  left: px-rem(34.5px);
 }
 
 .toggled .thumb-small {
-  left: px-rem(13.5);
+  left: px-rem(14px);
 }
 
 .invisible {

--- a/packages/gamut/src/Toggle/styles/index.module.scss
+++ b/packages/gamut/src/Toggle/styles/index.module.scss
@@ -30,13 +30,13 @@
 }
 
 .track-medium {
-  width: 3.75rem;
-  height: 1.8rem;
+  width: px-rem(60);
+  height: px-rem(29);
 }
 
 .track-small {
-  width: 1.75rem;
-  height: 0.938rem;
+  width: px-rem(28);
+  height: px-rem(15);
 }
 
 .toggled .track {
@@ -56,27 +56,27 @@
 }
 
 .thumb-medium {
-  top: 0.215rem;
-  left: 0.204rem;
-  width: 1.38rem;
-  height: 1.38rem;
+  top: px-rem(3.5);
+  left: px-rem(3.5);
+  width: px-rem(22);
+  height: px-rem(22);
   border-radius: 99rem;
 }
 
 .thumb-small {
-  top: 0.075rem;
-  left: 0.1rem;
-  width: 0.8rem;
-  height: 0.78rem;
-  border-radius: 0.75rem;
+  top: px-rem(1);
+  left: px-rem(1.5);
+  width: px-rem(13);
+  height: px-rem(12.5);
+  border-radius: px-rem(12);
 }
 
 .toggled .thumb-medium {
-  left: 2.17rem;
+  left: px-rem(34.5);
 }
 
 .toggled .thumb-small {
-  left: 0.9rem;
+  left: px-rem(13.5);
 }
 
 .invisible {


### PR DESCRIPTION
## Overview

This PR cleans up the rem sizing for the track and thumb (some of the decimals go out 2+ places). Converting rem to the px-rem() function as per Aaron's suggestion in [PR 885](https://github.com/Codecademy/client-modules/pull/885)


### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: [GM-64](https://codecademy.atlassian.net/browse/GM-64)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
