### PR TITLE
chore(Styles): Assorted theme / variable additions

### DIFF
--- a/packages/gamut-styles/src/system.ts
+++ b/packages/gamut-styles/src/system.ts
@@ -57,6 +57,22 @@ const {
       scale: 'colors',
     },
   },
+  grid: {
+    columnGap: {
+      propName: 'columnGap',
+      scale: 'spacing',
+    },
+    rowGap: {
+      propName: 'rowGap',
+      scale: 'spacing',
+    },
+  },
+  shadows: {
+    boxShadow: {
+      propName: 'boxShadow',
+      scale: 'boxShadows',
+    },
+  },
 });
 
 export {

--- a/packages/gamut-styles/src/system.ts
+++ b/packages/gamut-styles/src/system.ts
@@ -67,12 +67,6 @@ const {
       scale: 'spacing',
     },
   },
-  shadows: {
-    boxShadow: {
-      propName: 'boxShadow',
-      scale: 'boxShadows',
-    },
-  },
 });
 
 export {

--- a/packages/gamut-styles/src/theme.tsx
+++ b/packages/gamut-styles/src/theme.tsx
@@ -1,6 +1,7 @@
 import * as tokens from './variables';
 
 export const theme = {
+  boxShadows: tokens.boxShadows,
   breakpoints: tokens.mediaQueries,
   fontSize: tokens.fontSize,
   fontFamily: tokens.fontFamily,

--- a/packages/gamut-styles/src/utilities.ts
+++ b/packages/gamut-styles/src/utilities.ts
@@ -1,6 +1,0 @@
-export * from './utilities/pxRem';
-export * from './utilities/boxShadow';
-export * from './utilities/fontSmoothing';
-export * from './utilities/noSelect';
-export * from './utilities/responsive';
-export * from './utilities/screenReaderOnly';

--- a/packages/gamut-styles/src/variables.ts
+++ b/packages/gamut-styles/src/variables.ts
@@ -1,9 +1,0 @@
-export * from './variables/colors';
-export * from './variables/responsive';
-export * from './variables/spacing';
-export * from './variables/timing';
-export * from './variables/typography';
-export * from './variables/effects';
-
-// Deprecated variables
-export * from './variables/deprecated-colors';

--- a/packages/gamut-styles/src/variables/colors.ts
+++ b/packages/gamut-styles/src/variables/colors.ts
@@ -1,6 +1,7 @@
 const black = '#000000';
 const white = '#ffffff';
-const swatches = {
+
+export const swatches = {
   beige: {
     '0': '#FFF0E5',
   },

--- a/packages/gamut-styles/src/variables/colors.ts
+++ b/packages/gamut-styles/src/variables/colors.ts
@@ -48,7 +48,7 @@ export const swatches = {
   },
 } as const;
 
-const flatSwatches = {
+export const flatSwatches = {
   'beige-0': '#FFF0E5',
   'blue-0': '#F5FCFF',
   'blue-300': '#66C4FF',
@@ -77,8 +77,7 @@ const flatSwatches = {
   'gray-900': '#19191a',
 } as const;
 
-export const colors = {
-  ...flatSwatches,
+export const trueColors = {
   beige: swatches.beige[0],
   blue: swatches.blue[500],
   green: swatches.green[700],
@@ -96,6 +95,11 @@ export const colors = {
   yellow: swatches.yellow[500],
   black,
   white,
+} as const;
+
+export const colors = {
+  ...flatSwatches,
+  ...trueColors,
 } as const;
 
 export const colorNames = {

--- a/packages/gamut-styles/src/variables/colors.ts
+++ b/packages/gamut-styles/src/variables/colors.ts
@@ -1,7 +1,6 @@
 const black = '#000000';
 const white = '#ffffff';
-
-export const swatches = {
+const swatches = {
   beige: {
     '0': '#FFF0E5',
   },
@@ -48,7 +47,37 @@ export const swatches = {
   },
 } as const;
 
+const flatSwatches = {
+  'beige-0': '#FFF0E5',
+  'blue-0': '#F5FCFF',
+  'blue-300': '#66C4FF',
+  'blue-500': '#1557FF',
+  'blue-900': '#10162f',
+  'green-0': '#F5FFE3',
+  'green-400': '#AEE938',
+  'green-700': '#008A27',
+  'yellow-0': '#FFFAE5',
+  'yellow-500': '#FFD300',
+  'pink-0': '#FFF5FF',
+  'pink-400': '#F966FF',
+  'red-500': '#E91C11',
+  'orange-500': '#FF8C00',
+  'hyper-400': '#5533FF',
+  'hyper-500': '#3A10E5',
+  'gray-0': '#ffffff',
+  'gray-100': '#f6f5fa',
+  'gray-200': '#dddce0',
+  'gray-300': '#c4c3c7',
+  'gray-400': '#a2a2a6',
+  'gray-500': '#828285',
+  'gray-600': '#646466',
+  'gray-700': '#4b4b4d',
+  'gray-800': '#323233',
+  'gray-900': '#19191a',
+} as const;
+
 export const colors = {
+  ...flatSwatches,
   beige: swatches.beige[0],
   blue: swatches.blue[500],
   green: swatches.green[700],

--- a/packages/gamut-styles/src/variables/index.ts
+++ b/packages/gamut-styles/src/variables/index.ts
@@ -4,6 +4,6 @@ export * from './spacing';
 export * from './typography';
 export * from './effects';
 export * from './shadows';
-
+export * from './timing';
 // Deprecated variables
 export * from './deprecated-colors';

--- a/packages/gamut-styles/src/variables/index.ts
+++ b/packages/gamut-styles/src/variables/index.ts
@@ -3,6 +3,7 @@ export * from './responsive';
 export * from './spacing';
 export * from './typography';
 export * from './effects';
+export * from './shadows';
 
 // Deprecated variables
 export * from './deprecated-colors';

--- a/packages/gamut-styles/src/variables/shadows.ts
+++ b/packages/gamut-styles/src/variables/shadows.ts
@@ -1,0 +1,8 @@
+import { boxShadow } from '../utilities';
+export const boxShadows = {
+  1: boxShadow(1),
+  2: boxShadow(2),
+  3: boxShadow(3),
+  4: boxShadow(4),
+  5: boxShadow(5),
+};

--- a/packages/gamut-styles/src/variables/shadows.ts
+++ b/packages/gamut-styles/src/variables/shadows.ts
@@ -5,4 +5,4 @@ export const boxShadows = {
   3: boxShadow(3),
   4: boxShadow(4),
   5: boxShadow(5),
-};
+} as const;

--- a/packages/styleguide/stories/Core/Foundations/Colors/Colors.stories.mdx
+++ b/packages/styleguide/stories/Core/Foundations/Colors/Colors.stories.mdx
@@ -17,6 +17,7 @@ import {
 import {
   brandColors,
   colors,
+  trueColors,
   colorNames,
   interactiveColors,
   swatches,
@@ -60,7 +61,7 @@ colors.blue;
 
 <Story name="Standard">
   <LayoutGrid rowGap="md" columnGap="md">
-    {objectKeys(colors).map((color) => (
+    {objectKeys(trueColors).map((color) => (
       <Column key={color} size={{ xs: 6, sm: 3 }}>
         <Container flex={false}>
           <Heading as="h2" fontSize="xs">


### PR DESCRIPTION
## Overview

- Flattened color swatch values to be accessible by a single key on the color object: `${color}-${weight}`
- Add our 5 box shadows to the theme.
- Adds spacing scale to grid-gap system functions for future use.
- Clean up relic files.


### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
