### PR TITLE
fix(System): Typescript memory performance fixes

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -102,6 +102,7 @@ module.exports = {
     'react/display-name': 'off',
 
     // These functional rules are annoying and we generally don't want them on
+    '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-magic-numbers': 'off',

--- a/packages/gamut-labs/src/experimental/Text/index.tsx
+++ b/packages/gamut-labs/src/experimental/Text/index.tsx
@@ -5,7 +5,7 @@ import { typography, color, space } from '@codecademy/gamut-styles';
 
 export const textStyles = compose(typography, color, space);
 
-export type TextProps = HandlerProps<typeof textStyles>;
+export interface TextProps extends HandlerProps<typeof textStyles> {}
 
 export const Text = styled.span<TextProps>(textStyles);
 

--- a/packages/gamut-styles/src/index.ts
+++ b/packages/gamut-styles/src/index.ts
@@ -8,6 +8,5 @@ export * from './system';
 export * from './theme';
 
 declare module '@emotion/react' {
-  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
   export interface Theme extends GamutTheme {}
 }

--- a/packages/gamut-styles/src/theme.tsx
+++ b/packages/gamut-styles/src/theme.tsx
@@ -8,6 +8,8 @@ export const theme = {
   fontWeight: tokens.fontWeight,
   colors: tokens.colors,
   spacing: tokens.spacing,
-};
+} as const;
 
-export type Theme = typeof theme;
+export type ThemeShape = typeof theme;
+
+export interface Theme extends ThemeShape {}

--- a/packages/gamut-system/src/types/config.ts
+++ b/packages/gamut-system/src/types/config.ts
@@ -9,7 +9,9 @@ import { SafeLookup, SafeMapKey, WeakRecord } from './utils';
 
 /** Theme Shape  */
 
-type BaseTheme = Readonly<WeakRecord<string, ScaleArray | ScaleMap>>;
+type BaseTheme = Readonly<{
+  [key: string]: any;
+}>;
 
 export type AbstractTheme = BaseTheme & {
   breakpoints?: {


### PR DESCRIPTION
## Overview
This resolves a significant performance issue with the theme shape being recreated every time it was referenced.  By changing these to interfaces the reference to the interface is preserved instead of copied resulting in a massive reduction in size both in memory and outputted file.

`system.d.ts`:  257556 => 41061 | 84% reduction
`Text.d.ts`:  53751 => 4924 | 91% reduction


### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
