### PR TITLE
fix: add in missing equals sign

### DIFF
--- a/packages/gamut-styles/utils/mixins/_responsive.scss
+++ b/packages/gamut-styles/utils/mixins/_responsive.scss
@@ -58,7 +58,7 @@
 // Named view port mixin
 
 @mixin getViewport($viewport) {
-  @if $viewport = "xl" {
+  @if $viewport == "xl" {
     @include xl-viewport() {
       @content;
     }


### PR DESCRIPTION
## Overview

### PR Checklist

- [x] Related to JIRA ticket: WEB-992
- [ ] I have run this code to verify it works

### Description
While participating in the hackathon, we realized that there is a syntax error in _responsive.scss that makes some webpack loaders fail. We've resolved this locally for the sake of the hackathon, but wanted to start a real fix as well.

### Notes
AFAICT this is a straightforward syntax error, but there may be some downstream clients that relied on this behavior; are there known areas to test for this change?

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
