### PR TITLE
feat: added focus trap to Popover

### DIFF
--- a/packages/gamut-labs/src/experimental/Popover/__tests__/Popover-test.tsx
+++ b/packages/gamut-labs/src/experimental/Popover/__tests__/Popover-test.tsx
@@ -91,7 +91,7 @@ describe('Popover', () => {
       isOpen: true,
       onRequestClose,
     });
-    fireEvent.keyDown(baseElement, { key: 'Escape', keyCode: 27 });
+    fireEvent.keyDown(baseElement, { key: 'escape', keyCode: 27 });
     expect(onRequestClose).toBeCalledTimes(1);
   });
 

--- a/packages/gamut-labs/src/experimental/Popover/index.tsx
+++ b/packages/gamut-labs/src/experimental/Popover/index.tsx
@@ -1,7 +1,7 @@
 import cx from 'classnames';
+import FocusTrap from 'focus-trap-react';
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { useWindowSize, useClickAway, useWindowScroll } from 'react-use';
-import { useHotkeys } from 'react-hotkeys-hook';
+import { useWindowSize, useWindowScroll } from 'react-use';
 
 import styles from './styles.module.scss';
 import { BodyPortal } from '@codecademy/gamut';
@@ -80,16 +80,6 @@ export const Popover: React.FC<PopoverProps> = ({
     };
   }, [targetRect, offset, align, position]);
 
-  const handleClickOutside = (event: MouseEvent | KeyboardEvent) => {
-    if (!isOpen) return;
-    if (
-      !targetRef?.current?.contains(event.target as Element) ||
-      event.type === 'keydown'
-    ) {
-      onRequestClose?.();
-    }
-  };
-
   useEffect(() => {
     setTargetRect(targetRef?.current?.getBoundingClientRect());
   }, [targetRef, isOpen, width, height, x, y]);
@@ -109,32 +99,37 @@ export const Popover: React.FC<PopoverProps> = ({
   }, [targetRect, isInViewport, onRequestClose]);
 
   const popoverRef = useRef<HTMLDivElement>(null);
-  useClickAway(popoverRef, handleClickOutside);
-  useHotkeys('escape', handleClickOutside, {}, [targetRect]);
 
   if (!isOpen || !targetRef) return null;
 
   return (
     <BodyPortal>
-      <div
-        ref={popoverRef}
-        className={cx(
-          styles.popover,
-          styles[`${position}-${align}`],
-          outline && styles.outline,
-          className
-        )}
-        style={getPopoverPosition()}
-        data-testid="popover-content-container"
+      <FocusTrap
+        focusTrapOptions={{
+          clickOutsideDeactivates: true,
+          onDeactivate: onRequestClose,
+        }}
       >
-        {showBeak && (
-          <div
-            className={cx(styles.beak, styles[`${position}-beak`])}
-            data-testid="popover-beak"
-          />
-        )}
-        {children}
-      </div>
+        <div
+          ref={popoverRef}
+          className={cx(
+            styles.popover,
+            styles[`${position}-${align}`],
+            outline && styles.outline,
+            className
+          )}
+          style={getPopoverPosition()}
+          data-testid="popover-content-container"
+        >
+          {showBeak && (
+            <div
+              className={cx(styles.beak, styles[`${position}-beak`])}
+              data-testid="popover-beak"
+            />
+          )}
+          {children}
+        </div>
+      </FocusTrap>
     </BodyPortal>
   );
 };


### PR DESCRIPTION
## Overview

### PR Checklist

- [ ] Related to designs: https://www.figma.com/faile/7PNKwpTpXjRrPjcCRSu215/Global-Nav?node-id=932%3A3085
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description

This adds in a little bit of the work we'd worked on in #846: specifically the usage of the focus trap. I've been trying to get the Reach UI components because they're quite a bit more accessible, but won't have them ready in time for the engagement team being able to launch this week.

There are two parallel investigations I tried out today:

* [Popover](https://github.com/reach/reach-ui/tree/develop/packages/popover) (#1151): the popover inside Reach UI is actually exactly what we want [Slack link](https://codecademy.slack.com/archives/CQ98K8PT6/p1605312553042200) _but_:
    * It doesn't expose a reasonable API for styling the insides differently based on the computed position style
    * It's not meant for public use: https://github.com/reach/reach-ui/issues/506
* [Menu Button](https://reach.tech/menu-button) (#1163): trying to use the Reach UI menu button instead of ours. It _almost_ works but for a Storybook complaint when I try to add the required CSS [Slack link](https://codecademy.slack.com/archives/C047ESP1T/p1605645523243000?thread_ts=1605631142.239000&cid=C047ESP1T)

I would like to continue pushing forward on them later, but need to unblock 🥚 friends. So here we/you go, at long last, the exact thing we/you wanted in #851 and I was super adamant about trying to avoid. 🙃 . Putting a co-authored-by tag because this really is partially what was coded there already...

Co-authored-by: Sooin Chung <sooin@codecademy.com>, Hasan Afzal <hasan@codecademy.com>