### PR TITLE
fix: Byline aria-label a11y bug

### DIFF
--- a/packages/gamut-labs/src/brand/Byline/index.tsx
+++ b/packages/gamut-labs/src/brand/Byline/index.tsx
@@ -32,20 +32,12 @@ export const Byline: React.FC<BylineProps> = ({
       data-testid="author-container"
       className={cx(s.author, classNames.author)}
     >
-      <span aria-label={`First Name: ${firstName}`}>{firstName}</span>
-      {lastName && (
-        <span aria-label={`Last Name: ${lastName}`} className={s.lastName}>
-          {` ${lastName}`}
-        </span>
-      )}
+      <span>{firstName}</span>
+      {lastName && <span className={s.lastName}>{` ${lastName}`}</span>}
     </span>
     <div data-testid="job-container" className={classNames.jobContainer}>
-      <span aria-label={`Occupation: ${occupation}`}>{occupation}</span>
-      {company && (
-        <span aria-label={`Company: ${company}`} className={s.company}>
-          {` @ ${company}`}
-        </span>
-      )}
+      <span>{occupation}</span>
+      {company && <span className={s.company}>{` @ ${company}`}</span>}
     </div>
     {location && (
       <div className={s.locationContainer}>

--- a/packages/gamut-labs/src/brand/Byline/index.tsx
+++ b/packages/gamut-labs/src/brand/Byline/index.tsx
@@ -32,17 +32,17 @@ export const Byline: React.FC<BylineProps> = ({
       data-testid="author-container"
       className={cx(s.author, classNames.author)}
     >
-      <span aria-label="First Name">{firstName}</span>
+      <span aria-label={`First Name: ${firstName}`}>{firstName}</span>
       {lastName && (
-        <span aria-label="Last Name" className={s.lastName}>
+        <span aria-label={`Last Name: ${lastName}`} className={s.lastName}>
           {` ${lastName}`}
         </span>
       )}
     </span>
     <div data-testid="job-container" className={classNames.jobContainer}>
-      <span aria-label="Occupation">{occupation}</span>
+      <span aria-label={`Occupation: ${occupation}`}>{occupation}</span>
       {company && (
-        <span aria-label="Company" className={s.company}>
+        <span aria-label={`Company: ${company}`} className={s.company}>
           {` @ ${company}`}
         </span>
       )}


### PR DESCRIPTION
## Overview
There's an a11y bug with the Byline (used within the Testimonial) discovered during a Test.IO A11y test that was run on the Back to School Campaign Page.

### The Bug: https://codecademy.test.io/products/9763/test_cycles/68462/bugs

> **Steps**
> 
> 1. Open https://codecademy.com/student-center
> 2. Tab to Tyler V. quote

> - Expected result: I expect to hear the "Tyler V. Student.... "
> - Actual result:  I hear "First name Last name Occupation..."

> The screen reader read the aria-label in this
> `<span aria-label="First Name">Tyler</span>`
> 

**Video of Bug:** https://uploads.test.io/uploads/bug_attachment/file/3732204/cc1cde2f-eabf-40b6-a610-0bb5db697286.mp4

<img width="500" alt="Screen Shot 2020-09-10 at 3 37 22 PM" src="https://user-images.githubusercontent.com/17210163/92792846-e400b500-f37b-11ea-9229-230928e09d5e.png">

### Updated fix after PR discussion:
Remove aria-labels all-together.

#### Original fix:
~Append the value of `firstName`, `lastName`, `occupation`, and `company` to their respective `aria-labels`.~


### PR Checklist

- [ ] Related to Abstract designs:
- [x] Related to JIRA ticket: [REACH-247](https://codecademy.atlassian.net/browse/REACH-247)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
