### PR TITLE
feat: tweaked red and green theme colors per design updates

### DIFF
--- a/packages/gamut-styles/src/variables/colors.ts
+++ b/packages/gamut-styles/src/variables/colors.ts
@@ -14,7 +14,7 @@ export const swatches = {
   green: {
     '0': '#F5FFE3',
     '400': '#AEE938',
-    '700': '#009C2C',
+    '700': '#008A27',
   },
   yellow: {
     '0': '#FFFAE5',
@@ -25,7 +25,7 @@ export const swatches = {
     '400': '#F966FF',
   },
   red: {
-    '500': '#F03329',
+    '500': '#E91C11',
   },
   orange: {
     '500': '#FF8C00',

--- a/packages/gamut-styles/utils/variables/_colors.scss
+++ b/packages/gamut-styles/utils/variables/_colors.scss
@@ -7,12 +7,12 @@
 $color-beige: #fff0e5;
 $color-light-blue: #66c4ff;
 $color-blue: #1557ff;
-$color-green: #009c2c;
+$color-green: #088a27;
 $color-light-green: #aee938;
 $color-navy: #10162f;
 $color-orange: #ff8c00;
 $color-pink: #f966ff;
-$color-red: #f03329;
+$color-red: #e91c11;
 $color-yellow: #ffd300;
 $color-hyper: #3a10e5;
 $color-pale-blue: #f5fcff;


### PR DESCRIPTION
## Overview

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/ReGfRNillGABAj5SlITalN/%F0%9F%93%90-Gamut?node-id=441%3A33
- ~[ ] Related to JIRA ticket: ABC-123~
- [x] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

### Description

We mentioned this in our Gamut biweekly. These are the proper colors now.
