### PR TITLE
fix: Check the contents of cta and not just the existence

### DIFF
--- a/packages/gamut-labs/src/landingPage/FeaturesSection.tsx
+++ b/packages/gamut-labs/src/landingPage/FeaturesSection.tsx
@@ -48,7 +48,9 @@ export const PageFeaturesSection: React.FC<PageFeaturesSectionProps> = ({
         <PageSectionTitle isPageHeading={false}>{title}</PageSectionTitle>
       )}
       {desc && <PageSectionDescription text={desc} />}
-      {cta && <PageSectionCTA href={cta.href}>{cta.text}</PageSectionCTA>}
+      {cta?.href && cta?.text && (
+        <PageSectionCTA href={cta.href}>{cta.text}</PageSectionCTA>
+      )}
     </div>
     <FlexContainer nowrap column>
       {features.map((feature) => (

--- a/packages/gamut-labs/src/landingPage/Hero.tsx
+++ b/packages/gamut-labs/src/landingPage/Hero.tsx
@@ -60,7 +60,9 @@ export const PageHero: React.FC<PageHeroProps> = ({
         </PageSectionTitle>
       )}
       {desc && <PageSectionDescription text={desc} />}
-      {cta && <PageSectionCTA href={cta.href}>{cta.text}</PageSectionCTA>}
+      {cta?.href && cta?.text && (
+        <PageSectionCTA href={cta.href}>{cta.text}</PageSectionCTA>
+      )}
     </Column>
     {imgSrc && (
       <RightColumn size={3}>

--- a/packages/gamut-labs/src/landingPage/Prefooter.tsx
+++ b/packages/gamut-labs/src/landingPage/Prefooter.tsx
@@ -48,7 +48,7 @@ export const PagePrefooter: React.FC<BaseProps> = ({
         {Title}
         {Desc}
       </FlexContent>
-      <CTA href={cta.href}>{cta.text}</CTA>
+      {cta?.href && cta?.text && <CTA href={cta.href}>{cta.text}</CTA>}
     </FlexContainer>
   ) : (
     <NoFlexContainer>

--- a/packages/gamut-labs/src/landingPage/Prefooter.tsx
+++ b/packages/gamut-labs/src/landingPage/Prefooter.tsx
@@ -42,15 +42,19 @@ export const PagePrefooter: React.FC<BaseProps> = ({
   const Title = title && <PageSectionTitle>{title}</PageSectionTitle>;
   const Desc = desc && <PageSectionDescription text={desc} />;
 
-  return cta ? (
-    <FlexContainer nowrap column justify="spaceBetween">
-      <FlexContent>
-        {Title}
-        {Desc}
-      </FlexContent>
-      {cta?.href && cta?.text && <CTA href={cta.href}>{cta.text}</CTA>}
-    </FlexContainer>
-  ) : (
+  if (cta && cta?.href && cta?.text) {
+    return (
+      <FlexContainer nowrap column justify="spaceBetween">
+        <FlexContent>
+          {Title}
+          {Desc}
+        </FlexContent>
+        <CTA href={cta.href}>{cta.text}</CTA>
+      </FlexContainer>
+    );
+  }
+
+  return (
     <NoFlexContainer>
       {Title}
       {Desc}


### PR DESCRIPTION
if href and text are empty strings, don't display.