### PR TITLE
fix(system): Fix color property WEB-1112

### DIFF
--- a/packages/gamut-system/src/core/system/__tests__/system-test.ts
+++ b/packages/gamut-system/src/core/system/__tests__/system-test.ts
@@ -14,9 +14,9 @@ describe(system, () => {
   describe('variant', () => {
     it('returns a style function with a propKey of variant by default', () => {
       const myVariant = variant({
-        primary: { color: 'blue' },
+        primary: { textColor: 'blue' },
         secondary: {
-          color: 'green',
+          textColor: 'green',
           backgroundColor: 'green',
           fontFamily: 'serif',
         },
@@ -29,8 +29,8 @@ describe(system, () => {
       const myVariant = variant({
         prop: 'colorVariant',
         variants: {
-          primary: { color: 'blue' },
-          secondary: { color: 'green' },
+          primary: { textColor: 'blue' },
+          secondary: { textColor: 'green' },
         },
       });
 

--- a/packages/gamut-system/src/core/system/index.ts
+++ b/packages/gamut-system/src/core/system/index.ts
@@ -51,9 +51,9 @@ export const system = <Config extends SystemConfig<{}>>(
         .reduce((carry, variant) => carry.concat(keys(variant)), [])
         .map((prop: string) => getDefaultPropKey(prop))
     );
-
     // Pick the correct handlers from the system (closure specific) and create a composite.
     const handlers = pick(systemShape.properties, props as any);
+
     const variantHandler = compose(...(values(handlers) as any));
 
     // Return the variant function

--- a/packages/gamut-system/src/props/colors.ts
+++ b/packages/gamut-system/src/props/colors.ts
@@ -1,6 +1,7 @@
 export const colors = {
-  color: {
-    propName: 'color',
+  textColor: {
+    propName: 'textColor',
+    property: 'color',
   },
   borderColor: {
     propName: 'borderColor',

--- a/packages/gamut-system/src/styleTemplates/createStandardStyleTemplate/__tests__/createStandardStyleTemplate-test.ts
+++ b/packages/gamut-system/src/styleTemplates/createStandardStyleTemplate/__tests__/createStandardStyleTemplate-test.ts
@@ -118,14 +118,13 @@ describe(createStandardStyleTemplate, () => {
   });
 
   it('can have a property used instead of propName', () => {
-    const theme = { spacing: [10, 20] };
     const styleTemplate = createStandardStyleTemplate({
       propName: 'textColor',
       property: 'color',
       transformValue: (val) => val,
     });
 
-    const themeValues = styleTemplate({ textColor: 'green', theme });
+    const themeValues = styleTemplate({ textColor: 'green' });
     expect(themeValues).toEqual({ color: 'green' });
   });
 });

--- a/packages/gamut-system/src/styleTemplates/createStandardStyleTemplate/__tests__/createStandardStyleTemplate-test.ts
+++ b/packages/gamut-system/src/styleTemplates/createStandardStyleTemplate/__tests__/createStandardStyleTemplate-test.ts
@@ -116,4 +116,16 @@ describe(createStandardStyleTemplate, () => {
     const themeValues = styleTemplate({ margin: 'sms', theme });
     expect(themeValues).toEqual({ margin: 'sms' });
   });
+
+  it('can have a property used instead of propName', () => {
+    const theme = { spacing: [10, 20] };
+    const styleTemplate = createStandardStyleTemplate({
+      propName: 'textColor',
+      property: 'color',
+      transformValue: (val) => val,
+    });
+
+    const themeValues = styleTemplate({ textColor: 'green', theme });
+    expect(themeValues).toEqual({ color: 'green' });
+  });
 });

--- a/packages/gamut-system/src/styleTemplates/createStandardStyleTemplate/index.ts
+++ b/packages/gamut-system/src/styleTemplates/createStandardStyleTemplate/index.ts
@@ -12,7 +12,7 @@ export const createStandardStyleTemplate = <
 >(
   config: Config
 ): StyleTemplate<Props> => {
-  const { propName: prop, transformValue } = config;
+  const { property, propName: prop, transformValue } = config;
   const getScaleFunction = createScaleValueTransformer(config);
 
   return (props: Props) => {
@@ -21,7 +21,7 @@ export const createStandardStyleTemplate = <
 
     return propValue !== undefined
       ? {
-          [prop]: transformValue(propValue),
+          [property || prop]: transformValue(propValue),
         }
       : propValue;
   };

--- a/packages/gamut-system/src/types/config.ts
+++ b/packages/gamut-system/src/types/config.ts
@@ -1,4 +1,9 @@
-import { Property, Properties, DirectionalProperty } from './properties';
+import {
+  PropName,
+  Property,
+  Properties,
+  DirectionalProperty,
+} from './properties';
 import { CSSObject } from '@emotion/core';
 import { SafeLookup, SafeMapKey, WeakRecord } from './utils';
 
@@ -47,7 +52,8 @@ export type ThematicScaleValue<
 /** Property Configurations */
 
 export type AbstractPropertyConfig = {
-  propName: Property;
+  propName: PropName;
+  property?: Property;
   dependentProps?: Readonly<string[]>;
   type?: 'standard' | 'directional';
   scale?: AnyScale;

--- a/packages/gamut-system/src/types/properties.ts
+++ b/packages/gamut-system/src/types/properties.ts
@@ -219,7 +219,8 @@ export type Properties = {
   };
 
   /** Colors */
-  color: {
+  textColor: {
+    property: 'color';
     defaultScale: CSS.Properties['color'];
   };
   borderColor: {
@@ -243,7 +244,11 @@ export type PropertyUnion = {
   } & Properties[P];
 }[keyof Properties];
 
-export type Property = keyof Properties;
+export type PropName = PropertyUnion['propName'];
+
+export type Property =
+  | Exclude<PropertyUnion, { property: string }>['propName']
+  | Extract<PropertyUnion, { property: string }>['property'];
 
 export type DirectionalProperty = Extract<
   PropertyUnion,


### PR DESCRIPTION
## Overview
`color` as a propname can conflict with some HTML / Intrinsic attributes.  This changes the propName at the API level to be more declarative as `textColor` while still using the correct css property.

Added:
- An extra field to config object to specify the correct property and type. 
- Updated standard config to use the property if available and default to propName if not configured.
- Test to ensure that this forwarding works.


### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: WEB-1112
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

