### PR TITLE
feat(focus-visible): Add stylis plugin for focus-visible support WEB-1148

### DIFF
--- a/packages/gamut-styles/src/cache.ts
+++ b/packages/gamut-styles/src/cache.ts
@@ -1,4 +1,4 @@
-import createCache, { Options } from '@emotion/cache';
+import createCache, { Options, StylisPlugin } from '@emotion/cache';
 
 export const EMOTION_KEY = 'gamut';
 export const EMOTION_CONTAINER = 'emotion-styles';
@@ -19,10 +19,20 @@ const getEmotionNode = () => {
   return node;
 };
 
+const focusVisible: StylisPlugin = (element) => {
+  if (element.type === 'rule' && element.value.includes(':focus-visible')) {
+    element.props = element.props.map((prop) =>
+      prop.replace(/:focus-visible/g, '[data-focus-visible-added]')
+    );
+  }
+  return undefined;
+};
+
 export const createEmotionCache = (optionOverrides?: Partial<Options>) =>
   createCache({
     key: EMOTION_KEY,
     speedy: true,
     container: getEmotionNode(),
+    stylisPlugins: [focusVisible],
     ...optionOverrides,
   });

--- a/packages/gamut-styles/src/cache/index.ts
+++ b/packages/gamut-styles/src/cache/index.ts
@@ -1,4 +1,5 @@
-import createCache, { Options, StylisPlugin } from '@emotion/cache';
+import createCache, { Options } from '@emotion/cache';
+import { focusVisible } from './stylisPlugins';
 
 export const EMOTION_KEY = 'gamut';
 export const EMOTION_CONTAINER = 'emotion-styles';
@@ -17,15 +18,6 @@ const getEmotionNode = () => {
   // if this has not been created add it to the DOM at the top of the body
   document.getElementsByTagName('body')[0].prepend(node);
   return node;
-};
-
-const focusVisible: StylisPlugin = (element) => {
-  if (element.type === 'rule' && element.value.includes(':focus-visible')) {
-    element.props = element.props.map((prop) =>
-      prop.replace(/:focus-visible/g, '[data-focus-visible-added]')
-    );
-  }
-  return undefined;
 };
 
 export const createEmotionCache = (optionOverrides?: Partial<Options>) =>

--- a/packages/gamut-styles/src/cache/stylisPlugins/focusVisible.ts
+++ b/packages/gamut-styles/src/cache/stylisPlugins/focusVisible.ts
@@ -1,0 +1,10 @@
+import { StylisPlugin } from '@emotion/cache';
+
+export const focusVisible: StylisPlugin = (element) => {
+  if (element.type === 'rule' && element.value.includes(':focus-visible')) {
+    element.props = element.props.map((prop) =>
+      prop.replace(/:focus-visible/g, '[data-focus-visible-added]')
+    );
+  }
+  return undefined;
+};

--- a/packages/gamut-styles/src/cache/stylisPlugins/index.ts
+++ b/packages/gamut-styles/src/cache/stylisPlugins/index.ts
@@ -1,0 +1,1 @@
+export * from './focusVisible';


### PR DESCRIPTION
### Overview

Emotion focus-visible support 🚀 
Authors: @dreamwasp @JoshuaKGoldberg @codecaaron 

<!--- CHANGELOG-DESCRIPTION -->
* Adds simple plugin to translate all `:focus-visible` pseudo selectors to the appropriate polyfill data-attribute on emotion components.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: WEB-1148
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Changes

Using emotions processor https://stylis.js.org/

A few fun things:
- All elements are mutable so we must overwrite the values.
- It's unclear why the API is "prop", but we're still investigating.
