### PR TITLE
fix(CheckIcon): Remove erroneous clip-path

### DIFF
--- a/packages/gamut-icons/src/svg/check-icon.svg
+++ b/packages/gamut-icons/src/svg/check-icon.svg
@@ -2,12 +2,7 @@
 	xmlns="http://www.w3.org/2000/svg">
   <!-- custom checkmark -->
   <title>check</title>
-	<g clip-path="url(#clip0)">
+	<g>
 		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.5522 3.93089C24.1426 4.51197 24.1502 5.46169 23.5691 6.05214L9.79135 20.0521C9.23431 20.6182 8.33262 20.6519 7.73481 20.1292L0.512587 13.8134C-0.111024 13.268 -0.174472 12.3204 0.370873 11.6968C0.916217 11.0732 1.86384 11.0097 2.48745 11.5551L8.6451 16.9399L21.4309 3.94786C22.012 3.35741 22.9617 3.34981 23.5522 3.93089Z" fill="black"/>
-	</g>
-	<defs>
-		<clipPath id="clip0">
-			<rect width="24" height="24" fill="white"/>
-		</clipPath>
-	</defs>
+  </g>
 </svg>


### PR DESCRIPTION
## Overview

Per @JoshuaKGoldberg 

> Unrelated to any current discussion, I’m getting some a11y failures in a branch 
> that uses the newest check-icon from gamut-icons… example page failing aXe: https://pr-18690.monolith.dev.codecademy.com/business
> ...
> The issue is that the ID for all of them is the same, generated from clip0


### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

