### PR TITLE
fix: Logo's defaultProps need to be of type LogoProps

### DIFF
--- a/packages/gamut-labs/src/brand/Logo/index.tsx
+++ b/packages/gamut-labs/src/brand/Logo/index.tsx
@@ -7,7 +7,7 @@ import { CodecademyProLockupLogo } from './CodecademyProLockupLogo';
 import { CodecademyProMonoLogo } from './CodecademyProMonoLogo';
 import { CodecademyPremiumLogo } from './CodecademyPremiumLogo';
 
-const defaultProps = {
+const defaultProps: LogoProps = {
   height: 32,
   type: 'default',
 };


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Changed `Logo`'s `defaultProps` to work with `styled(Logo)` in consumers.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: WEB-1140
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

Without this change, using `styled(Logo)` with Emotion gives:

```
    Argument of type 'typeof Logo' is not assignable to parameter of type 'ComponentClass<LogoProps, any>'.
```