### PR TITLE
fix(Styleguide): Add sectioning in a nice way

### DIFF
--- a/packages/gamut-system/src/core/createHandler/index.ts
+++ b/packages/gamut-system/src/core/createHandler/index.ts
@@ -50,14 +50,11 @@ export const createHandler = <
     transformValue,
   });
 
-  // Assign the scale key to the styleTemplate
-  const template = Object.assign(styleTemplate, { scale: config.scale });
-
   // Create a container to place composed style templates in.
   // This only contains our one requested style template to start, but might be added to later,
   // if compose combines this with other templates.
   const styleTemplates = {
-    [propName]: template,
+    [propName]: styleTemplate,
   } as Partial<
     Record<
       keyof ThematicProps<Theme, Config>,

--- a/packages/gamut-system/src/core/createHandler/index.ts
+++ b/packages/gamut-system/src/core/createHandler/index.ts
@@ -50,11 +50,14 @@ export const createHandler = <
     transformValue,
   });
 
+  // Assign the scale key to the styleTemplate
+  const template = Object.assign(styleTemplate, { scale: config.scale });
+
   // Create a container to place composed style templates in.
   // This only contains our one requested style template to start, but might be added to later,
   // if compose combines this with other templates.
   const styleTemplates = {
-    [propName]: styleTemplate,
+    [propName]: template,
   } as Partial<
     Record<
       keyof ThematicProps<Theme, Config>,

--- a/packages/styleguide/.storybook/addons/system/enhancers.ts
+++ b/packages/styleguide/.storybook/addons/system/enhancers.ts
@@ -6,7 +6,7 @@ import * as system from '@codecademy/gamut-styles/src/system';
 const DOCS_LINK =
   'Responsive Property [spec](https://github.com/Codecademy/client-modules/blob/main/packages/gamut-system/docs/responsive.md)';
 
-const { properties, variant } = system;
+const { properties, variant, ...groups } = system;
 
 const systemProps = Object.entries(properties).reduce<string[]>(
   (carry, [key, handler]) => {
@@ -58,18 +58,61 @@ const updateConrol = (arg) => {
   }
 };
 
-const enrichArg = compose(updateConrol, updateDescription, parseScaleValue);
+const updateCategory = (arg) => {
+  const group = Object.entries(groups).find(([key, { propNames }]) =>
+    propNames.includes(arg.name)
+  )[0];
+
+  return set('table.category', group, arg);
+};
+
+const enrichArg = compose(
+  updateCategory,
+  updateConrol,
+  updateDescription,
+  parseScaleValue
+);
 
 const formatSystemProps: ArgTypesEnhancer = ({ parameters }) => {
   const { argTypes } = parameters;
   return mapValues((args) => {
-    if (args.name === 'theme') {
+    if (
+      args.name === 'theme' &&
+      args.table.type.summary.indexOf('Theme') > -1
+    ) {
       return {
         ...args,
+        table: {
+          ...args.table,
+          category: 'base',
+        },
         description: 'Codecademy Theme',
         control: {
           ...args.control,
           disable: true,
+        },
+      };
+    }
+
+    if (args.name === 'as') {
+      const summary = get('table.type.summary', args);
+      const options = sortScale(summary.split(' | '));
+
+      return {
+        ...args,
+        description:
+          'Configures what element tag this component should present as',
+        table: {
+          ...args.table,
+          category: 'base',
+        },
+        control: {
+          ...args.control,
+          type: 'select',
+          options: map(
+            (val) => (typeof val === 'string' ? val.replace(/"/g, '') : val),
+            options
+          ),
         },
       };
     }

--- a/packages/styleguide/.storybook/addons/system/enhancers.ts
+++ b/packages/styleguide/.storybook/addons/system/enhancers.ts
@@ -28,6 +28,10 @@ const sortScale = (scale: string[]) => {
   return scale;
 };
 
+const sanitizeOptions = map((val) =>
+  typeof val === 'string' ? val.replace(/"/g, '') : val
+);
+
 const formatSystemProps: ArgTypesEnhancer = ({ parameters }) => {
   const { argTypes } = parameters;
   return mapValues((arg) => {
@@ -63,10 +67,7 @@ const formatSystemProps: ArgTypesEnhancer = ({ parameters }) => {
         control: {
           ...arg.control,
           type: 'select',
-          options: map(
-            (val) => (typeof val === 'string' ? val.replace(/"/g, '') : val),
-            options
-          ),
+          options: sanitizeOptions(options),
         },
       };
     }
@@ -79,17 +80,13 @@ const formatSystemProps: ArgTypesEnhancer = ({ parameters }) => {
       const rawScale = arg?.table?.type?.summary;
       const options = rawScale && sortScale(getScale(rawScale).split(' | '));
       const parsedScale = options.join(' | ');
-      const sanitizedOptions = map(
-        (val) => (typeof val === 'string' ? val.replace(/"/g, '') : val),
-        options
-      ) as string[] | number[];
 
       let control: {
         type: 'string' | 'select';
-        options?: string[] | number[];
+        options?: unknown[];
       } = {
         type: 'select',
-        options: sanitizedOptions,
+        options: sanitizeOptions(options),
       };
 
       if (rawScale.indexOf('string') > -1) {

--- a/packages/styleguide/.storybook/components/PropsTable/index.tsx
+++ b/packages/styleguide/.storybook/components/PropsTable/index.tsx
@@ -44,7 +44,7 @@ export const PropsTable: React.FC<Parameters<typeof ArgsTable>[0]> = (
   const {
     parameters: { argTypes },
   } = context;
-  const [showSystemProps, toggleSystemProps] = useState(false);
+  const [showSystemProps, toggleSystemProps] = useState(true);
 
   const usedProps = useMemo<string[]>(
     () => Object.keys(argTypes).filter((prop) => systemProps.includes(prop)),

--- a/packages/styleguide/.storybook/components/PropsTable/index.tsx
+++ b/packages/styleguide/.storybook/components/PropsTable/index.tsx
@@ -1,6 +1,18 @@
 import React, { useContext, useState, useMemo } from 'react';
-import * as system from '@codecademy/gamut-styles/src/system';
-import { Toggle } from '@codecademy/gamut/src';
+import {
+  properties,
+  background,
+  typography,
+  space,
+  grid,
+  flex,
+  color,
+  shadow,
+  border,
+  positioning,
+  layout,
+} from '@codecademy/gamut-styles';
+import { Toggle } from '@codecademy/gamut';
 import { ArgsTable, DocsContext } from '@storybook/addon-docs/blocks';
 import { intersection } from 'lodash';
 import {
@@ -14,7 +26,18 @@ import {
   ToggleLabel,
 } from './Elements';
 
-const { properties, variant, ...groups } = system;
+const groups = {
+  typography,
+  space,
+  grid,
+  flex,
+  color,
+  shadow,
+  border,
+  background,
+  positioning,
+  layout,
+};
 
 const systemProps = Object.entries(properties).reduce<string[]>(
   (carry, [key, handler]) => {


### PR DESCRIPTION
### Overview

Found a better native way to do this with props tables.

<!--- CHANGELOG-DESCRIPTION -->
* Utilizes Storybook ArgsTable categories for system props.  Adding the correct groups through the addon enhancer.
* Ensures `theme` and `as` are categorized under a specific area.
<!--- END-CHANGELOG-DESCRIPTION -->

<img width="1083" alt="Screen Shot 2020-12-06 at 1 02 05 PM" src="https://user-images.githubusercontent.com/52927224/101288206-50e0eb00-37c3-11eb-9c54-789fe63fd410.png">

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change


