### PR TITLE
fix: default img alt to "", accept isPageHeading, update tests

### DIFF
--- a/packages/gamut-labs/src/brand/LandingPageSection/LandingPageHero.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/LandingPageHero.tsx
@@ -61,7 +61,7 @@ export const LandingPageHero: React.FC<LandingPageHeroProps> = ({
   cta,
   ctaHref,
   imgSrc,
-  imgAlt,
+  imgAlt = '',
   isPageHeading,
   testId,
 }) => (
@@ -73,7 +73,7 @@ export const LandingPageHero: React.FC<LandingPageHeroProps> = ({
       }}
     >
       {title && (
-        <LandingPageSectionTitle isPageHeading={isPageHeading ?? false}>
+        <LandingPageSectionTitle isPageHeading={isPageHeading}>
           {title}
         </LandingPageSectionTitle>
       )}
@@ -89,7 +89,3 @@ export const LandingPageHero: React.FC<LandingPageHeroProps> = ({
     )}
   </Layout>
 );
-
-LandingPageHero.defaultProps = {
-  imgAlt: '',
-};

--- a/packages/gamut-labs/src/brand/LandingPageSection/LandingPageHero.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/LandingPageHero.tsx
@@ -29,25 +29,29 @@ const Image = styled.img`
 export type LandingPageHeroProps = {
   title?: string;
   /**
-    Main body text (can include html)
-  */
+   * Main body text (can include markdown)
+   */
   desc?: string;
   /**
-    Button text
-  */
+   * Button text
+   */
   cta?: string;
   /**
-    Url to navigate to when clicking the button
-  */
+   * Url to navigate to when clicking the button
+   */
   ctaHref?: string;
   /**
-    Hero image URL
-  */
+   * Hero image URL
+   */
   imgSrc?: string;
   /**
-    Hero image alt text (for screen readers)
-  */
+   * Hero image alt text (for screen readers)
+   */
   imgAlt?: string;
+  /**
+   * True if this is the semantic page heading (h1)
+   */
+  isPageHeading?: boolean;
   testId?: string;
 };
 
@@ -58,6 +62,7 @@ export const LandingPageHero: React.FC<LandingPageHeroProps> = ({
   ctaHref,
   imgSrc,
   imgAlt,
+  isPageHeading,
   testId,
 }) => (
   <Layout testId={testId}>
@@ -68,7 +73,9 @@ export const LandingPageHero: React.FC<LandingPageHeroProps> = ({
       }}
     >
       {title && (
-        <LandingPageSectionTitle isPageHeading>{title}</LandingPageSectionTitle>
+        <LandingPageSectionTitle isPageHeading={isPageHeading ?? false}>
+          {title}
+        </LandingPageSectionTitle>
       )}
       {desc && <LandingPageSectionDescription text={desc} />}
       {cta && ctaHref && (
@@ -82,3 +89,7 @@ export const LandingPageHero: React.FC<LandingPageHeroProps> = ({
     )}
   </Layout>
 );
+
+LandingPageHero.defaultProps = {
+  imgAlt: '',
+};

--- a/packages/gamut-labs/src/brand/LandingPageSection/Title.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/Title.tsx
@@ -8,7 +8,7 @@ const Title = styled(Heading)`
 `;
 
 export type LandingPageSectionTitleProps = {
-  isPageHeading: boolean;
+  isPageHeading?: boolean;
   className?: string;
   testId?: string;
 };

--- a/packages/gamut-labs/src/brand/LandingPageSection/__tests__/LandingPageHero-test.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/__tests__/LandingPageHero-test.tsx
@@ -1,52 +1,51 @@
-import { shallow, mount } from 'enzyme';
 import React from 'react';
-import {
-  LandingPageHero,
-  LandingPageSectionCTA,
-  LandingPageSectionTitle,
-  LandingPageSectionDescription,
-} from '..';
+import { render } from '@testing-library/react';
+import { LandingPageHero } from '..';
 
 describe('LandingPageHero', () => {
-  it('should only render a title when one is provided', () => {
-    const wrapper = shallow(<LandingPageHero title="test" />);
-    expect(wrapper.find(LandingPageSectionTitle)).toHaveLength(1);
-
-    const wrapperNoTitle = shallow(<LandingPageHero />);
-    expect(wrapperNoTitle.find(LandingPageSectionTitle)).toHaveLength(0);
+  it('should render a title when one is provided', () => {
+    const wrapper = render(<LandingPageHero title="title" />);
+    wrapper.getByText('title');
   });
 
-  it('should only render a description when one is provided', () => {
-    const wrapper = shallow(<LandingPageHero desc="test" />);
-    expect(wrapper.find(LandingPageSectionDescription)).toHaveLength(1);
-
-    const wrapperNoDesc = shallow(<LandingPageHero />);
-    expect(wrapperNoDesc.find(LandingPageSectionDescription)).toHaveLength(0);
+  it('should render a description when one is provided', () => {
+    const wrapper = render(<LandingPageHero desc="desc" />);
+    wrapper.getByText('desc');
   });
 
-  it('should only render a button when both an href and cta are provided', () => {
-    const wrapper = shallow(
-      <LandingPageHero cta="test" ctaHref="https://codecademy.com" />
+  it('should render a button when both ctaHref and cta are provided', () => {
+    const wrapper = render(
+      <LandingPageHero cta="cta" ctaHref="https://codecademy.com" />
     );
-    expect(wrapper.find(LandingPageSectionCTA)).toHaveLength(1);
+    wrapper.getByText('cta');
+  });
 
-    const wrapperNoHref = shallow(<LandingPageHero cta="test" />);
-    expect(wrapperNoHref.find(LandingPageSectionCTA)).toHaveLength(0);
+  it('should not render a button when only cta is provided', () => {
+    const wrapper = render(<LandingPageHero cta="cta" />);
+    expect(wrapper.queryByText('cta')).not.toBeInTheDocument();
+  });
 
-    const wrapperNoCta = shallow(
+  it('should not render a button when only ctaHref is provided', () => {
+    const wrapper = render(
       <LandingPageHero ctaHref="https://codecademy.com" />
     );
-    expect(wrapperNoCta.find(LandingPageSectionCTA)).toHaveLength(0);
-
-    const wrapperNoCtaOrHref = shallow(<LandingPageHero />);
-    expect(wrapperNoCtaOrHref.find(LandingPageSectionCTA)).toHaveLength(0);
+    expect(
+      wrapper.queryByText('https://codecademy.com')
+    ).not.toBeInTheDocument();
   });
 
-  it('should only render an image when an imgSrc is provided', () => {
-    const wrapper = mount(<LandingPageHero imgSrc="test" />);
-    expect(wrapper.find('img')).toHaveLength(1);
+  it('should render an img with alt="" when an imgSrc is provided', () => {
+    const wrapper = render(<LandingPageHero imgSrc="test" />);
+    wrapper.getByAltText('');
+  });
 
-    const wrapperNoImg = mount(<LandingPageHero />);
-    expect(wrapperNoImg.find('img')).toHaveLength(0);
+  it('should not render an image when imgSrc is not provided', () => {
+    const wrapper = render(<LandingPageHero imgAlt="alt" />);
+    expect(wrapper.queryByAltText('alt')).not.toBeInTheDocument();
+  });
+
+  it('should not render anything when no props are provided', () => {
+    const wrapper = render(<LandingPageHero />);
+    expect(wrapper.queryByText(/.+/)).not.toBeInTheDocument();
   });
 });

--- a/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageHero.stories.mdx
+++ b/packages/styleguide/stories/Labs/Brand/Organisms/LandingPageHero.stories.mdx
@@ -11,7 +11,7 @@ import { LandingPageHero } from '@codecademy/gamut-labs/src';
     title:
       "I'd rather be listening to Grammy-Award winning 1999 hit Smooth by Santana",
     desc:
-      'feat. <a href="https://en.wikipedia.org/wiki/Rob_Thomas_(musician)">Rob Thomas of Matchbox Twenty</a> off the multi-platinum album',
+      'feat. [Rob Thomas of Matchbox Twenty](https://en.wikipedia.org/wiki/Rob_Thomas_(musician)) off the multi-platinum album',
     cta: 'Supernatural',
     ctaHref:
       'https://open.spotify.com/album/10aiDpdFGyfCFEcqpx6XTq?si=xR1nDqVqROK6KYM8J-l_rw',


### PR DESCRIPTION
## Overview

applying posthumous feedback from https://github.com/Codecademy/client-modules/pull/1161, along with some other small tweaks
- default `imgAlt` to `""`
- accept `isPageHeading` prop and apply it to `LandingPageTitle`
- use markdown in story instead of html
- format tsdoc comments more goodly
- switch to RTL for tests, make them less bad

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: REACH-377
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change