### PR TITLE
fix: updated export/import bodyportal

### DIFF
--- a/packages/gamut-labs/src/experimental/Popover/index.tsx
+++ b/packages/gamut-labs/src/experimental/Popover/index.tsx
@@ -4,7 +4,7 @@ import { useWindowSize, useClickAway, useWindowScroll } from 'react-use';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import styles from './styles.module.scss';
-import { BodyPortal } from '../../../../gamut/src/BodyPortal';
+import { BodyPortal } from '@codecademy/gamut';
 
 export type PopoverProps = {
   children: React.ReactElement<any>;

--- a/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
+++ b/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
@@ -13,6 +13,7 @@ Array [
   "Banner",
   "BannerStyle",
   "BannerType",
+  "BodyPortal",
   "Button",
   "ButtonBase",
   "buttonPresetThemes",

--- a/packages/gamut/src/index.tsx
+++ b/packages/gamut/src/index.tsx
@@ -7,6 +7,7 @@ export * from './AppBar';
 export * from './AppBar/AppBarSection';
 export * from './Badge';
 export * from './Banner';
+export * from './BodyPortal';
 export * from './Button';
 export * from './ButtonBase';
 export * from './Card/CardBody';


### PR DESCRIPTION
## Overview
It was brought to my attention that the import for BodyPortal was causing an error:
Error: Can't resolve '../../../../gamut/src/BodyPortal' in '/Users/cassiespain/Desktop/cc/Codecademy/node_modules/@codecademy/gamut-labs/dist/experimental/Popover'

I've updated to import BodyPortal from '@codecademy/gamut' and exported in the gamut/src/index file for it to work.

- [x] Related to past JIRA ticket: LX-4014 & EGG-298 (#846) 
- [x] I have run this code to verify it works

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
