### PR TITLE
fix: RadialProgress inner circle shouldn't show at value 0

### DIFF
--- a/packages/gamut/src/RadialProgress/index.tsx
+++ b/packages/gamut/src/RadialProgress/index.tsx
@@ -11,12 +11,10 @@ export interface RadialProgressProps extends SVGProps<SVGSVGElement> {
   strokeLinecap?: 'round' | 'butt' | 'square';
 }
 
-const offsetForEmptyProgress = 260;
-const offsetForFullProgress = 8;
-const offsetDelta = offsetForEmptyProgress - offsetForFullProgress;
+const offsetDelta = 280;
 
 const convertPercentToOffset = (percent: number) =>
-  offsetForEmptyProgress - Math.floor(offsetDelta * (percent / 100));
+  offsetDelta - Math.floor(offsetDelta * (percent / 100));
 
 export const RadialProgress: React.FC<RadialProgressProps> = ({
   children,
@@ -62,14 +60,14 @@ export const RadialProgress: React.FC<RadialProgressProps> = ({
         <circle
           cx="50"
           cy="50"
-          r="40"
+          r="45"
           stroke="currentColor"
           strokeWidth={strokeWidth}
           strokeLinecap={strokeLinecap}
           fill="none"
           opacity="1"
           strokeDashoffset={finalValue}
-          strokeDasharray="260"
+          strokeDasharray={offsetDelta}
           transform="rotate(-90 50 50)"
         >
           {startingValue !== finalValue && (

--- a/packages/gamut/src/RadialProgress/index.tsx
+++ b/packages/gamut/src/RadialProgress/index.tsx
@@ -11,10 +11,12 @@ export interface RadialProgressProps extends SVGProps<SVGSVGElement> {
   strokeLinecap?: 'round' | 'butt' | 'square';
 }
 
-const offsetDelta = 280;
+const offsetForEmptyProgress = 290;
+const offsetForFullProgress = 10;
+const offsetDelta = offsetForEmptyProgress - offsetForFullProgress;
 
 const convertPercentToOffset = (percent: number) =>
-  offsetDelta - Math.floor(offsetDelta * (percent / 100));
+  offsetForEmptyProgress - Math.floor(offsetDelta * (percent / 100));
 
 export const RadialProgress: React.FC<RadialProgressProps> = ({
   children,
@@ -67,7 +69,7 @@ export const RadialProgress: React.FC<RadialProgressProps> = ({
           fill="none"
           opacity="1"
           strokeDashoffset={finalValue}
-          strokeDasharray={offsetDelta}
+          strokeDasharray={offsetForEmptyProgress}
           transform="rotate(-90 50 50)"
         >
           {startingValue !== finalValue && (

--- a/packages/gamut/src/RadialProgress/index.tsx
+++ b/packages/gamut/src/RadialProgress/index.tsx
@@ -62,7 +62,7 @@ export const RadialProgress: React.FC<RadialProgressProps> = ({
         <circle
           cx="50"
           cy="50"
-          r="45"
+          r="40"
           stroke="currentColor"
           strokeWidth={strokeWidth}
           strokeLinecap={strokeLinecap}

--- a/packages/gamut/src/RadialProgress/index.tsx
+++ b/packages/gamut/src/RadialProgress/index.tsx
@@ -44,7 +44,7 @@ export const RadialProgress: React.FC<RadialProgressProps> = ({
       style={{ height: size, width: size }}
     >
       <svg
-        aria-label={`${finalValue}% progress`}
+        aria-label={`${value}% progress`}
         viewBox="0 0 100 100"
         height={size}
         width={size}


### PR DESCRIPTION
## Overview

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

Introduced by me in #943. ~The inner circle shouldn't have `r=45`, just the outer.~ No, that wasn't the solution; it just moved the inner circle counterclockwise. Switching to assuming an empty offset of 280 and full offset of 0 seems to have done the trick...