### PR TITLE
fix: corrected GridForm Values to allow FileList

### DIFF
--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -52,7 +52,7 @@ export type GridFormProps<Values extends {}> = {
 };
 
 export function GridForm<
-  Values extends Record<string, boolean | string | undefined>
+  Values extends Record<string, boolean | string | undefined | FileList>
 >({
   children,
   className,


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: WEB-298
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change _(in the form of type checking)_

### Description

`GridForm`'s `Values` is the vague description of what could possible exist as the submit value for a form: an object whose keys are strings and values are `boolean`, `string`, `undefined`, or (in the case of a file input), `FileList`. The description before was missing that `FileList` input type.