### PR TITLE
feat(Button): Add stop gap theme keys for common new button colors  WEB-1126

### DIFF
--- a/packages/gamut/src/Button/styles/variables.scss
+++ b/packages/gamut/src/Button/styles/variables.scss
@@ -34,13 +34,14 @@ $btn-disabled-color: $color-gray-600;
 $btn-box-shadow-color: rgba(0, 0, 0, 0.3);
 
 $btn-swatches: (
-  "mint": $deprecated-swatches-mint-700,
-  "darkmint": $deprecated-swatches-mint-800,
-  "grey": $color-gray-300,
-  "greyblue": $deprecated-swatches-grey-blue-600,
+  // Gamut Next
+  "hyper": $color-hyper,
+  "red": $color-red,
+  "navy": $color-navy,
   "white": $color-white,
-  "royalblue": $deprecated-gamut-royal-blue,
-  "purple": $deprecated-gamut-purple,
+  // Gamut Classic
+  "grey": $color-gray-300,
+  "brand-blue": $color-blue-500,
   "brand-red": $brand-red,
   "brand-orange": $brand-orange,
   "brand-yellow": $brand-yellow,
@@ -49,7 +50,12 @@ $btn-swatches: (
   "brand-mint": $brand-mint,
   "brand-beige": $brand-beige,
   "brand-dark-blue": $brand-dark-blue,
-  "brand-blue": $color-blue-500,
+  "mint": $deprecated-swatches-mint-700,
+  "darkmint": $deprecated-swatches-mint-800,
+  "greyblue": $deprecated-swatches-grey-blue-600,
+  "royalblue": $deprecated-gamut-royal-blue,
+  "purple": $deprecated-gamut-purple,
+  // Alerts
   "notice": $color-yellow-300,
   "error": $color-red-300,
   "announcement": $color-purple-300,

--- a/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
@@ -10,6 +10,7 @@ import { action } from '@storybook/addon-actions';
 import { select, text, boolean } from '@storybook/addon-knobs';
 import {
   themes,
+  newThemeKeys,
   brandThemeKeys,
   statusThemeKeys,
   deprecatedThemeKeys,
@@ -55,6 +56,25 @@ Play with this button, if you&apos;d like!
 ## Themes
 
 There are several theme sets you can use with `Button`
+
+### New
+
+<Canvas columns={1}>
+  <Story name="New Buttons">
+    {(args) =>
+      newThemeKeys.map((theme) => (
+        <Button
+          key={`${theme}`}
+          onClick={action('Clicked Button')}
+          style={{ margin: '1rem' }}
+          theme={theme}
+        >
+          {theme}
+        </Button>
+      ))
+    }
+  </Story>
+</Canvas>
 
 ### Brand
 

--- a/packages/styleguide/stories/Core/Atoms/Button/helpers.tsx
+++ b/packages/styleguide/stories/Core/Atoms/Button/helpers.tsx
@@ -1,4 +1,6 @@
 import { buttonPresetThemes } from '@codecademy/gamut/src';
+export const newThemeKeys = ['hyper', 'navy', 'red'];
+
 export const brandThemeKeys = [
   'brand-red',
   'brand-orange',


### PR DESCRIPTION
## Overview

Small change to prevent any weird workarounds with buttons and `styled` decorations due to `theme` being a reserved prop.

Note: this only adds the colors and no other style changes until all are finalized.

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/DIWmrLJ4iaesJH0mwvsiqV/Identity-Phase-1?node-id=0%3A1
- [x] Related to JIRA ticket:  WEB-1126
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
