### PR TITLE
fix: Add query params to tracking calls

### DIFF
--- a/packages/tracking/src/__tests__/track.spec.ts
+++ b/packages/tracking/src/__tests__/track.spec.ts
@@ -1,4 +1,4 @@
-import { createTracker } from './track';
+import { createTracker } from '../track';
 
 const apiBaseUrl = 'https://www.codecademy.com';
 const authToken = 'super-secure-token';
@@ -7,7 +7,7 @@ const fakeWindow = {
   location: {
     href: 'https://example.com/',
     pathname: '/',
-    search: '',
+    search: '?utm_source=twitter',
   },
   document: {
     title: 'Test Title',
@@ -43,7 +43,7 @@ describe('createTracker', () => {
 
     expect(beaconMock.mock.calls.length).toBe(1);
     expect(beaconMock.mock.calls[0][0]).toBe(
-      `${apiBaseUrl}/analytics/user?authentication_token=${authToken}`
+      `${apiBaseUrl}/analytics/user?utm_source=twitter&authentication_token=${authToken}`
     );
     const formData = beaconMock.mock.calls[0][1];
     expect(formData).toBeInstanceOf(FormData);

--- a/packages/tracking/src/__tests__/user.spec.ts
+++ b/packages/tracking/src/__tests__/user.spec.ts
@@ -1,5 +1,5 @@
 import fetch from 'jest-fetch-mock';
-import { fetchUser } from './user';
+import { fetchUser } from '../user';
 
 const apiBaseUrl = 'https://www.codecademy.com';
 const authUser = {

--- a/packages/tracking/src/track.ts
+++ b/packages/tracking/src/track.ts
@@ -56,7 +56,9 @@ export const createTracker = (
       console.groupEnd();
     }
 
-    beacon(`/analytics/${category}`, {
+    // This allows the UTM query params to get registered in the user session.
+    const queryParams = window.location.search;
+    beacon(`/analytics/${category}${queryParams}`, {
       category,
       event,
       properties: JSON.stringify(properties),


### PR DESCRIPTION
## Overview
static_sites has logic to add the query params to the tracking call.  When I was porting this, I originally assumed this was irrelevant, as all necessary data would be based in as FormData props.  This was an incorrect assumption.  There is a weird quirk how the monolith uses an after hook to detect utm params and add them to the users session.  However, if someone hits a third party site first, then because rails didn't process the request the UTM params never get tracked.  This seems to be overcome in static-sites by adding the original pages query params to all tracking calls, that way the tracking call itself allows rails to detect UTM params.

Note, the little hack will not scale if we move tracking to its own library.  We should probably have some standardized session store for tracking params across pages.

### PR Checklist

- [X] Related to JIRA ticket: REACH-364
- [X] I have run this code to verify it works
- [X] This PR includes unit tests for the code change
