### PR TITLE
style: disable jsx-a11y/accessible-emoji rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -112,6 +112,7 @@ module.exports = {
 
     // These rules have been deprecated in their plugins but not yet removed from presets
     'jsx-a11y/label-has-for': 'off',
+    'jsx-a11y/accessible-emoji': 'off',
 
     // These style rules conflict with Prettier but aren't disabled by its plugins
     '@typescript-eslint/quotes': 'off',


### PR DESCRIPTION
## Overview
Disable deprecated "jsx-a11y/accessible-emoji" lint rule.

For more context: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/627

### PR Checklist
- [x] Related to JIRA ticket: EGG-476

### Description

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
