### PR TITLE
fix: remove fill color from ArrowChevronDownFilledIcon

### DIFF
--- a/packages/gamut-icons/src/svg/arrow-chevron-down-filled-icon.svg
+++ b/packages/gamut-icons/src/svg/arrow-chevron-down-filled-icon.svg
@@ -1,5 +1,5 @@
 <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
 <title>filled-arrow-down</title>
 <rect width="8" height="8" fill="white"/>
-<path d="M7.06574 1.5L4 6.09861L0.934259 1.5H7.06574Z" fill="#10162F" stroke="#10162F"/>
+<path d="M7.06574 1.5L4 6.09861L0.934259 1.5H7.06574Z" />
 </svg>


### PR DESCRIPTION
## Overview
remove fill and stroke color from ArrowChevronDownFilledIcon svg so that it can change color based on css color property

needed for Codecademy-engineering/Codecademy#19905 

### PR Checklist

- [ ] Related to designs: [figma](https://www.figma.com/file/7PNKwpTpXjRrPjcCRSu215/Global-Nav?node-id=899%3A100)
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description
![Screen Shot 2020-11-05 at 10 49 26 AM](https://user-images.githubusercontent.com/3805607/98263247-986e2000-1f54-11eb-8078-1b8e587d387d.png)


<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
