### PR TITLE
feat!: Added import/no-default-export to ESLint config

### DIFF
--- a/packages/enzyme-helpers/rollup.config.js
+++ b/packages/enzyme-helpers/rollup.config.js
@@ -1,6 +1,7 @@
 import resolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 
+// eslint-disable-next-line import/no-default-export
 export default {
   input: 'src/main.js',
   output: [

--- a/packages/enzyme-helpers/test/TestComponent.js
+++ b/packages/enzyme-helpers/test/TestComponent.js
@@ -1,11 +1,9 @@
 import React from 'react';
 
-const TestComponent = ({ onClick, ...props }) => (
+export const TestComponent = ({ onClick, ...props }) => (
   <div {...props} data-testid="container">
     <button type="button" onClick={onClick} data-testid="button">
       A test component
     </button>
   </div>
 );
-
-export default TestComponent;

--- a/packages/enzyme-helpers/test/main-test.js
+++ b/packages/enzyme-helpers/test/main-test.js
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import { createEnzymeHelpers } from '../src/main';
-import TestComponent from './TestComponent';
+import { TestComponent } from './TestComponent';
 
 describe('Enzyme Helpers', () => {
   describe('Base Functionality', () => {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -36,6 +36,7 @@ module.exports = {
   rules: {
     // These off-by-default or configurable rules are good and we like having them on
     eqeqeq: 'error',
+    'import/no-default-export': 'error',
     'no-console': 'error',
     'no-eval': 'error',
     'no-global-assign': 'error',

--- a/packages/gamut/src/Accordion/index.tsx
+++ b/packages/gamut/src/Accordion/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import AccordionArea from '../AccordionArea';
+import { AccordionArea } from '../AccordionArea';
 import {
   AccordionButton,
   AccordionButtonSize,

--- a/packages/gamut/src/AccordionArea/__tests__/AccordionArea-test.tsx
+++ b/packages/gamut/src/AccordionArea/__tests__/AccordionArea-test.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import AccordionArea, { AccordionAreaProps } from '..';
+import { AccordionArea, AccordionAreaProps } from '..';
 
 const renderComponent = (overrides: Partial<AccordionAreaProps> = {}) => {
   const props = {

--- a/packages/gamut/src/AccordionArea/index.tsx
+++ b/packages/gamut/src/AccordionArea/index.tsx
@@ -59,5 +59,3 @@ export const AccordionArea: React.FC<AccordionAreaProps> = ({
     </div>
   );
 };
-
-export default AccordionArea;


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to Abstract designs:~
- [x] Related to JIRA ticket: WEB-1022
- [x] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

### Description

Adds [`import/no-default-export`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-default-export.md) per our [RFC](https://www.notion.so/codecademy/Migration-Default-to-Named-Exports-529170b17a3d41a4add35ced6b5ed181).

Adds `import/no-default-export` as an error, and fixes the last `export default` I'd sneakily left in the codebase to check that it runs.

See https://app.circleci.com/pipelines/github/Codecademy/client-modules/6423/workflows/28081b01-ea3f-4ab3-9621-9b7e6a2771d5/jobs/37300 for a workflow showing the rule does, indeed, produce errors when it should.