### PR TITLE
docs: remove 'Abstract' mention from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ### PR Checklist
 
-- [ ] Related to Abstract designs:
+- [ ] Related to designs:
 - [ ] Related to JIRA ticket: ABC-123
 - [ ] I have run this code to verify it works
 - [ ] This PR includes unit tests for the code change


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to Abstract designs:~
- ~[ ] Related to JIRA ticket: ABC-123~
- ~[ ] I have run this code to verify it works~
- ~[ ] This PR includes unit tests for the code change~

### Description

We don't use Abstract as much anymore. Lots of Figma.
