### PR TITLE
fix: MarkdownAnchor should still render children

### DIFF
--- a/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
@@ -269,4 +269,14 @@ var test = true;
       expect(markdown.text().trim()).toEqual(expectedText);
     });
   });
+
+  describe('Renders links', () => {
+    it('renders a link with text', () => {
+      const text = '[link](/url)';
+      const expectedText = `link`;
+      expect(text).not.toEqual(expectedText);
+      const markdown = mount(<Markdown text={text} />);
+      expect(markdown.text().trim()).toEqual(expectedText);
+    });
+  });
 });

--- a/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
@@ -177,6 +177,14 @@ var test = true;
   });
 
   describe('Markdown anchor links', () => {
+    it('Renders a link with text', () => {
+      const text = '[link](/url)';
+      const expectedText = `link`;
+      expect(text).not.toEqual(expectedText);
+      const markdown = mount(<Markdown text={text} />);
+      expect(markdown.text().trim()).toEqual(expectedText);
+    });
+
     it('Adds rel="noopener" to external links', () => {
       const markdown = mount(
         <Markdown text={`<a href="http://google.com">google</a>`} />
@@ -266,16 +274,6 @@ var test = true;
       const expectedText = `This is some code with a &mdash; in the middle and this is a \u2014`;
       expect(text).not.toEqual(expectedText);
       const markdown = mount(<Markdown inline text={text} />);
-      expect(markdown.text().trim()).toEqual(expectedText);
-    });
-  });
-
-  describe('Renders links', () => {
-    it('renders a link with text', () => {
-      const text = '[link](/url)';
-      const expectedText = `link`;
-      expect(text).not.toEqual(expectedText);
-      const markdown = mount(<Markdown text={text} />);
       expect(markdown.text().trim()).toEqual(expectedText);
     });
   });

--- a/packages/gamut/src/Markdown/libs/overrides/MarkdownAnchor/__tests__/MarkdownAnchor-test.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/MarkdownAnchor/__tests__/MarkdownAnchor-test.tsx
@@ -38,4 +38,12 @@ describe('MarkdownAnchor', () => {
     const anchor = mount(<MarkdownAnchor href="www.codecademy.com" />);
     expect(anchor.find(`a[href='www.codecademy.com']`).length).toEqual(1);
   });
+
+  it('renders its children', () => {
+    const text = 'natalie rulez';
+
+    const anchor = mount(<MarkdownAnchor href="/">{text}</MarkdownAnchor>);
+
+    expect(anchor.text()).toEqual(text);
+  });
 });

--- a/packages/gamut/src/Markdown/libs/overrides/MarkdownAnchor/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/MarkdownAnchor/index.tsx
@@ -24,7 +24,10 @@ const matchesOrigin = (href: string) => {
   return false;
 };
 
-const MarkdownAnchor: React.FC<MarkdownAnchorProps> = (props) => {
+const MarkdownAnchor: React.FC<MarkdownAnchorProps> = ({
+  children,
+  ...props
+}) => {
   const asProps = {
     ...props,
     target: '_blank',
@@ -36,7 +39,7 @@ const MarkdownAnchor: React.FC<MarkdownAnchorProps> = (props) => {
     delete asProps.rel;
   }
 
-  return <Anchor asProps={asProps} />;
+  return <Anchor asProps={asProps}>{children}</Anchor>;
 };
 
 export default MarkdownAnchor;


### PR DESCRIPTION
## Overview

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

This came from a cleanup I'd done post-checking in #883. 