### PR TITLE
chore: rename 's' styles to 'styles'

### DIFF
--- a/packages/gamut-labs/src/brand/Avatar/index.tsx
+++ b/packages/gamut-labs/src/brand/Avatar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 import cx from 'classnames';
 import { VisualTheme } from '@codecademy/gamut';
 
@@ -26,9 +26,11 @@ export const Avatar: React.FC<AvatarProps> = ({
   return (
     <div
       className={cx(
-        s.container,
+        styles.container,
         className,
-        theme === VisualTheme.DarkMode ? s.darkContainer : s.lightContainer
+        theme === VisualTheme.DarkMode
+          ? styles.darkContainer
+          : styles.lightContainer
       )}
     >
       {/*  The current rules for alt-text don't allow images with aria-labelledby to have no alt. So, we need to disable the rule for that line. https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/411#issue-306995775 */}

--- a/packages/gamut-labs/src/brand/BrandMonospace/index.tsx
+++ b/packages/gamut-labs/src/brand/BrandMonospace/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 type BrandMonospaceProps = {
   /** Element to render as (span is the default) */
@@ -9,4 +9,4 @@ type BrandMonospaceProps = {
 export const BrandMonospace: React.FC<BrandMonospaceProps> = ({
   as: Element = 'span',
   children,
-}) => <Element className={s.font}>{children}</Element>;
+}) => <Element className={styles.font}>{children}</Element>;

--- a/packages/gamut-labs/src/brand/Byline/index.tsx
+++ b/packages/gamut-labs/src/brand/Byline/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 import cx from 'classnames';
 import networkPin from './assets/networkPin.svg';
 
@@ -27,23 +27,23 @@ export const Byline: React.FC<BylineProps> = ({
   company,
   lastName,
 }) => (
-  <div className={cx(s.bylineContainer, classNames.bylineContainer)}>
+  <div className={cx(styles.bylineContainer, classNames.bylineContainer)}>
     <span
       data-testid="author-container"
-      className={cx(s.author, classNames.author)}
+      className={cx(styles.author, classNames.author)}
     >
       <span>{firstName}</span>
-      {lastName && <span className={s.lastName}>{` ${lastName}`}</span>}
+      {lastName && <span className={styles.lastName}>{` ${lastName}`}</span>}
     </span>
     <div data-testid="job-container" className={classNames.jobContainer}>
       <span>{occupation}</span>
-      {company && <span className={s.company}>{` @ ${company}`}</span>}
+      {company && <span className={styles.company}>{` @ ${company}`}</span>}
     </div>
     {location && (
-      <div className={s.locationContainer}>
+      <div className={styles.locationContainer}>
         <img
           alt="Location pin icon"
-          className={s.networkPin}
+          className={styles.networkPin}
           src={networkPin}
         />
         <span className={classNames.location}>{location}</span>

--- a/packages/gamut-labs/src/brand/EditorialMolecules/EditorialImage/index.tsx
+++ b/packages/gamut-labs/src/brand/EditorialMolecules/EditorialImage/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type EditorialImageProps = {
   /** The URL used for the image src */
@@ -16,9 +16,9 @@ export const EditorialImage: React.FC<EditorialImageProps> = ({
   caption,
 }) => (
   <div>
-    <div className={s.imageContainer}>
-      <img className={s.image} alt={alt} src={image} />
+    <div className={styles.imageContainer}>
+      <img className={styles.image} alt={alt} src={image} />
     </div>
-    {caption && <span className={s.caption}>{caption}</span>}
+    {caption && <span className={styles.caption}>{caption}</span>}
   </div>
 );

--- a/packages/gamut-labs/src/brand/EditorialMolecules/EditorialQuote/index.tsx
+++ b/packages/gamut-labs/src/brand/EditorialMolecules/EditorialQuote/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type EditorialQuoteProps = {
   quote: string;
 };
 
 export const EditorialQuote: React.FC<EditorialQuoteProps> = ({ quote }) => (
-  <q className={s.quote}>{quote}</q>
+  <q className={styles.quote}>{quote}</q>
 );

--- a/packages/gamut-labs/src/brand/Header/HeaderTab/index.tsx
+++ b/packages/gamut-labs/src/brand/Header/HeaderTab/index.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type HeaderTabProps = HTMLAttributes<HTMLElement> & {
   className?: string;
@@ -14,7 +14,7 @@ export const HeaderTab: React.FC<HeaderTabProps> = ({
   id,
   testId,
 }) => {
-  const classes = cx(s.headerTab, className);
+  const classes = cx(styles.headerTab, className);
 
   return (
     <div id={id} className={classes} data-testid={testId}>

--- a/packages/gamut-labs/src/brand/Loading/index.tsx
+++ b/packages/gamut-labs/src/brand/Loading/index.tsx
@@ -2,7 +2,7 @@ import { deprecatedColors as colors } from '@codecademy/gamut-styles';
 import cx from 'classnames';
 import React from 'react';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type LoadingProps = {
   className?: string;
@@ -14,7 +14,7 @@ const color2 = colors.blue[900];
 export const Loading: React.FC<LoadingProps> = ({ className }) => {
   const icon = (
     <svg
-      className={cx(s.loading, className)}
+      className={cx(styles.loading, className)}
       data-testid="loading"
       xmlns="https://www.w3.org/2000/svg"
       width="123"
@@ -23,35 +23,35 @@ export const Loading: React.FC<LoadingProps> = ({ className }) => {
     >
       <title>Loading Icon</title>
       <path
-        className={cx(s.path, s.c)}
+        className={cx(styles.path, styles.c)}
         stroke={color1}
         fill="none"
         strokeMiterlimit="10"
         d="M18.7 57.6c0 4.2.4 7.4 1.2 9.8 2.3 7.1 8.4 11 16.3 11 5.9 0 10.6-2.4 13.7-6.1.2-.4.3-.8-.1-1.2l-5.2-4.5c-.4-.3-.8-.3-1.2.1-2 2.2-4 3.5-7.3 3.5-3.5 0-6.2-1.7-7.4-5.1-.7-2-.8-4.4-.8-7.4 0-3.1.2-5.4.8-7.4 1.1-3.5 3.9-5.2 7.4-5.2 3.3 0 5.3 1.2 7.3 3.5.3.4.7.5 1.2.2l5.2-4.5c.4-.3.3-.8.1-1.2-3.1-3.8-7.8-6.2-13.7-6.2-7.9 0-14 3.9-16.3 11-.8 2.3-1.2 5.5-1.2 9.7"
       />
       <path
-        className={cx(s.path, s.underline)}
+        className={cx(styles.path, styles.underline)}
         stroke={color1}
         fill="none"
         strokeMiterlimit="10"
         d="M120.7 97.2c.5 0 .8-.3.8-.8v-7.5c0-.5-.3-.8-.8-.8h-28c-.5 0-.8.3-.8.8v7.5c0 .5.3.8.8.8h28"
       />
       <path
-        className={cx(s.path, s.outer)}
+        className={cx(styles.path, styles.outer)}
         stroke={color1}
         fill="none"
         strokeMiterlimit="10"
         d="M42.7 1.5H2.1 2c-.3.2-.5.5-.5.8v94c0 .3.1.5.3.7.1.1.3.1.5.1h80.8c.3 0 .5-.1.6-.3.1-.1.2-.3.2-.5v-94c0-.2-.1-.4-.2-.6-.1-.1-.3-.2-.6-.2H42.7"
       />
       <path
-        className={cx(s.path, s.inner)}
+        className={cx(styles.path, styles.inner)}
         stroke={color1}
         fill="none"
         strokeMiterlimit="10"
         d="M42.7 88H11.3h-.1c-.3-.1-.5-.4-.5-.7V11.5c0-.4.2-.6.5-.8h63.1c.3.1.5.4.5.8v75.7c0 .4-.2.6-.5.7H42.7"
       />
       <path
-        className={cx(s.pathTwo, s.c)}
+        className={cx(styles.pathTwo, styles.c)}
         stroke={color2}
         fill="none"
         strokeWidth="3"
@@ -59,7 +59,7 @@ export const Loading: React.FC<LoadingProps> = ({ className }) => {
         d="M18.7 57.6c0 4.2.4 7.4 1.2 9.8 2.3 7.1 8.4 11 16.3 11 5.9 0 10.6-2.4 13.7-6.1.2-.4.3-.8-.1-1.2l-5.2-4.5c-.4-.3-.8-.3-1.2.1-2 2.2-4 3.5-7.3 3.5-3.5 0-6.2-1.7-7.4-5.1-.7-2-.8-4.4-.8-7.4 0-3.1.2-5.4.8-7.4 1.1-3.5 3.9-5.2 7.4-5.2 3.3 0 5.3 1.2 7.3 3.5.3.4.7.5 1.2.2l5.2-4.5c.4-.3.3-.8.1-1.2-3.1-3.8-7.8-6.2-13.7-6.2-7.9 0-14 3.9-16.3 11-.8 2.3-1.2 5.5-1.2 9.7"
       />
       <path
-        className={cx(s.pathTwo, s.underline)}
+        className={cx(styles.pathTwo, styles.underline)}
         stroke={color2}
         fill="none"
         strokeWidth="3"
@@ -67,7 +67,7 @@ export const Loading: React.FC<LoadingProps> = ({ className }) => {
         d="M120.7 97.2c.5 0 .8-.3.8-.8v-7.5c0-.5-.3-.8-.8-.8h-28c-.5 0-.8.3-.8.8v7.5c0 .5.3.8.8.8h28"
       />
       <path
-        className={cx(s.pathTwo, s.outer)}
+        className={cx(styles.pathTwo, styles.outer)}
         stroke={color2}
         fill="none"
         strokeWidth="3"
@@ -75,7 +75,7 @@ export const Loading: React.FC<LoadingProps> = ({ className }) => {
         d="M42.7 1.5H2.1 2c-.3.2-.5.5-.5.8v94c0 .3.1.5.3.7.1.1.3.1.5.1h80.8c.3 0 .5-.1.6-.3.1-.1.2-.3.2-.5v-94c0-.2-.1-.4-.2-.6-.1-.1-.3-.2-.6-.2H42.7"
       />
       <path
-        className={cx(s.pathTwo, s.inner)}
+        className={cx(styles.pathTwo, styles.inner)}
         stroke={color2}
         fill="none"
         strokeWidth="3"

--- a/packages/gamut-labs/src/brand/Quote/index.tsx
+++ b/packages/gamut-labs/src/brand/Quote/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 import cx from 'classnames';
 import { VisualTheme } from '@codecademy/gamut';
 import orangeQuotes from '../assets/orangeQuotes.svg';
@@ -18,14 +18,16 @@ export const Quote: React.FC<QuoteProps> = ({
 }) => (
   <div
     className={cx(
-      theme === VisualTheme.DarkMode ? s.darkContainer : s.lightContainer
+      theme === VisualTheme.DarkMode
+        ? styles.darkContainer
+        : styles.lightContainer
     )}
   >
     <img
       src={theme === VisualTheme.DarkMode ? purpleQuotes : orangeQuotes}
       alt=""
-      className={cx(s.icon, classNames.icon)}
+      className={cx(styles.icon, classNames.icon)}
     />
-    <q className={cx(s.text, classNames.text)}>{text}</q>
+    <q className={cx(styles.text, classNames.text)}>{text}</q>
   </div>
 );

--- a/packages/gamut-labs/src/brand/Testimonial/index.tsx
+++ b/packages/gamut-labs/src/brand/Testimonial/index.tsx
@@ -42,7 +42,9 @@ export const Testimonial: React.FC<TestimonialProps> = ({
       })}
     >
       <div className={styles.testimonialCardContainer}>
-        <div className={cx(styles.contentContainer, s[`${size}Container`])}>
+        <div
+          className={cx(styles.contentContainer, styles[`${size}Container`])}
+        >
           {imageUrl && (
             <div className={styles.avatarContainer}>
               <Avatar

--- a/packages/gamut-labs/src/brand/Testimonial/index.tsx
+++ b/packages/gamut-labs/src/brand/Testimonial/index.tsx
@@ -3,7 +3,7 @@ import { Avatar, Byline, Quote } from '../../index';
 import { VisualTheme } from '@codecademy/gamut';
 import cx from 'classnames';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type Testimonial = {
   firstName: string;
@@ -36,24 +36,26 @@ export const Testimonial: React.FC<TestimonialProps> = ({
 
   return (
     <div
-      className={cx(s.testimonialWrapper, {
-        [s.darkWrapper]: theme === VisualTheme.DarkMode,
-        [s.lightWrapper]: theme === VisualTheme.LightMode,
+      className={cx(styles.testimonialWrapper, {
+        [styles.darkWrapper]: theme === VisualTheme.DarkMode,
+        [styles.lightWrapper]: theme === VisualTheme.LightMode,
       })}
     >
-      <div className={s.testimonialCardContainer}>
-        <div className={cx(s.contentContainer, s[`${size}Container`])}>
+      <div className={styles.testimonialCardContainer}>
+        <div className={cx(styles.contentContainer, s[`${size}Container`])}>
           {imageUrl && (
-            <div className={s.avatarContainer}>
+            <div className={styles.avatarContainer}>
               <Avatar
                 src={imageUrl}
                 theme={theme}
-                className={cx({ [s.largeContainerAvatar]: size === 'large' })}
+                className={cx({
+                  [styles.largeContainerAvatar]: size === 'large',
+                })}
                 alt=""
               />
             </div>
           )}
-          <div className={s.bylineContainer}>
+          <div className={styles.bylineContainer}>
             <Byline
               firstName={firstName}
               occupation={occupation}
@@ -61,7 +63,7 @@ export const Testimonial: React.FC<TestimonialProps> = ({
               lastName={lastName}
             />
           </div>
-          <div className={s.quoteContainer}>
+          <div className={styles.quoteContainer}>
             <Quote text={quote} theme={theme} />
           </div>
         </div>

--- a/packages/gamut/src/Alert/index.tsx
+++ b/packages/gamut/src/Alert/index.tsx
@@ -16,7 +16,7 @@ import { Button } from '../Button';
 import { BannerType, BANNER_CONFIG } from './constants';
 import { BannerCTA } from './types';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type AlertProps = {
   className?: string;
@@ -52,9 +52,9 @@ export const Alert: React.FC<AlertProps> = ({
 
   return (
     <CardShell
-      className={cx(s.container, className, {
-        [s.container__fluid]: fluid,
-        [s[`container__${type}`]]: type,
+      className={cx(styles.container, className, {
+        [styles.container__fluid]: fluid,
+        [styles[`container__${type}`]]: type,
       })}
       role="status"
       aria-label="alert box"
@@ -62,18 +62,18 @@ export const Alert: React.FC<AlertProps> = ({
     >
       <Container align="start" justify="spaceAround" grow={1}>
         {showIcon && (
-          <Container className={s.section} justify="center" align="center">
+          <Container className={styles.section} justify="center" align="center">
             <TypeIcon size={24} />
           </Container>
         )}
         <Container
-          className={s.section__main}
+          className={styles.section__main}
           align="start"
           grow={1}
           shrink={1}
         >
           <Container
-            className={s.section}
+            className={styles.section}
             grow={1}
             shrink={1}
             align="start"
@@ -82,16 +82,20 @@ export const Alert: React.FC<AlertProps> = ({
             <Truncate
               lines={isExpanded ? undefined : lines}
               onTruncate={setIsTruncated}
-              className={s.truncate}
+              className={styles.truncate}
             >
               {children}
             </Truncate>
             {showExpandToggle && (
               <Container inline>
                 <ButtonBase
-                  className={cx(s.iconButton, s.iconButton__pushRight, {
-                    [s[`iconButton__${type}`]]: type,
-                  })}
+                  className={cx(
+                    styles.iconButton,
+                    styles.iconButton__pushRight,
+                    {
+                      [styles[`iconButton__${type}`]]: type,
+                    }
+                  )}
                   onClick={() => setIsExpanded(!isExpanded)}
                 >
                   <ToggleIcon size={16} />
@@ -100,11 +104,11 @@ export const Alert: React.FC<AlertProps> = ({
             )}
           </Container>
           {cta && (
-            <Container className={s.section} shrink={1}>
+            <Container className={styles.section} shrink={1}>
               <Button
                 caps
                 theme={type}
-                className={s.actionButton}
+                className={styles.actionButton}
                 onClick={cta.onClick}
                 href={cta.href}
                 disabled={cta.disabled}
@@ -115,10 +119,10 @@ export const Alert: React.FC<AlertProps> = ({
           )}
         </Container>
         {onClose && (
-          <Container className={s.section} shrink={1} center>
+          <Container className={styles.section} shrink={1} center>
             <ButtonBase
-              className={cx(s.iconButton, {
-                [s[`iconButton__${type}`]]: type,
+              className={cx(styles.iconButton, {
+                [styles[`iconButton__${type}`]]: type,
               })}
               aria-label="Close Alert"
               onClick={onClose}

--- a/packages/gamut/src/Button/index.tsx
+++ b/packages/gamut/src/Button/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import cx from 'classnames';
 import { ButtonBase, ButtonBaseProps } from '../ButtonBase';
 import { omitProps } from '../utils/omitProps';
-import s from './styles/index.module.scss';
+import styles from './styles/index.module.scss';
 
 // themes can be an alias to a color
 // or a unique button type
@@ -107,23 +107,25 @@ export const Button: React.FC<ButtonProps> = (props) => {
     theme = buttonPresetThemes[theme];
   }
 
-  const typeClassName = props.link ? s.link : s.btn;
-  const themeClassName = props.link ? s[`link-${theme}`] : s[`btn-${theme}`];
+  const typeClassName = props.link ? styles.link : styles.btn;
+  const themeClassName = props.link
+    ? styles[`link-${theme}`]
+    : styles[`btn-${theme}`];
 
   const classes = cx(
     typeClassName,
     themeClassName,
-    s[props.size!],
+    styles[props.size!],
     {
-      [s.block]: props.block,
-      [s.go]: props.go,
-      [s.outline]: props.outline,
-      [s.underline]: props.underline,
-      [s.caps]: props.caps,
-      [s.round]: props.round,
-      [s.square]: props.square,
-      [s.flat]: props.flat,
-      [s['fit-text']]: props.fitText,
+      [styles.block]: props.block,
+      [styles.go]: props.go,
+      [styles.outline]: props.outline,
+      [styles.underline]: props.underline,
+      [styles.caps]: props.caps,
+      [styles.round]: props.round,
+      [styles.square]: props.square,
+      [styles.flat]: props.flat,
+      [styles['fit-text']]: props.fitText,
     },
     props.className
   );

--- a/packages/gamut/src/Card/CardBody.tsx
+++ b/packages/gamut/src/Card/CardBody.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import cx from 'classnames';
-import s from './styles/CardBody.module.scss';
+import styles from './styles/CardBody.module.scss';
 
 const defaultProps = {
   standardPadding: true,
@@ -22,7 +22,7 @@ export const CardBody = ({
 }: CardBodyProps) => {
   const bodyClasses = cx(
     {
-      [s.standardPadding]: standardPadding,
+      [styles.standardPadding]: standardPadding,
     },
     className
   );

--- a/packages/gamut/src/Card/CardFooter.tsx
+++ b/packages/gamut/src/Card/CardFooter.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import cx from 'classnames';
-import s from './styles/CardFooter.module.scss';
+import styles from './styles/CardFooter.module.scss';
 
 const defaultProps = {
   border: 'none',
@@ -43,17 +43,17 @@ export const CardFooter = ({
   className,
 }: CardFooterProps) => {
   const footerClasses = cx(
-    s.footer,
+    styles.footer,
     {
-      [s.flex]: flex,
-      [s.solidTopBorder]: border === 'solid',
-      [s.dashedTopBorder]: border === 'dashed',
-      [s.transparentTopBorder]: border === 'none',
-      [s.leftAlign]: align === 'left',
-      [s.centerAlign]: align === 'center',
-      [s.rightAlign]: align === 'right',
-      [s.standardPadding]: standardPadding,
-      [s.standardHeight]: standardHeight,
+      [styles.flex]: flex,
+      [styles.solidTopBorder]: border === 'solid',
+      [styles.dashedTopBorder]: border === 'dashed',
+      [styles.transparentTopBorder]: border === 'none',
+      [styles.leftAlign]: align === 'left',
+      [styles.centerAlign]: align === 'center',
+      [styles.rightAlign]: align === 'right',
+      [styles.standardPadding]: standardPadding,
+      [styles.standardHeight]: standardHeight,
     },
     className
   );

--- a/packages/gamut/src/Card/CardShell.tsx
+++ b/packages/gamut/src/Card/CardShell.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/CardShell.module.scss';
+import styles from './styles/CardShell.module.scss';
 
 const defaultProps = {
   hoverShadow: false,
@@ -16,9 +16,9 @@ export type CardShellProps = HTMLAttributes<HTMLDivElement> & {
 export const CardShell = React.forwardRef<HTMLDivElement, CardShellProps>(
   ({ children, hoverShadow, className, ...props }, ref) => {
     const shellClasses = cx(
-      s.shell,
+      styles.shell,
       {
-        [s.hoverShadow]: hoverShadow,
+        [styles.hoverShadow]: hoverShadow,
       },
       className
     );

--- a/packages/gamut/src/ContentContainer/index.tsx
+++ b/packages/gamut/src/ContentContainer/index.tsx
@@ -1,7 +1,7 @@
 import cx from 'classnames';
 import React, { ReactHTML } from 'react';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type ContentContainerProps = {
   className?: string;
@@ -24,9 +24,9 @@ export const ContentContainer: React.FC<ContentContainerProps> = ({
   const Element = el || 'div';
   const classes = cx(
     {
-      [s.contentContainerWide]: wide,
+      [styles.contentContainerWide]: wide,
     },
-    s.contentContainer,
+    styles.contentContainer,
     className
   );
 

--- a/packages/gamut/src/DeprecatedTabs/index.tsx
+++ b/packages/gamut/src/DeprecatedTabs/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Children, ReactNode } from 'react';
 import { TabList, Tab, TabPanel, Wrapper } from 'react-aria-tabpanel';
 
-import s from './styles/index.module.scss';
+import styles from './styles/index.module.scss';
 
 export interface DeprecatedTabsProps {
   config: {
@@ -46,17 +46,17 @@ export class DeprecatedTabs extends Component<
       100;
 
     return (
-      <TabList className={s.tabList}>
+      <TabList className={styles.tabList}>
         {this.props.config.map((c, i) => {
           const key = this.createId(i);
           return (
             <Tab
               id={key}
               key={key}
-              className={`${s.tab} ${
+              className={`${styles.tab} ${
                 this.props.animatedUnderlineStyle
-                  ? s.animatedUnderline
-                  : s.traditional
+                  ? styles.animatedUnderline
+                  : styles.traditional
               }`}
               active={key === activeTabId}
             >
@@ -66,7 +66,7 @@ export class DeprecatedTabs extends Component<
         })}
         {this.props.animatedUnderlineStyle && (
           <div
-            className={s.tabIndicator}
+            className={styles.tabIndicator}
             style={{
               left: `${leftPercent}%`,
               width: `${100 / this.props.config.length}%`,
@@ -80,7 +80,7 @@ export class DeprecatedTabs extends Component<
 
   renderTabPanels = (activeTabId: string) => (
     // render all tab panels, but only active tab panel contains anything
-    <div className={s.tabPanelContainer}>
+    <div className={styles.tabPanelContainer}>
       {this.props.config.map((c, i) => {
         const key = this.createId(i);
         const isActive = key === activeTabId;
@@ -89,7 +89,7 @@ export class DeprecatedTabs extends Component<
             tabId={key}
             key={key}
             active={isActive}
-            className={s.tabPanel}
+            className={styles.tabPanel}
           >
             {isActive || this.props.renderAllChildren ? (
               Children.toArray(this.props.children)[i]
@@ -125,7 +125,7 @@ export class DeprecatedTabs extends Component<
       <Wrapper
         onChange={this.onChange}
         activeTabId={activeTabId}
-        className={s.tabContainer}
+        className={styles.tabContainer}
       >
         {this.renderTabList(activeTabId)}
         {this.renderTabPanels(activeTabId)}

--- a/packages/gamut/src/FlexBox/Container.tsx
+++ b/packages/gamut/src/FlexBox/Container.tsx
@@ -1,7 +1,7 @@
 import { isNumber, omit } from 'lodash';
 import React, { ReactNode, HTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/index.module.scss';
+import styles from './styles/index.module.scss';
 
 const internalProps = [
   'flex',
@@ -79,22 +79,22 @@ export class Container extends React.Component<ContainerProps> {
 
   render() {
     const classes = cx(this.props.className, {
-      [s.flex]: this.props.flex && !this.props.inline,
-      [s.inline]: this.props.flex && this.props.inline,
-      [s.fld]: isNumber(this.props.grow) || isNumber(this.props.shrink),
-      [s[`flg-${this.props.grow}`]]: isNumber(this.props.grow),
-      [s[`fls-${this.props.shrink}`]]: isNumber(this.props.shrink),
-      [s.row]: this.props.row,
-      [s.col]: this.props.column,
-      [s.wrap]: this.props.wrap,
-      [s.nowrap]: this.props.nowrap,
-      [s.rev]: this.props.reverse,
-      [s.fit]: this.props.fit,
-      [s['align-center']]: this.props.center && !this.props.align,
-      [s['justify-center']]: this.props.center && !this.props.justify,
-      [s[`align-${this.props.align}`]]: !!this.props.align,
-      [s[`justify-${this.props.justify}`]]: !!this.props.justify,
-      [s[`aself-${this.props.alignSelf}`]]: !!this.props.alignSelf,
+      [styles.flex]: this.props.flex && !this.props.inline,
+      [styles.inline]: this.props.flex && this.props.inline,
+      [styles.fld]: isNumber(this.props.grow) || isNumber(this.props.shrink),
+      [styles[`flg-${this.props.grow}`]]: isNumber(this.props.grow),
+      [styles[`fls-${this.props.shrink}`]]: isNumber(this.props.shrink),
+      [styles.row]: this.props.row,
+      [styles.col]: this.props.column,
+      [styles.wrap]: this.props.wrap,
+      [styles.nowrap]: this.props.nowrap,
+      [styles.rev]: this.props.reverse,
+      [styles.fit]: this.props.fit,
+      [styles['align-center']]: this.props.center && !this.props.align,
+      [styles['justify-center']]: this.props.center && !this.props.justify,
+      [styles[`align-${this.props.align}`]]: !!this.props.align,
+      [styles[`justify-${this.props.justify}`]]: !!this.props.justify,
+      [styles[`aself-${this.props.alignSelf}`]]: !!this.props.alignSelf,
     });
 
     const propsToTransfer = omit(this.props, internalProps);

--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, InputHTMLAttributes } from 'react';
-import s from './styles/Checkbox.module.scss';
+import styles from './styles/Checkbox.module.scss';
 import cx from 'classnames';
 
 export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
@@ -21,28 +21,33 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
       <input
         id={id || htmlFor}
         type="checkbox"
-        className={s.invisible}
+        className={styles.invisible}
         {...rest}
         ref={ref}
       />
-      <label className={s.checkboxLabel} htmlFor={id || htmlFor}>
-        <div className={cx(s.checkbox, multiline && s.checkboxMultiline)}>
+      <label className={styles.checkboxLabel} htmlFor={id || htmlFor}>
+        <div
+          className={cx(styles.checkbox, multiline && styles.checkboxMultiline)}
+        >
           <svg
             width="24px"
             height="24px"
             viewBox="0 0 20 20"
-            className={s.checkboxVector}
+            className={styles.checkboxVector}
           >
             <path
               d="M3,1 L17,1 L17,1 C18.1045695,1 19,1.8954305 19,3 L19,17 L19,17 C19,18.1045695 18.1045695,19 17,19 L3,19 L3,19 C1.8954305,19 1,18.1045695 1,17 L1,3 L1,3 C1,1.8954305 1.8954305,1 3,1 Z"
-              className={s.squareVector}
+              className={styles.squareVector}
               fill="none"
             />
-            <polyline points="4 11 8 15 16 6" className={s.checkVector} />
+            <polyline points="4 11 8 15 16 6" className={styles.checkVector} />
           </svg>
         </div>
         <span
-          className={cx(s.checkboxText, multiline && s.checkboxTextMultiline)}
+          className={cx(
+            styles.checkboxText,
+            multiline && styles.checkboxTextMultiline
+          )}
         >
           {label}
         </span>

--- a/packages/gamut/src/Form/Form.tsx
+++ b/packages/gamut/src/Form/Form.tsx
@@ -1,13 +1,13 @@
 import React, { FormHTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/Form.module.scss';
+import styles from './styles/Form.module.scss';
 
 export type FormProps = FormHTMLAttributes<HTMLFormElement> & {
   className?: string;
 };
 
 export const Form: React.FC<FormProps> = ({ method = 'post', ...props }) => {
-  const className = cx(s.Form, props.className);
+  const className = cx(styles.Form, props.className);
 
   return <form {...props} method={method} className={className} />;
 };

--- a/packages/gamut/src/Form/FormError.tsx
+++ b/packages/gamut/src/Form/FormError.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/FormError.module.scss';
+import styles from './styles/FormError.module.scss';
 
 export const FormError: React.FC<HTMLAttributes<HTMLSpanElement>> = (props) => {
-  return <span className={cx(s.formError, props.className)} {...props} />;
+  return <span className={cx(styles.formError, props.className)} {...props} />;
 };

--- a/packages/gamut/src/Form/FormGroup.tsx
+++ b/packages/gamut/src/Form/FormGroup.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/FormGroup.module.scss';
+import styles from './styles/FormGroup.module.scss';
 import { FormGroupDescription } from './FormGroupDescription';
 import { FormGroupLabel } from './FormGroupLabel';
 
@@ -19,7 +19,7 @@ export const FormGroup: React.FC<FormGroupProps> = ({
   className,
   ...rest
 }) => {
-  const classNames = cx(s.FormGroup, className);
+  const classNames = cx(styles.FormGroup, className);
 
   const labelComponent = label ? (
     <FormGroupLabel htmlFor={htmlFor}>{label}</FormGroupLabel>

--- a/packages/gamut/src/Form/FormGroupDescription.tsx
+++ b/packages/gamut/src/Form/FormGroupDescription.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
-import s from './styles/FormGroupDescription.module.scss';
+import styles from './styles/FormGroupDescription.module.scss';
 
 export type FormGroupDescriptionProps = React.HTMLAttributes<HTMLDivElement> & {
   className?: string;
@@ -9,6 +9,6 @@ export type FormGroupDescriptionProps = React.HTMLAttributes<HTMLDivElement> & {
 export const FormGroupDescription: React.FC<FormGroupDescriptionProps> = (
   props
 ) => {
-  const className = cx(s.FormGroupDescription, props.className);
+  const className = cx(styles.FormGroupDescription, props.className);
   return <div {...props} className={className} />;
 };

--- a/packages/gamut/src/Form/FormGroupLabel.tsx
+++ b/packages/gamut/src/Form/FormGroupLabel.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/FormGroupLabel.module.scss';
+import styles from './styles/FormGroupLabel.module.scss';
 
 export type FormGroupLabelProps = FormGroupLabelPropsWithFor &
   FormGroupLabelPropsPlain;
@@ -19,7 +19,7 @@ export const FormGroupLabel: React.FC<FormGroupLabelProps> = ({
   className,
   ...rest
 }) => {
-  const classNames = cx(s.FormGroupLabel, className);
+  const classNames = cx(styles.FormGroupLabel, className);
 
   if (htmlFor) {
     return <label {...rest} htmlFor={htmlFor} className={classNames} />;

--- a/packages/gamut/src/Form/Input.tsx
+++ b/packages/gamut/src/Form/Input.tsx
@@ -1,6 +1,6 @@
 import React, { InputHTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/Input.module.scss';
+import styles from './styles/Input.module.scss';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
   className?: string;
@@ -15,12 +15,12 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ error, htmlFor, className, id, ...rest }, ref) => {
     const classNames = cx(
-      s.Input,
+      styles.Input,
       {
-        [s.fileInput]: rest.type === 'file',
+        [styles.fileInput]: rest.type === 'file',
       },
       {
-        [s.error]: error,
+        [styles.error]: error,
       },
       className
     );

--- a/packages/gamut/src/Form/Radio.tsx
+++ b/packages/gamut/src/Form/Radio.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, InputHTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/Radio.module.scss';
+import styles from './styles/Radio.module.scss';
 
 export type RadioProps = InputHTMLAttributes<HTMLInputElement> & {
   checked?: boolean;
@@ -33,14 +33,14 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
     },
     ref
   ) => {
-    const classNames = cx(s.Radio, className);
+    const classNames = cx(styles.Radio, className);
 
     const inputId = id ? `${htmlFor}-${id}` : htmlFor;
 
     return (
       <div className={classNames}>
         <input
-          className={s.radioInput}
+          className={styles.radioInput}
           id={inputId}
           name={name}
           required={required}
@@ -52,7 +52,7 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
           value={value}
           {...rest}
         />
-        <label htmlFor={htmlFor} className={s.radioLabel}>
+        <label htmlFor={htmlFor} className={styles.radioLabel}>
           {label}
         </label>
       </div>

--- a/packages/gamut/src/Form/Select.tsx
+++ b/packages/gamut/src/Form/Select.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, SelectHTMLAttributes } from 'react';
 import { isArray, isObject, each } from 'lodash';
 import cx from 'classnames';
-import s from './styles/Select.module.scss';
+import styles from './styles/Select.module.scss';
 
 export type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
   error?: boolean;
@@ -12,7 +12,11 @@ export type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
 
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   (props, ref) => {
-    const className = cx(s.Select, props.className, props.error && s.error);
+    const className = cx(
+      styles.Select,
+      props.className,
+      props.error && styles.error
+    );
     const { options, error, id, ...rest } = props;
 
     let selectOptions: ReactNode[] = [];
@@ -39,7 +43,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
 
     return (
       <div className={className}>
-        <svg className={s.selectIcon}>
+        <svg className={styles.selectIcon}>
           <path
             d="M1.175 0L5 3.825 8.825 0 10 1.183l-5 5-5-5z"
             fill="#3E3E40"
@@ -47,7 +51,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         </svg>
         <select
           {...rest}
-          className={s.selectInput}
+          className={styles.selectInput}
           defaultValue={props.defaultValue || ''}
           id={id || props.htmlFor}
           ref={ref}

--- a/packages/gamut/src/Form/TextArea.tsx
+++ b/packages/gamut/src/Form/TextArea.tsx
@@ -1,6 +1,6 @@
 import React, { TextareaHTMLAttributes } from 'react';
 import cx from 'classnames';
-import s from './styles/TextArea.module.scss';
+import styles from './styles/TextArea.module.scss';
 
 export type TextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   className?: string;
@@ -14,9 +14,9 @@ export type TextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ error, htmlFor, className, id, ...rest }, ref) => {
     const classNames = cx(
-      s.TextArea,
+      styles.TextArea,
       {
-        [s.error]: error,
+        [styles.error]: error,
       },
       className
     );

--- a/packages/gamut/src/Layout/Column.tsx
+++ b/packages/gamut/src/Layout/Column.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 
 import { generateResponsiveClassnames } from '../utils/generateResponsiveClassnames';
 import { ContainerElementProps, ColumnSizes, OffsetColumnSizes } from './types';
-import s from './styles/Column.module.scss';
+import styles from './styles/Column.module.scss';
 import {
   ResponsiveProperty,
   OptionalResponsiveProperty,
@@ -24,9 +24,9 @@ export const Column: React.FC<ColumnProps> = ({
   testId,
 }) => {
   const classNames = cx(
-    s.container,
+    styles.container,
     className,
-    generateResponsiveClassnames({ size, offset }, s)
+    generateResponsiveClassnames({ size, offset }, styles)
   );
   return (
     <div className={classNames} data-testid={testId}>

--- a/packages/gamut/src/Layout/LayoutGrid.tsx
+++ b/packages/gamut/src/Layout/LayoutGrid.tsx
@@ -5,7 +5,7 @@ import { generateResponsiveClassnames } from '../utils/generateResponsiveClassna
 import { ContainerElementProps, GapSizes } from './types';
 import { ResponsiveProperty } from '../typings/responsive-properties';
 
-import s from './styles/Grid.module.scss';
+import styles from './styles/Grid.module.scss';
 
 export type LayoutGridProps = {
   /** The grid-gap size that should be present between rows */
@@ -22,9 +22,9 @@ export const LayoutGrid: React.FC<Partial<LayoutGridProps>> = ({
   columnGap,
 }) => {
   const classes = cx(
-    s.container,
+    styles.container,
     className,
-    generateResponsiveClassnames({ rowGap, columnGap }, s)
+    generateResponsiveClassnames({ rowGap, columnGap }, styles)
   );
 
   return (

--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -21,7 +21,7 @@ const htmlToReactParser = new HtmlToReact.Parser({
   xmlMode: true,
 });
 
-const preprocessingInstructions = createPreprocessingInstructions(s);
+const preprocessingInstructions = createPreprocessingInstructions(styles);
 
 const isValidNode = function () {
   return true;

--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -12,7 +12,7 @@ import {
 } from './libs/overrides';
 import { defaultSanitizationConfig } from './libs/sanitizationConfig';
 import { createPreprocessingInstructions } from './libs/preprocessing';
-import s from './styles/index.module.scss';
+import styles from './styles/index.module.scss';
 import { Iframe } from './libs/overrides/Iframe';
 import { MarkdownAnchor } from './libs/overrides/MarkdownAnchor';
 import { Table } from './libs/overrides/Table';
@@ -55,7 +55,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
 
     if (!text) return null;
 
-    const spacingStyles = s[`spacing-${spacing}`];
+    const spacingStyles = styles[`spacing-${spacing}`];
     const classes = cx(spacingStyles, className);
 
     const Wrapper = inline ? 'span' : 'div';

--- a/packages/gamut/src/Markdown/libs/overrides/Iframe/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/Iframe/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/iframe-has-title */
 import React, { HTMLAttributes, FunctionComponent } from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export interface IframeProps extends HTMLAttributes<HTMLIFrameElement> {
   src?: string;
@@ -27,7 +27,7 @@ export const Iframe: FunctionComponent<IframeProps> = (props) => {
     };
     return (
       <div
-        className={s.youtubeVideoWrapper}
+        className={styles.youtubeVideoWrapper}
         data-testid="yt-iframe"
         style={wrapperStyles}
       >

--- a/packages/gamut/src/Markdown/libs/overrides/Table/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/Table/index.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export interface TableProps extends HTMLAttributes<HTMLTableElement> {
   maxHeight?: number | string;
@@ -7,7 +7,7 @@ export interface TableProps extends HTMLAttributes<HTMLTableElement> {
 
 export const Table: React.FC<TableProps> = ({ maxHeight, ...props }) => {
   return (
-    <div className={s.tableWrapper} style={{ maxHeight }}>
+    <div className={styles.tableWrapper} style={{ maxHeight }}>
       <table {...props} />
     </div>
   );

--- a/packages/gamut/src/Menus/MenuItem/__tests__/MenuItem-test.tsx
+++ b/packages/gamut/src/Menus/MenuItem/__tests__/MenuItem-test.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import { MenuItem } from '../index';
-import s from '../styles.module.scss';
+import styles from '../styles.module.scss';
 
 describe('MenuItem', () => {
   test.each([
@@ -11,6 +11,6 @@ describe('MenuItem', () => {
   ])('selected class is %d when selected is %d', (selected, hasClass) => {
     const component = mount(<MenuItem selected={selected} />);
 
-    expect(component.find('li').hasClass(s.selected)).toBe(hasClass);
+    expect(component.find('li').hasClass(styles.selected)).toBe(hasClass);
   });
 });

--- a/packages/gamut/src/Menus/MenuItem/index.tsx
+++ b/packages/gamut/src/Menus/MenuItem/index.tsx
@@ -2,7 +2,7 @@ import cx from 'classnames';
 import React from 'react';
 
 import { ChildComponentDescriptor } from '../../typings/react';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type AsProps = {
   className?: string;
@@ -33,10 +33,10 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   selected,
   children,
 }) => {
-  const childClassName = cx(s.link, asProps.className);
+  const childClassName = cx(styles.link, asProps.className);
 
   return (
-    <li className={cx(s.menuItem, { [s.selected]: selected })}>
+    <li className={cx(styles.menuItem, { [styles.selected]: selected })}>
       <As {...asProps} className={childClassName}>
         {children}
       </As>

--- a/packages/gamut/src/Menus/SideMenu/index.tsx
+++ b/packages/gamut/src/Menus/SideMenu/index.tsx
@@ -1,12 +1,12 @@
 import cx from 'classnames';
 import React from 'react';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type SideMenuProps = {
   className?: string;
 };
 
 export const SideMenu: React.FC<SideMenuProps> = ({ children, className }) => {
-  return <ul className={cx(s.sideMenu, className)}>{children}</ul>;
+  return <ul className={cx(styles.sideMenu, className)}>{children}</ul>;
 };

--- a/packages/gamut/src/NotificationList/NotificationIcon.tsx
+++ b/packages/gamut/src/NotificationList/NotificationIcon.tsx
@@ -3,7 +3,7 @@ import { get } from 'lodash';
 import { Icon } from '../deprecated/Icon';
 import { NotificationIconSettings } from './typings';
 import { iconMap } from '../deprecated/Icon/iconMap';
-import s from './styles/NotificationIcon.module.scss';
+import styles from './styles/NotificationIcon.module.scss';
 
 const renderIcon = (props: NotificationIconProps) => {
   const { iconSettings, iconSlug, imageUrl } = props;
@@ -18,14 +18,14 @@ const renderIcon = (props: NotificationIconProps) => {
     };
 
     return (
-      <div className={s.iconComponentContainer} style={iconStyle}>
-        <Icon name={iconSlug} className={s.iconImage} />
+      <div className={styles.iconComponentContainer} style={iconStyle}>
+        <Icon name={iconSlug} className={styles.iconImage} />
       </div>
     );
   }
 
   if (imageUrl) {
-    return <img src={imageUrl} className={s.icon} alt="" />;
+    return <img src={imageUrl} className={styles.icon} alt="" />;
   }
 
   return null;
@@ -38,5 +38,5 @@ export type NotificationIconProps = {
 };
 
 export const NotificationIcon: React.FC<NotificationIconProps> = (props) => (
-  <div className={s.iconContainer}>{renderIcon(props)}</div>
+  <div className={styles.iconContainer}>{renderIcon(props)}</div>
 );

--- a/packages/gamut/src/NotificationList/NotificationItem.tsx
+++ b/packages/gamut/src/NotificationList/NotificationItem.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { Truncate } from '../Truncate';
 import { Notification } from './typings';
 import { NotificationIcon } from './NotificationIcon';
-import s from './styles/Notification.module.scss';
+import styles from './styles/Notification.module.scss';
 
 export type NotificationItemProps = {
   onClick?: (event: object) => void;
@@ -27,8 +27,8 @@ export const NotificationItem: React.FC<NotificationItemProps> = (props) => {
     unread,
   } = notification;
 
-  const notificationClasses = cx(s.notification, {
-    [s.unread]: unread,
+  const notificationClasses = cx(styles.notification, {
+    [styles.unread]: unread,
   });
 
   const [TagName, tagProps] = link
@@ -49,11 +49,11 @@ export const NotificationItem: React.FC<NotificationItemProps> = (props) => {
         iconSlug={iconSlug}
         imageUrl={imageUrl}
       />
-      <div className={s.body}>
-        <div className={s.text}>
+      <div className={styles.body}>
+        <div className={styles.text}>
           <Truncate lines={3}>{text}</Truncate>
         </div>
-        <div className={s.time}>{formatTime(date)}</div>
+        <div className={styles.time}>{formatTime(date)}</div>
       </div>
     </TagName>
   );

--- a/packages/gamut/src/NotificationList/index.tsx
+++ b/packages/gamut/src/NotificationList/index.tsx
@@ -4,7 +4,7 @@ import { isEmpty } from 'lodash';
 import { omitProps } from '../utils/omitProps';
 import { Notification } from './typings';
 import { NotificationItem } from './NotificationItem';
-import s from './styles/index.module.scss';
+import styles from './styles/index.module.scss';
 
 const byDate = (notification1: Notification, notification2: Notification) => {
   return (
@@ -32,8 +32,8 @@ export const NotificationList = (props: NotificationListProps) => {
     maxNotifications
   );
   const notificationClasses = cx(
-    s.notificationsContainer,
-    { [s.emptyContainer]: isEmpty(notifications) },
+    styles.notificationsContainer,
+    { [styles.emptyContainer]: isEmpty(notifications) },
     className
   );
 
@@ -43,7 +43,7 @@ export const NotificationList = (props: NotificationListProps) => {
       className={notificationClasses}
     >
       {isEmpty(notifications) ? (
-        <button className={s.emptyText} type="button">
+        <button className={styles.emptyText} type="button">
           {'No new notifications.'}
           <br />
           {"You're all caught up!"}

--- a/packages/gamut/src/Tabs/Tab/index.tsx
+++ b/packages/gamut/src/Tabs/Tab/index.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, FunctionComponent } from 'react';
 
 import { omitProps } from '../../utils/omitProps';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type TabProps = {
   active?: boolean;
@@ -29,12 +29,12 @@ export const Tab: FunctionComponent<TabProps> = ({
   tabIndex = 0,
   ...rest
 }: TabProps) => {
-  const tabClasses = cx(s.tab, className, {
-    [s.tab_default]: defaultTheme,
-    [s.active]: active,
-    [s.tab_default__active]: defaultTheme && active,
+  const tabClasses = cx(styles.tab, className, {
+    [styles.tab_default]: defaultTheme,
+    [styles.active]: active,
+    [styles.tab_default__active]: defaultTheme && active,
     [activeClassName!]: active && activeClassName,
-    [s.disabled]: disabled,
+    [styles.disabled]: disabled,
   });
   const dataPropsToTransfer = omitProps([], rest);
 

--- a/packages/gamut/src/Tabs/TabList/index.tsx
+++ b/packages/gamut/src/Tabs/TabList/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, FunctionComponent, ReactNode } from 'react';
 import cx from 'classnames';
 import { Tab } from '../Tab';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type TabListProps = {
   activeTabIndex?: number;
@@ -28,7 +28,7 @@ export const TabList: FunctionComponent<TabListProps> = ({
   maxWidth,
   onChange,
 }) => {
-  const classes = cx(s.tabList, className, { [s.center]: center });
+  const classes = cx(styles.tabList, className, { [styles.center]: center });
   return (
     <div className={classes} role="tablist" style={{ maxWidth }}>
       {(React.Children.toArray(children) as any)

--- a/packages/gamut/src/Tabs/TabPanel/index.tsx
+++ b/packages/gamut/src/Tabs/TabPanel/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, FunctionComponent } from 'react';
 import cx from 'classnames';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export type TabPanelProps = {
   active?: boolean;
@@ -25,8 +25,8 @@ export const TabPanel: FunctionComponent<TabPanelProps> = ({
     aria-hidden={!active}
     role="tabpanel"
     className={cx(className, {
-      [s.active]: active,
-      [s.hidden]: !active,
+      [styles.active]: active,
+      [styles.hidden]: !active,
     })}
   >
     {active || renderAllPanels ? children : null}

--- a/packages/gamut/src/Toggle/index.tsx
+++ b/packages/gamut/src/Toggle/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import cx from 'classnames';
-import s from './styles/index.module.scss';
+import styles from './styles/index.module.scss';
 
 export type ToggleProps = {
   checked?: boolean;
@@ -23,9 +23,9 @@ export class Toggle extends Component<ToggleProps, {}> {
     } = this.props;
     return (
       <label
-        className={cx(s.toggleButton, {
-          [s.toggled]: checked,
-          [s.disabled]: disabled,
+        className={cx(styles.toggleButton, {
+          [styles.toggled]: checked,
+          [styles.disabled]: disabled,
         })}
         arial-label={label}
         htmlFor={label}
@@ -33,14 +33,16 @@ export class Toggle extends Component<ToggleProps, {}> {
         <input
           type="checkbox"
           checked={checked}
-          className={s.invisible}
+          className={styles.invisible}
           id={label}
           disabled={disabled}
           onChange={onChange}
         />
-        <span className={s.invisible}>{label}</span>
-        <div className={cx(s.track, s[theme], s[`track-${size}`])} />
-        <div className={cx(s.thumb, s[`thumb-${size}`])} />
+        <span className={styles.invisible}>{label}</span>
+        <div
+          className={cx(styles.track, styles[theme], styles[`track-${size}`])}
+        />
+        <div className={cx(styles.thumb, styles[`thumb-${size}`])} />
       </label>
     );
   }

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import cx from 'classnames';
 import { CardBody } from '../Card';
 import { VisualTheme } from '../theming/VisualTheme';
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 export enum ToolTipPosition {
   BottomLeft = 'bottom-left',
@@ -37,10 +37,10 @@ export const ToolTip: React.FC<ToolTipProps> = ({
   wrapperClassName,
 }) => {
   return (
-    <div className={cx(s.toolTipWrapper, wrapperClassName)}>
+    <div className={cx(styles.toolTipWrapper, wrapperClassName)}>
       <div
         aria-labelledby={id}
-        className={s.targetContainer}
+        className={styles.targetContainer}
         // ToolTips sometimes contain actual <button>s, which cannot be a child of a button.
         // This element still needs tab focus so we must use the `tabIndex=0` hack. Sigh.
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
@@ -50,17 +50,17 @@ export const ToolTip: React.FC<ToolTipProps> = ({
       </div>
       <div
         className={cx(
-          s.toolTipContainer,
-          s[position],
+          styles.toolTipContainer,
+          styles[position],
           theme === VisualTheme.DarkMode
-            ? s.toolTipContainerDark
-            : s.toolTipContainerLight,
+            ? styles.toolTipContainerDark
+            : styles.toolTipContainerLight,
           tipClassName
         )}
         role="tooltip"
         id={id}
       >
-        <CardBody className={s.toolTipBody}>{children}</CardBody>
+        <CardBody className={styles.toolTipBody}>{children}</CardBody>
       </div>
     </div>
   );

--- a/packages/gamut/src/Truncate/index.tsx
+++ b/packages/gamut/src/Truncate/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TruncateMarkup from 'react-truncate-markup';
 import cx from 'classnames';
 
-import s from './styles.module.scss';
+import styles from './styles.module.scss';
 
 type TruncateProps = {
   /** element for the component */
@@ -24,7 +24,7 @@ export const Truncate: React.FC<TruncateProps> = ({
 }) => {
   /** Truncate markup expects a single child element */
   const content = (
-    <Element className={cx(s.wrapper, className)}>{children}</Element>
+    <Element className={cx(styles.wrapper, className)}>{children}</Element>
   );
 
   /** If lines is false do not attempt to truncate */

--- a/packages/gamut/src/Typography/Heading.tsx
+++ b/packages/gamut/src/Typography/Heading.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-import s from './styles/Heading.module.scss';
+import styles from './styles/Heading.module.scss';
 import { ContainerElementProps } from '../Layout/types';
 import { generateResponsiveClassnames } from '../utils/generateResponsiveClassnames';
 import { ResponsiveProperty } from '../typings/responsive-properties';
@@ -33,11 +33,11 @@ export const Heading: React.FC<HeadingProps> = ({
   return (
     <Element
       className={cx(
-        s.heading,
+        styles.heading,
         className,
-        generateResponsiveClassnames({ fontSize }, s),
+        generateResponsiveClassnames({ fontSize }, styles),
         {
-          [s.hideMargin]: hideMargin,
+          [styles.hideMargin]: hideMargin,
         }
       )}
       data-testid={testId}

--- a/packages/gamut/src/Typography/Text.tsx
+++ b/packages/gamut/src/Typography/Text.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-import s from './styles/Text.module.scss';
+import styles from './styles/Text.module.scss';
 import { ContainerElementProps } from '../Layout/types';
 import { generateResponsiveClassnames } from '../utils/generateResponsiveClassnames';
 import { ResponsiveProperty } from '../typings/responsive-properties';
@@ -30,9 +30,9 @@ export const Text: React.FC<TextProps> = ({
   return (
     <Element
       className={cx(
-        s.text,
+        styles.text,
         className,
-        generateResponsiveClassnames({ fontSize }, s)
+        generateResponsiveClassnames({ fontSize }, styles)
       )}
       data-testid={testId}
       style={style}


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: WEB-947
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

Per the [Updated Jest, React, and Redux Preferences RFC](https://www.notion.so/codecademy/Updated-React-Redux-and-Jest-Preferences-207154440e25476b93d4f41ad48728e6), renames our `s` style imports to `styles`. This isn't exactly high priority work but it's part of a larger goal of standardizing our code approaches to reduce confusing variance across files.