### PR TITLE
fix: prevent VO from saying "group" for ProgressBar

### DIFF
--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -54,8 +54,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
     <div
       aria-label={`Progress: ${percent}%`}
       aria-live="polite"
-      // eslint-disable-next-line jsx-a11y/aria-role
-      role="text"
+      role="figure"
       className={cx(styles.progressBar, styles[theme], className)}
       style={{
         background: backgroundColor,

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -54,6 +54,8 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
     <div
       aria-label={`Progress: ${percent}%`}
       aria-live="polite"
+      // eslint-disable-next-line jsx-a11y/aria-role
+      role="text"
       className={cx(styles.progressBar, styles[theme], className)}
       style={{
         background: backgroundColor,


### PR DESCRIPTION
## Overview
testio came back to say that the Progress Bar should not say "Progress: 100%, group" on voiceover

this PR changes it to say "Progress: 100%, figure" instead, because it is a more apt description

the testio tester suggested using role="text" so that the voiceover would just say "Progress: 100%" but there is no standard way to do this effectively on all browsers, so instead we'll just have the role be more descriptive (i.e. "figure" instead of "group")

~~previously the VoiceOver would say "Progress: 100%, group" on the progress bar, but this PR changes it to say "Progress: 100%" (without the "group")~~

~~it also needs the eslint-ignore because "text" is not officially an allowed aria role type -- even though it was proposed it was not accepted, but people use it for this workaround~~

~~see article:
https://blog.chrisworfolk.com/how-to-stop-voiceover-saying-the-word-group
and issue:
https://www.w3.org/WAI/ARIA/track/issues/435~~

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: EGG-487
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description

<!--
## Merging your changes

When you are ready to merge to main and publish your changes, use the "squash and merge" button in GitHub, and follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide) to format your PR title and write your PR merge description.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
