### PR TITLE
fix: update flex items to grow and shrink evenly in landing page features section

### DIFF
--- a/packages/gamut-labs/src/brand/LandingPageSection/LandingPageFeature.tsx
+++ b/packages/gamut-labs/src/brand/LandingPageSection/LandingPageFeature.tsx
@@ -21,6 +21,7 @@ const StyledMarkdown = styled(Markdown)`
 `;
 
 const FeatureBlock = styled.div`
+  flex: 1;
   ${mediaQueries.sm} {
     &:not(:last-of-type) {
       margin-right: 1rem;


### PR DESCRIPTION
## Overview

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/2aBlW1pgFt5PT6soRu1HXy/%E2%9C%8F%EF%B8%8F-Landing-Page-Templates---Unification?node-id=1%3A43
- [x] Related to JIRA ticket: [REACH-384]
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description
Add `flex: 1` to feature items so they all appear the same size.

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
