### PR TITLE
feat: ProAltLogo

### DIFF
--- a/packages/gamut-labs/src/brand/ProLogoAlt/__tests__/ProLogoAlt-test.tsx
+++ b/packages/gamut-labs/src/brand/ProLogoAlt/__tests__/ProLogoAlt-test.tsx
@@ -1,0 +1,11 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { ProLogoAlt } from '@codecademy/gamut-labs/src/brand/ProLogoAlt';
+
+describe('LogoProAlt', () => {
+  it('renders the Pro Alt logo', () => {
+    const wrapper = mount(<ProLogoAlt />);
+    expect(wrapper.exists()).toBe(true);
+  });
+});

--- a/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
+++ b/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
@@ -3,18 +3,15 @@ import { colors } from '@codecademy/gamut-styles';
 
 export type ProLogoAltProps = {
   ariaLabel?: string;
-  backgroundColor?: string;
-  textColor?: string;
+  backgroundColor?: keyof typeof colors;
+  textColor?: keyof typeof colors;
   width?: number;
 };
 
-const backgroundDefault = colors.yellow;
-const textDefault = colors.black;
-
 export const ProLogoAlt: React.FC<ProLogoAltProps> = ({
   ariaLabel = 'Codecademy Pro Logo',
-  backgroundColor = backgroundDefault,
-  textColor = textDefault,
+  backgroundColor = 'yellow',
+  textColor = 'black',
   width = 50,
 }) => (
   <svg
@@ -24,11 +21,14 @@ export const ProLogoAlt: React.FC<ProLogoAltProps> = ({
     xmlns="http://www.w3.org/2000/svg"
     aria-label={ariaLabel}
   >
-    <g fill={backgroundColor} fillRule="evenodd">
-      <path d="m0 0h74v40h-74zm78 34h17v6h-17z" fill={backgroundColor} />
+    <g fill={colors[backgroundColor]} fillRule="evenodd">
+      <path
+        d="m0 0h74v40h-74zm78 34h17v6h-17z"
+        fill={colors[backgroundColor]}
+      />
       <path
         d="m13.971 23.67v6.82h-3.971v-20.145h6.82c4.749 0 7.253 2.965 7.253 6.62 0 3.625-2.504 6.705-7.253 6.705zm2.245-9.871h-2.245v6.446h2.245c2.187 0 3.77-1.036 3.77-3.28 0-2.245-1.583-3.166-3.77-3.166zm21.518 16.691-4.46-7.741h-2.821v7.741h-4v-20.145h7.568c4.404 0 6.994 2.62 6.994 6.13 0 1.9-.777 4.317-3.828 5.526l5.151 8.49h-4.604zm-.72-13.986c0-1.784-1.295-2.705-3.51-2.705h-3.051v5.468h3.05c2.216 0 3.511-1.036 3.511-2.763zm16.453-6.504c5.843 0 10.533 4.346 10.533 10.418s-4.69 10.417-10.533 10.417c-5.842 0-10.533-4.345-10.533-10.417s4.691-10.418 10.533-10.418zm0 17.152c3.799 0 6.36-2.878 6.36-6.734 0-3.857-2.561-6.734-6.36-6.734s-6.36 2.877-6.36 6.734c0 3.856 2.561 6.734 6.36 6.734z"
-        fill={textColor}
+        fill={colors[textColor]}
       />
     </g>
   </svg>

--- a/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
+++ b/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
@@ -13,7 +13,7 @@ const textDefault = colors.black;
 const widthDefault = 50;
 
 export const ProLogoAlt: React.FC<ProLogoAltProps> = ({
-  ariaLabel = 'ProLogo',
+  ariaLabel = 'Codecademy Pro Logo',
   backgroundColor = backgroundDefault,
   textColor = textDefault,
   width = widthDefault,

--- a/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
+++ b/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
@@ -10,13 +10,12 @@ export type ProLogoAltProps = {
 
 const backgroundDefault = colors.yellow;
 const textDefault = colors.black;
-const widthDefault = 50;
 
 export const ProLogoAlt: React.FC<ProLogoAltProps> = ({
   ariaLabel = 'Codecademy Pro Logo',
   backgroundColor = backgroundDefault,
   textColor = textDefault,
-  width = widthDefault,
+  width = 50,
 }) => (
   <svg
     width={width}

--- a/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
+++ b/packages/gamut-labs/src/brand/ProLogoAlt/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { colors } from '@codecademy/gamut-styles';
+
+export type ProLogoAltProps = {
+  ariaLabel?: string;
+  backgroundColor?: string;
+  textColor?: string;
+  width?: number;
+};
+
+const backgroundDefault = colors.yellow;
+const textDefault = colors.black;
+const widthDefault = 50;
+
+export const ProLogoAlt: React.FC<ProLogoAltProps> = ({
+  ariaLabel = 'ProLogo',
+  backgroundColor = backgroundDefault,
+  textColor = textDefault,
+  width = widthDefault,
+}) => (
+  <svg
+    width={width}
+    viewBox="0 0 95 40"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-label={ariaLabel}
+  >
+    <g fill={backgroundColor} fillRule="evenodd">
+      <path d="m0 0h74v40h-74zm78 34h17v6h-17z" fill={backgroundColor} />
+      <path
+        d="m13.971 23.67v6.82h-3.971v-20.145h6.82c4.749 0 7.253 2.965 7.253 6.62 0 3.625-2.504 6.705-7.253 6.705zm2.245-9.871h-2.245v6.446h2.245c2.187 0 3.77-1.036 3.77-3.28 0-2.245-1.583-3.166-3.77-3.166zm21.518 16.691-4.46-7.741h-2.821v7.741h-4v-20.145h7.568c4.404 0 6.994 2.62 6.994 6.13 0 1.9-.777 4.317-3.828 5.526l5.151 8.49h-4.604zm-.72-13.986c0-1.784-1.295-2.705-3.51-2.705h-3.051v5.468h3.05c2.216 0 3.511-1.036 3.511-2.763zm16.453-6.504c5.843 0 10.533 4.346 10.533 10.418s-4.69 10.417-10.533 10.417c-5.842 0-10.533-4.345-10.533-10.417s4.691-10.418 10.533-10.418zm0 17.152c3.799 0 6.36-2.878 6.36-6.734 0-3.857-2.561-6.734-6.36-6.734s-6.36 2.877-6.36 6.734c0 3.856 2.561 6.734 6.36 6.734z"
+        fill={textColor}
+      />
+    </g>
+  </svg>
+);

--- a/packages/gamut-labs/src/brand/index.ts
+++ b/packages/gamut-labs/src/brand/index.ts
@@ -7,5 +7,6 @@ export * from './Header/HeaderTab';
 export * from './Loading';
 export * from './Logo';
 export * from './ProLogo';
+export * from './ProLogoAlt';
 export * from './Quote';
 export * from './Testimonial';

--- a/packages/styleguide/helpers/selectableColors.ts
+++ b/packages/styleguide/helpers/selectableColors.ts
@@ -10,3 +10,12 @@ export const selectableColors = Object.keys(colors).reduce<
     [colorKey]: colorAtKey,
   };
 }, {});
+
+export const selectableColorNames = Object.keys(colors).reduce<
+  Record<string, string>
+>((acc, colorKey) => {
+  return {
+    ...acc,
+    [colorKey]: colorKey,
+  };
+}, {});

--- a/packages/styleguide/stories/Labs/Brand/Atoms/ProLogo.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/ProLogo.stories.mdx
@@ -2,17 +2,17 @@ import { Meta, Props, Canvas, Story } from '@storybook/addon-docs/dist/blocks';
 import { select, number, boolean } from '@storybook/addon-knobs';
 import { StoryStatus } from '~styleguide/blocks';
 import { ProLogo } from '@codecademy/gamut-labs/src';
-import { selectableColors } from '../../../../helpers';
+import { selectableColorNames } from '../../../../helpers';
 
 <Meta
   title="Labs/Brand/Atoms/ProLogo"
   component={ProLogo}
   argTypes={{
     backgroundColor: {
-      control: { type: 'select', options: selectableColors },
+      control: { type: 'select', options: selectableColorNames },
     },
     cutoutColor: {
-      control: { type: 'select', options: selectableColors },
+      control: { type: 'select', options: selectableColorNames },
     },
   }}
   args={{

--- a/packages/styleguide/stories/Labs/Brand/Atoms/ProLogoAlt.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/ProLogoAlt.stories.mdx
@@ -21,7 +21,7 @@ import { selectableColors } from '../../../../helpers';
 
 <StoryStatus status="volatile" />
 
-New version of the Pro Alt that allows you to chose the text color. Use sparingly, and make sure it has a lot of visual distinction to stand out appropriately.
+Version of the Pro Alt logo that allows you to choose the text color. Use sparingly, and make sure it has a lot of visual distinction to stand out appropriately.
 
 <Canvas withSource="open">
   <Story name="ProLogoAlt">{(args) => <ProLogoAlt {...args} />}</Story>

--- a/packages/styleguide/stories/Labs/Brand/Atoms/ProLogoAlt.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/ProLogoAlt.stories.mdx
@@ -2,17 +2,17 @@ import { Meta, Props, Canvas, Story } from '@storybook/addon-docs/dist/blocks';
 import { select, number, boolean } from '@storybook/addon-knobs';
 import { StoryStatus } from '~styleguide/blocks';
 import { ProLogoAlt } from '@codecademy/gamut-labs/src';
-import { selectableColors } from '../../../../helpers';
+import { selectableColorNames } from '../../../../helpers';
 
 <Meta
   title="Labs/Brand/Atoms/ProLogoAlt"
   component={ProLogoAlt}
   argTypes={{
     backgroundColor: {
-      control: { type: 'select', options: selectableColors },
+      control: { type: 'select', options: selectableColorNames },
     },
     textColor: {
-      control: { type: 'select', options: selectableColors },
+      control: { type: 'select', options: selectableColorNames },
     },
   }}
 />

--- a/packages/styleguide/stories/Labs/Brand/Atoms/ProLogoAlt.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Atoms/ProLogoAlt.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta, Props, Canvas, Story } from '@storybook/addon-docs/dist/blocks';
+import { select, number, boolean } from '@storybook/addon-knobs';
+import { StoryStatus } from '~styleguide/blocks';
+import { ProLogoAlt } from '@codecademy/gamut-labs/src';
+import { selectableColors } from '../../../../helpers';
+
+<Meta
+  title="Labs/Brand/Atoms/ProLogoAlt"
+  component={ProLogoAlt}
+  argTypes={{
+    backgroundColor: {
+      control: { type: 'select', options: selectableColors },
+    },
+    textColor: {
+      control: { type: 'select', options: selectableColors },
+    },
+  }}
+/>
+
+# ProLogoAlt
+
+<StoryStatus status="volatile" />
+
+New version of the Pro Alt that allows you to chose the text color. Use sparingly, and make sure it has a lot of visual distinction to stand out appropriately.
+
+<Canvas withSource="open">
+  <Story name="ProLogoAlt">{(args) => <ProLogoAlt {...args} />}</Story>
+</Canvas>
+
+<Props story="ProLogoAlt" />


### PR DESCRIPTION
## Overview
This creates a new version of our Pro Alt Logo that allows dev to choose the inner text color. 

### PR Checklist

- [x] Related to designs: [LX-4320](https://codecademy.atlassian.net/browse/LX-4320)
- [x] Related to JIRA ticket: [LX-4320](https://codecademy.atlassian.net/browse/LX-4320)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description
Previously this effect had been achieved by loading in an image (as it is [here](https://www.codecademy.com/learn/paths/computer-science)). This logo also should improve the load time of page.

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
