### PR TITLE
[REACH-344] feat: Start on the Landing Page Section area in Gamut

### DIFF
--- a/packages/gamut-labs/src/brand/LandingPageSection/CTA.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/CTA.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import { Button } from '@codecademy/gamut';
+
+const CTA = styled.div`
+  margin: 2rem 0 0;
+`;
+
+export type LandingPageSectionCTAProps = {
+  href: string;
+  className?: string;
+  testId?: string;
+};
+
+export const LandingPageSectionCTA: React.FC<LandingPageSectionCTAProps> = ({
+  href,
+  className,
+  testId,
+  children,
+}) => (
+  <CTA className={className} data-testid={testId}>
+    <Button theme="hyper" href={href}>
+      {children}
+    </Button>
+  </CTA>
+);

--- a/packages/gamut-labs/src/brand/LandingPageSection/Description.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/Description.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import { Markdown } from '@codecademy/gamut';
+
+const Description = styled.div`
+  margin: 2rem 0 0;
+`;
+
+export type LandingPageSectionDescriptionProps = {
+  text: string;
+  className?: string;
+  testId?: string;
+};
+
+export const LandingPageSectionDescription: React.FC<LandingPageSectionDescriptionProps> = ({
+  text,
+  className,
+  testId,
+}) => (
+  <Description className={className} data-testid={testId}>
+    <Markdown text={text} />
+  </Description>
+);

--- a/packages/gamut-labs/src/brand/LandingPageSection/Title.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/Title.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import { Heading } from '@codecademy/gamut';
+
+const Title = styled(Heading)`
+  margin: 2rem 0 0;
+`;
+
+export type LandingPageSectionTitleProps = {
+  isPageHeading: boolean;
+  className?: string;
+  testId?: string;
+};
+
+export const LandingPageSectionTitle: React.FC<LandingPageSectionTitleProps> = ({
+  isPageHeading,
+  className,
+  testId,
+  children,
+}) => (
+  <Title
+    as={isPageHeading ? 'h1' : 'h2'}
+    fontSize={
+      isPageHeading
+        ? {
+            lg: 'xxl',
+            sm: 'xl',
+            xs: 'lg',
+          }
+        : {
+            lg: 'lg',
+            xs: 'md',
+          }
+    }
+    className={className}
+    testId={testId}
+  >
+    {children}
+  </Title>
+);

--- a/packages/gamut-labs/src/brand/LandingPageSection/index.ts
+++ b/packages/gamut-labs/src/brand/LandingPageSection/index.ts
@@ -1,0 +1,3 @@
+export * from './Title';
+export * from './Description';
+export * from './CTA';

--- a/packages/gamut-labs/src/brand/index.ts
+++ b/packages/gamut-labs/src/brand/index.ts
@@ -4,6 +4,7 @@ export * from './Byline';
 export * from './EditorialMolecules';
 export * from './Header/HeaderContainer';
 export * from './Header/HeaderTab';
+export * from './LandingPageSection';
 export * from './Loading';
 export * from './Logo';
 export * from './ProLogo';

--- a/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageSectionCTA.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageSectionCTA.stories.mdx
@@ -1,0 +1,27 @@
+import { Meta, Props, Canvas, Story } from '@storybook/addon-docs/dist/blocks';
+import { text } from '@storybook/addon-knobs';
+import { StoryStatus } from '~styleguide/blocks';
+import { LandingPageSectionCTA } from '@codecademy/gamut-labs/src';
+
+<Meta
+  title="Labs/Brand/Organisms/LandingPageSectionCTA"
+  component={LandingPageSectionCTA}
+/>
+
+# LandingPageSectionCTA
+
+<StoryStatus status="unstable" />
+
+This is a cta used in sections on a marketing page.
+
+<Canvas withSource="open">
+  <Story name="LandingPageSectionCTA">
+    {(args) => (
+      <LandingPageSectionCTA href={text('href', 'https://example.com/')}>
+        {text('Text', 'Lorem ipsum dolor sit amet')}
+      </LandingPageSectionCTA>
+    )}
+  </Story>
+</Canvas>
+
+<Props of={LandingPageSectionCTA} />

--- a/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageSectionDescription.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageSectionDescription.stories.mdx
@@ -1,0 +1,34 @@
+import { Meta, Props, Canvas, Story } from '@storybook/addon-docs/dist/blocks';
+import { text } from '@storybook/addon-knobs';
+import { StoryStatus } from '~styleguide/blocks';
+import { LandingPageSectionDescription } from '@codecademy/gamut-labs/src';
+
+<Meta
+  title="Labs/Brand/Organisms/LandingPageSectionDescription"
+  component={LandingPageSectionDescription}
+  parameters={{ knobs: { escapeHTML: false } }}
+/>
+
+# LandingPageSectionDescription
+
+<StoryStatus status="unstable" />
+
+This is a description field used in sections on a marketing page.
+
+<Canvas withSource="open">
+  <Story name="LandingPageSectionDescription">
+    {(args) => (
+      <LandingPageSectionDescription
+        text={text(
+          'markdown',
+          `
+## Hello World
+This is markdown
+          `
+        )}
+      />
+    )}
+  </Story>
+</Canvas>
+
+<Props of={LandingPageSectionDescription} />

--- a/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageSectionTitle.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageSectionTitle.stories.mdx
@@ -1,0 +1,27 @@
+import { Meta, Props, Canvas, Story } from '@storybook/addon-docs/dist/blocks';
+import { text, boolean } from '@storybook/addon-knobs';
+import { StoryStatus } from '~styleguide/blocks';
+import { LandingPageSectionTitle } from '@codecademy/gamut-labs/src';
+
+<Meta
+  title="Labs/Brand/Organisms/LandingPageSectionTitle"
+  component={LandingPageSectionTitle}
+/>
+
+# LandingPageSectionTitle
+
+<StoryStatus status="unstable" />
+
+This is title field used in sections on a marketing page.
+
+<Canvas withSource="open">
+  <Story name="LandingPageSectionTitle">
+    {(args) => (
+      <LandingPageSectionTitle isPageHeading={boolean('isPageHeading', false)}>
+        {text('Text', 'Lorem ipsum dolor sit amet')}
+      </LandingPageSectionTitle>
+    )}
+  </Story>
+</Canvas>
+
+<Props of={LandingPageSectionTitle} />


### PR DESCRIPTION
## Overview

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/2aBlW1pgFt5PT6soRu1HXy/%E2%9C%8F%EF%B8%8F-Landing-Page-Templates---Unification?node-id=1%3A43
- [x] Related to JIRA ticket: REACH-344
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description
These are just some of the smaller entities that be used in a number of Landing Page Section organisms.