### PR TITLE
fix(system): Fix theme type inference for some keys

### DIFF
--- a/packages/gamut-system/src/types/config.ts
+++ b/packages/gamut-system/src/types/config.ts
@@ -10,7 +10,7 @@ import { SafeLookup, SafeMapKey, WeakRecord } from './utils';
 /** Theme Shape  */
 
 type BaseTheme = Readonly<{
-  [key: string]: any;
+  readonly [key: string]: any;
 }>;
 
 export type AbstractTheme = BaseTheme & {


### PR DESCRIPTION
## Overview
System `ThematicProps` failed when the theme key was a constructed const for some reason.

```tsx
const flatSwatches = {} as const;
const trueColors = {} as const;

export const colors = {
  ...flatSwatches,
  ...trueColors,
} as const;
```

Narrowed `AbstractTheme` keys to `readonly` and it somehow fixed it?  Not sure the TS reason why, behavior with interfaces is something I'm not super familiar with, rules seem much different. 

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
