### PR TITLE
fix(Button): Add rel by default if none is set when target=_blank

### DIFF
--- a/packages/gamut/src/ButtonBase/__tests__/Button-test.tsx
+++ b/packages/gamut/src/ButtonBase/__tests__/Button-test.tsx
@@ -29,6 +29,12 @@ describe('<ButtonBase>', () => {
     expect(wrapper.find('a').length).toBe(1);
   });
 
+  it('adds rel="noopnener" if no rel is set on <a> tags with target="_blank"', () => {
+    const wrapper = shallow(<ButtonBase href="/awesome" target="_blank" />);
+    expect(wrapper.prop('rel')).toContain('noopener');
+    expect(wrapper.prop('rel')).toContain('noreferrer');
+  });
+
   it('uses a <button> tag when you omit an href and the As prop', () => {
     const wrapper = shallow(<ButtonBase />);
     expect(wrapper.find('button').length).toBe(1);

--- a/packages/gamut/src/ButtonBase/index.tsx
+++ b/packages/gamut/src/ButtonBase/index.tsx
@@ -4,7 +4,15 @@ import { omitProps } from '../utils/omitProps';
 import styles from './styles.module.scss';
 import { ChildComponentDescriptor } from '../typings/react';
 
-const propKeys = ['children', 'className', 'href', 'link', 'onClick'];
+const propKeys = [
+  'children',
+  'className',
+  'href',
+  'link',
+  'onClick',
+  'target',
+  'rel',
+];
 
 export type ButtonBaseProps = Omit<
   HTMLProps<HTMLLinkElement> & HTMLProps<HTMLButtonElement>,
@@ -23,6 +31,8 @@ export type ButtonBaseProps = Omit<
   children?: ReactNode;
   className?: string;
   href?: string;
+  target?: string;
+  rel?: string;
   /**
    * Variant that displays the button as an inline link element, but maintains its semantic meaning as a button.
    */
@@ -39,7 +49,7 @@ export type ButtonBaseProps = Omit<
 };
 
 export const ButtonBase: React.FC<ButtonBaseProps> = (props) => {
-  const { href, className, link, onClick } = props;
+  const { href, className, link, onClick, target, rel } = props;
   const { as: As, asProps = {}, ...restOfProps } = props;
   const propsToTransfer = omitProps(propKeys, restOfProps);
 
@@ -59,9 +69,15 @@ export const ButtonBase: React.FC<ButtonBaseProps> = (props) => {
   }
 
   if (href) {
+    // Check if this is a popup and and appropriate rel props if they don't exist (see https://web.dev/external-anchors-use-rel-noopener/)
+    const anchorProps = {
+      target,
+      rel: target === '_blank' && !rel ? 'noopener noreferrer' : rel,
+    };
+
     // Anchor tag receives children content from propsToTransfer
     // eslint-disable-next-line jsx-a11y/anchor-has-content
-    return <a {...defaultProps} href={href} />;
+    return <a {...defaultProps} {...anchorProps} href={href} />;
   }
 
   // eslint-disable-next-line react/button-has-type


### PR DESCRIPTION
## Overview
Just a failsafe for when a Button component has an `href` and `target="_blank"` but no `rel` prop. Noticed we were doing this in Markdown but not here.

### PR Checklist

- [ ] Related to Abstract designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
