### PR TITLE
fix: used type-only export for ButtonProps

### DIFF
--- a/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
+++ b/packages/gamut/__tests__/__snapshots__/gamut-test.ts.snap
@@ -17,7 +17,6 @@ Array [
   "ButtonDeprecated",
   "ButtonDeprecatedBase",
   "buttonPresetThemes",
-  "ButtonProps",
   "CardBody",
   "CardFooter",
   "CardShell",

--- a/packages/gamut/src/Button/index.ts
+++ b/packages/gamut/src/Button/index.ts
@@ -1,6 +1,6 @@
 export * from './CTAButton';
 export * from './FillButton';
 export * from './IconButton';
-export { ButtonProps } from './shared';
+export type { ButtonProps } from './shared';
 export * from './StrokeButton';
 export * from './TextButton';


### PR DESCRIPTION
## Overview

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

@saghdaey is seeing _`Cannot find 'ButtonProps'`_ errors locally in a `yarn link`ed gamut's `Button/index.js`. How unfortunate. I'm guessing this is some Babel/TypeScript quirk of accidentally printing the import to a JS file even though it's, in practice, only a type system import. It should go away with a `type` only import to tell Babel/TypeScript to not print out the export in JS land.