### PR TITLE
feat(markdown): update overrides storybook for clarity

### DIFF
--- a/packages/styleguide/stories/Core/Atoms/Markdown/Markdown.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Markdown/Markdown.stories.mdx
@@ -53,67 +53,69 @@ This is markdown
 
 In cases where our default Markdown renderer is not returning exactly what you need, you can override specific tags or custom tags.
 
-  <Canvas>
-    <Story name="Element Overrides">
-        <Markdown
-          overrides={{
-            CodeBlock: {
-              component: (props) => <Text style={{ color: 'darkblue'}} {...props} />,
-            },
-            CustomElement: {
-              component: ({ title }) => {
-                return (
-                  <Heading
-                    as="h3"
-                    fontSize="md"
-                    style={{
-                      color: 'rebeccapurple',
-                    }}
-                  >
-                    {title}
-                  </Heading>
-                );
-              },
-              allowedAttributes: ['title'],
-            },
-          }}
-          text="## Hello World
+<Canvas>
+  <Story name="Element Overrides">
+    <Markdown
+      overrides={{
+        CodeBlock: {
+          component: (props) => (
+            <Text style={{ color: 'darkblue' }} {...props} />
+          ),
+        },
+        CustomElement: {
+          component: ({ title }) => {
+            return (
+              <Heading
+                as="h3"
+                fontSize="md"
+                style={{
+                  color: 'rebeccapurple',
+                }}
+              >
+                {title}
+              </Heading>
+            );
+          },
+          allowedAttributes: ['title'],
+        },
+      }}
+      text="## Hello World
           <CodeBlock>Span inside a custom code block element</CodeBlock>
           <CustomElement title='A Custom Component' />"
-        />
-    </Story>
-  </Canvas>
+    />
+  </Story>
+</Canvas>
 
-  A common override may be to change the font size of a Heading.
+A common override may be to change the font size of a Heading.
 
-  <Canvas>
-    <Story name="Tag Overrides">
-        <Markdown
-          overrides={{
-            h3: {
-              component: (props) => <Heading {...props} as="h3" size="xs" />
-            }
-          }}
-          text="### Smaller H3"
-        />
-    </Story>
-  </Canvas>
+<Canvas>
+  <Story name="Tag Overrides">
+    <Markdown
+      overrides={{
+        h3: {
+          component: (props) => <Heading {...props} as="h3" size="xs" />,
+        },
+      }}
+      text="### Smaller H3"
+    />
+  </Story>
+</Canvas>
 
-  If you need to override a link, iframe, or table, you also need to provide the `skipDefaultOverides` prop.
+If you need to override a link, iframe, or table, you also need to provide the `skipDefaultOverides` prop.
 
-  <Canvas>
-    <Story name="Link Overrides">
-        <Markdown
-          skipDefaultOverides
-          overrides={{
-            a: {
-              component: Text,
-            }
-          }}
-          text="[This was a link](https://codecademy.com)."
-        />
-    </Story>
-  </Canvas>
+<Canvas>
+  <Story name="Link Overrides">
+    <Markdown
+      skipDefaultOverides
+      overrides={{
+        a: {
+          component: Text,
+        },
+      }}
+      text="[This was a link](https://codecademy.com)."
+    />
+  </Story>
+</Canvas>
 
 ## Inline Markdown
 

--- a/packages/styleguide/stories/Core/Atoms/Markdown/Markdown.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Markdown/Markdown.stories.mdx
@@ -51,39 +51,69 @@ This is markdown
 
 ## Element Overrides
 
-<Canvas>
-  <Story name="Element Overrides">
-    {(args) => (
-      <Markdown
-        spacing={select('spacing', ['tight', 'loose', 'none'], 'none')}
-        overrides={{
-          CodeBlock: {
-            component: (props) => (
-              <Text style={{ color: 'darkblue' }} {...props} />
-            ),
-          },
-          CustomElement: {
-            component: ({ title }) => {
-              return (
-                <Heading
-                  as="h3"
-                  fontSize="md"
-                  style={{
-                    color: 'rebeccapurple',
-                  }}
-                >
-                  {title}
-                </Heading>
-              );
+In cases where our default Markdown renderer is not returning exactly what you need, you can override specific tags or custom tags.
+
+  <Canvas>
+    <Story name="Element Overrides">
+        <Markdown
+          overrides={{
+            CodeBlock: {
+              component: (props) => <Text style={{ color: 'darkblue'}} {...props} />,
             },
-            allowedAttributes: ['title'],
-          },
-        }}
-        text={customText}
-      />
-    )}
-  </Story>
-</Canvas>
+            CustomElement: {
+              component: ({ title }) => {
+                return (
+                  <Heading
+                    as="h3"
+                    fontSize="md"
+                    style={{
+                      color: 'rebeccapurple',
+                    }}
+                  >
+                    {title}
+                  </Heading>
+                );
+              },
+              allowedAttributes: ['title'],
+            },
+          }}
+          text="## Hello World
+          <CodeBlock>Span inside a custom code block element</CodeBlock>
+          <CustomElement title='A Custom Component' />"
+        />
+    </Story>
+  </Canvas>
+
+  A common override may be to change the font size of a Heading.
+
+  <Canvas>
+    <Story name="Tag Overrides">
+        <Markdown
+          overrides={{
+            h3: {
+              component: (props) => <Heading {...props} as="h3" size="xs" />
+            }
+          }}
+          text="### Smaller H3"
+        />
+    </Story>
+  </Canvas>
+
+  If you need to override a link, iframe, or table, you also need to provide the `skipDefaultOverides` prop.
+
+  <Canvas>
+    <Story name="Link Overrides">
+        <Markdown
+          skipDefaultOverides
+          overrides={{
+            a: {
+              component: Text,
+            }
+          }}
+          text="[This was a link](https://codecademy.com)."
+        />
+    </Story>
+  </Canvas>
 
 ## Inline Markdown
 


### PR DESCRIPTION
## Overview

Recently I was working on a ticket to override some tags from the Markdown gamut component. Upon accessing the storybook, I was confused because the 'Show Code' part looked like this:

<img width="996" alt="Screen Shot 2020-11-10 at 6 11 50 PM" src="https://user-images.githubusercontent.com/30914906/98744736-38c2ab00-2380-11eb-9582-046f5562936e.png">

(note the `function noRefCheck()`). To complete my task, I had to dig into the `Markdown` source code & look at over places where overrides were used.

This PR fixes the `Show Code` panel & also adds a few more examples to make it clearer how to override things in the Markdown component. 

The formatting is a bit funky, but it now looks like:
<img width="984" alt="Screen Shot 2020-11-10 at 6 13 46 PM" src="https://user-images.githubusercontent.com/30914906/98744878-7d4e4680-2380-11eb-98fc-f0adf2a13d9c.png">

<img width="1027" alt="Screen Shot 2020-11-10 at 6 13 27 PM" src="https://user-images.githubusercontent.com/30914906/98744860-71fb1b00-2380-11eb-9e78-b44ea9b1877d.png">

## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
