### PR TITLE
feat: used withTheme and create APIs for system

### DIFF
--- a/packages/gamut-system/README.md
+++ b/packages/gamut-system/README.md
@@ -20,8 +20,6 @@ Checkout each section
 - [Customization](docs/customization.md)
 - [Compose](docs/compose.md)
 
-
-
 ## Usage
 
 Create your new system locally to your app:
@@ -31,7 +29,7 @@ import { system, HandlerProps } from '@codecademy/gamut-system';
 
 export const {
   propGroups: { typography, spacing, layout },
-} = system({});
+} = system.create({});
 
 export type TypographyProps = HandlerProps<typeof typography>;
 export type SpacingProps = HandlerProps<typeof spacing>;
@@ -79,4 +77,3 @@ export const Box = styled<BoxProps>`
 // Object syntax
 <Box margin={{ xs: 16, sm: 24, md: 32 }} />
 ```
-

--- a/packages/gamut-system/docs/customization.md
+++ b/packages/gamut-system/docs/customization.md
@@ -25,7 +25,7 @@ type AbstractPropertyConfig = {
 To use this you must pass a subset of the base config and its property definitions (propGroups and handlers):
 
 ```tsx
-export const { properties } = system({
+export const { properties } = system.create({
   typography: {
     fontSize: {
       propName: 'fontSize',
@@ -61,13 +61,15 @@ type ThemeShape = {
 }
 
 
-export const { properties }  = (system as ThemedSystem<ThemeShape>)({
-  typography: {
-    fontSize: {
-      propName: 'fontSize',
-      scale: 'fontSizes'
-  },
-});
+export const { properties } = system
+  .withTheme<ThemeShape>()
+  .create({
+    typography: {
+      fontSize: {
+        propName: 'fontSize',
+        scale: 'fontSizes'
+    },
+  });
 ```
 
 In your react code:

--- a/packages/gamut-system/docs/getting-started.md
+++ b/packages/gamut-system/docs/getting-started.md
@@ -26,7 +26,7 @@ export const {
   grid,
   properties,
   variants
-} = system({});
+} = system.create({});
 ```
 
 ## Using in a component

--- a/packages/gamut-system/docs/responsive.md
+++ b/packages/gamut-system/docs/responsive.md
@@ -87,14 +87,12 @@ const MyTheme = {
   }
 }
 
-const themedSystem = system as ThemedSystem<MyTheme>
-
 export const {
   layout,
   spacing,
   typography,
   variant
-} = themedSystem({});
+} = system.withTheme<MyTheme>().create({});
 
 export const Apps = ({ children }) => <ThemeProvider theme={MyTheme}>{children}</ThemeProvider>
 ```

--- a/packages/gamut-system/docs/variants.md
+++ b/packages/gamut-system/docs/variants.md
@@ -6,7 +6,7 @@ There may be cases where you want to change many props at the same time to achie
 import styled from '@emotion/styled';
 import { system, HandlerProps } from '@codecademy/gamut-system';
 
-export const { variants } = system({});
+export const { variants } = system.create({});
 
 const buttonVariants = variants({
   variants: {

--- a/packages/gamut-system/src/core/system/__tests__/emotion-components-test.tsx
+++ b/packages/gamut-system/src/core/system/__tests__/emotion-components-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { system, ThemedSystem } from '..';
+import { system } from '..';
 import render from 'react-test-renderer';
 import styled from '@emotion/styled';
 import { matchers } from 'jest-emotion';
@@ -11,7 +11,7 @@ expect.extend(matchers);
 
 describe('Styled components integration', () => {
   describe('base components', () => {
-    const { variant, typography } = system({});
+    const { variant, typography } = system.create({});
     const textVariants = variant({
       primary: { fontSize: '1rem', textColor: 'blue' },
       secondary: { fontSize: '0.85rem' },
@@ -63,7 +63,7 @@ describe('Styled components integration', () => {
       <ThemeProvider theme={theme}>{children}</ThemeProvider>
     );
 
-    const { variant, typography } = (system as ThemedSystem<ThemeShape>)({
+    const { variant, typography } = system.withTheme<ThemeShape>().create({
       typography: { fontSize: { propName: 'fontSize', scale: 'fontSizes' } },
     });
 

--- a/packages/gamut-system/src/core/system/__tests__/system-test.ts
+++ b/packages/gamut-system/src/core/system/__tests__/system-test.ts
@@ -1,7 +1,7 @@
-import { system, ThemedSystem } from '..';
+import { system } from '..';
 
-describe(system, () => {
-  const { properties, variant, ...groups } = system({});
+describe('system', () => {
+  const { properties, variant, ...groups } = system.create();
 
   describe('initializing system', () => {
     it('initializes a system with any empty config', () => {
@@ -41,7 +41,7 @@ describe(system, () => {
   });
 
   describe('Custom Scales', () => {
-    const { typography, variant } = system({
+    const { typography, variant } = system.create({
       typography: {
         fontSize: { propName: 'fontSize', scale: { sm: '14px', md: '16px' } },
       },
@@ -68,15 +68,15 @@ describe(system, () => {
   });
 
   describe('Theme Scales', () => {
-    const themedSystem = system as ThemedSystem<{
-      fontSize: { sm: string; md: string };
-    }>;
-
-    const { typography, variant } = themedSystem({
-      typography: {
-        fontSize: { propName: 'fontSize', scale: 'fontSize' },
-      },
-    });
+    const { typography, variant } = system
+      .withTheme<{
+        fontSize: { sm: string; md: string };
+      }>()
+      .create({
+        typography: {
+          fontSize: { propName: 'fontSize', scale: 'fontSize' },
+        },
+      });
     const theme = { fontSize: { sm: '14px', md: '16px' } };
 
     it('theme scale values are found off of the specified theme', () => {

--- a/packages/gamut-system/src/core/system/index.ts
+++ b/packages/gamut-system/src/core/system/index.ts
@@ -6,15 +6,12 @@ import { entries, keys, mapValues, merge, pick, uniq, values } from 'lodash';
 import { getDefaultPropKey } from '../utils';
 import { System, SystemConfig } from '../../types/system';
 
-export type ThemedSystem<Theme extends AbstractTheme> = <
+const create = <
+  Theme extends AbstractTheme,
   Config extends SystemConfig<Theme>
 >(
-  config: Config
-) => System<Theme, Config>;
-
-export const system = <Config extends SystemConfig<{}>>(
-  config: Config
-): System<{}, Config> => {
+  config?: Config
+): System<Theme, Config> => {
   // Initializes the return object
   const systemShape = {
     properties: {},
@@ -67,4 +64,15 @@ export const system = <Config extends SystemConfig<{}>>(
   systemShape.variant = createVariant;
 
   return systemShape;
+};
+
+export const system = {
+  create,
+  withTheme: <Theme extends AbstractTheme>() => {
+    return {
+      create: <Config extends SystemConfig<Theme>>(config: Config) => {
+        return create<Theme, Config>(config);
+      },
+    };
+  },
 };


### PR DESCRIPTION
Like we talked about on Slack: adjusts the top-level API a bit to be fluent, so we don't have to `as` cast with a `ThemedSystem`.