### PR TITLE
fix: AccordionArea typo in docs

### DIFF
--- a/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
@@ -46,7 +46,7 @@ If you'd like a "controlled" component equivalent, you can manually use the `Acc
 Most accordions should use an `AccordionButton`; other forms of buttons are acceptable for custom accordions.
 
 <Preview>
-  <Story name="Accordion">
+  <Story name="AccordionArea">
     {() => {
       const expanded = boolean('Expanded');
       return (

--- a/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
+++ b/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx
@@ -4,7 +4,7 @@ import {
   AccordionButton,
 } from '@codecademy/gamut/src';
 import { Meta, Props, Preview, Story } from '@storybook/addon-docs/dist/blocks';
-import { select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { useState } from 'react';
 
 import { StoryStatus } from '../../../Blocks';
@@ -25,7 +25,6 @@ such as a "hint" section in the LE or a list of department jobs on a careers pag
 <Preview>
   <Story name="Accordion">
     <Accordion
-      expanded={expanded}
       size={select('Size', ['normal', 'large'], undefined)}
       theme={select('Theme', ['blue', 'plain', 'yellow'], undefined)}
       top="Click me!"

--- a/packages/styleguide/stories/Deprecated/Atoms/IconDeprecated.stories.mdx
+++ b/packages/styleguide/stories/Deprecated/Atoms/IconDeprecated.stories.mdx
@@ -6,7 +6,7 @@ import {
 } from '@storybook/addon-docs/dist/blocks';
 import { StoryStatus } from '~styleguide/blocks';
 import { Icon } from '@codecademy/gamut/src/deprecated';
-import iconMap from '@codecademy/gamut/src/deprecated/Icon/iconMap';
+import { iconMap } from '@codecademy/gamut/src/deprecated/Icon/iconMap';
 
 <Meta title="Deprecated/Atoms/Icon" componet={Icon} />
 


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/Codecademy/client-modules/6375/workflows/1746b445-515b-4fdc-9284-a5a9d89d06f2/jobs/37030/parallel-runs/0/steps/0-108:

```
WARN Module build failed (from ./node_modules/babel-loader/lib/index.js):
WARN SyntaxError: /home/circleci/repo/packages/styleguide/stories/Core/Molecules/Accordion.stories.mdx: Identifier 'accordion' has already been declared (86:13)
WARN 
WARN   84 | accordion.parameters = { storySource: { source: '<Accordion expanded={expanded} size={select(\'Size\', [\'normal\', \'large\'], undefined)} theme={select(\'Theme\', [\'blue\', \'plain\', \'yellow\'], undefined)} top=\"Click me!\">\n      Hidden treasure!\n    </Accordion>' } };
WARN   85 | 
WARN > 86 | export const accordion = (() => {
WARN      |              ^
WARN   87 |   const expanded = boolean('Expanded');
WARN   88 |   return <AccordionArea expanded={expanded} top={<AccordionButton expanded={expanded}>Click me!</AccordionButton>}>
WARN   89 |           Hidden treasure!
```
