### PR TITLE
feat(Stylelint): Add stylelint config and presets WEB-990

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('./packages/stylelint-config');

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "jounqin.vscode-mdx",
-    "jpoissonnier.vscode-styled-components"
+    "jpoissonnier.vscode-styled-components",
+    "hex-ci.stylelint-plus"
   ]
 }

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,0 +1,37 @@
+module.exports = {
+  cache: true,
+  extends: ['stylelint-config-standard', 'stylelint-config-styled-components'],
+  rules: {
+    'at-rule-no-vendor-prefix': true,
+    'media-feature-name-no-vendor-prefix': true,
+    'property-no-vendor-prefix': true,
+    'selector-no-vendor-prefix': true,
+    'shorthand-property-no-redundant-values': true,
+    'value-no-vendor-prefix': true,
+    'selector-max-type': [
+      0,
+      {
+        ignore: ['descendant', 'child', 'next-sibling'],
+        message:
+          'Avoid using element type selectors if possible. If needed, they must be scoped to a class name.',
+      },
+    ],
+    'declaration-block-no-shorthand-property-overrides': null,
+    'no-descending-specificity': null,
+    'property-no-unknown': null,
+    'selector-pseudo-class-no-unknown': null,
+
+    'at-rule-empty-line-before': null,
+    'at-rule-no-unknown': null,
+    'block-closing-brace-newline-after': null,
+    'comment-empty-line-before': null,
+    'declaration-colon-newline-after': null,
+    'declaration-empty-line-before': null,
+    'font-family-no-missing-generic-family-keyword': null,
+    indentation: null,
+    'rule-empty-line-before': null,
+    'selector-combinator-space-before': null,
+    'selector-descendant-combinator-no-non-space': null,
+    'value-list-comma-newline-after': null,
+  },
+};

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@codecademy/stylelint-config",
+  "version": "1.0.0",
+  "description": "Shared stylelint config for Codecademy",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Codecademy/client-modules/packages/stylelint-config"
+  },
+  "author": "codecademy",
+  "license": "ISC",
+  "peerDependencies": {
+    "stylelint": "^13.6.1"
+  },
+  "dependencies": {
+    "stylelint-config-standard": "20.0.0",
+    "stylelint-config-styled-components": "0.1.1"
+  },
+  "devDependencies": {
+    "stylelint": "13.3.3"
+  }
+}


### PR DESCRIPTION
## Overview
Adds stylelint config package.

This will also work on styled-components.

### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: WEB-990
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

- Adds `@codecademy/stylelint-config` npm package.
- Based off of https://github.com/codecademy-engineering/Codecademy/blob/master/.stylelintrc
- Adds 'stylelint-config-styled-components' to disable conflicting rules
- Adds recommended VSCode extension: `hex-ci.stylelint-plus` (the one distributed by stylelint didn't seem to work out of the box, however, this does, happy to switch if people get the other one working easily).

Styled component config is basically just:
```js
module.exports = {
  "rules": {
    "value-no-vendor-prefix": true,
    "property-no-vendor-prefix": true,
    "no-empty-source": null,
    "no-missing-end-of-source-newline": null
  }
}
```

Further work:
- A full audit of the rules that we want. 
- Enable specific rulesets per package.
- Replace usage on Monolith with a new package.
- Add lint verification scripts and tasks if we are happy with the rulesets.
- Deprecate SCSS lint?
