### PR TITLE
feat:  Markdown anchor tag override for Landing Page components

### DIFF
--- a/packages/gamut-labs/src/landingPage/Description.tsx
+++ b/packages/gamut-labs/src/landingPage/Description.tsx
@@ -1,25 +1,37 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { BaseProps } from './types';
 
-import { Markdown } from '@codecademy/gamut';
+import {
+  Markdown,
+  MarkdownAnchor,
+  MarkdownAnchorProps,
+} from '@codecademy/gamut';
 
-const DescriptionContainer = styled.div`
+export const DescriptionContainer = styled.div`
   margin: 2rem 0 0;
   max-width: 38rem;
 `;
 
 export type DescriptionProps = {
   text: string;
-  className?: string;
-  testId?: string;
-};
+} & Pick<BaseProps, 'onMarkdownLinkClick'>;
 
 export const Description: React.FC<DescriptionProps> = ({
   text,
-  className,
-  testId,
+  onMarkdownLinkClick,
 }) => (
-  <DescriptionContainer className={className} data-testid={testId}>
-    <Markdown text={text} />
-  </DescriptionContainer>
+  <Markdown
+    text={text}
+    skipDefaultOverrides={{ a: true }}
+    overrides={{
+      a: {
+        component: (props: MarkdownAnchorProps) => (
+          <MarkdownAnchor href={props.href} onClick={onMarkdownLinkClick}>
+            {props.children}
+          </MarkdownAnchor>
+        ),
+      },
+    }}
+  />
 );

--- a/packages/gamut-labs/src/landingPage/Description.tsx
+++ b/packages/gamut-labs/src/landingPage/Description.tsx
@@ -26,11 +26,21 @@ export const Description: React.FC<DescriptionProps> = ({
     skipDefaultOverrides={{ a: true }}
     overrides={{
       a: {
-        component: (props: MarkdownAnchorProps) => (
-          <MarkdownAnchor href={props.href} onClick={onMarkdownLinkClick}>
-            {props.children}
+        component: ({ href, children }: MarkdownAnchorProps) => (
+          <MarkdownAnchor href={href} onClick={onMarkdownLinkClick}>
+            {children}
           </MarkdownAnchor>
         ),
+        // From https://github.com/bevacqua/insane/blob/master/defaults.js
+        allowedAttributes: [
+          'title',
+          'accesskey',
+          'href',
+          'name',
+          'target',
+          'aria-label',
+          'onclick',
+        ],
       },
     }}
   />

--- a/packages/gamut-labs/src/landingPage/Feature.tsx
+++ b/packages/gamut-labs/src/landingPage/Feature.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import { Heading, Markdown } from '@codecademy/gamut';
+import { Heading } from '@codecademy/gamut';
 import { mediaQueries } from '@codecademy/gamut-styles';
+import { Description } from './index';
+import { BaseProps } from './types';
 
 const Icon = styled.img`
   width: 4rem;
@@ -16,7 +18,7 @@ const Image = styled.img`
   margin-bottom: 2rem;
 `;
 
-const StyledMarkdown = styled(Markdown)`
+const StyledDescription = styled(Description)`
   font-size: 1rem;
 `;
 
@@ -60,7 +62,7 @@ export type FeatureProps = {
   desc?: string;
 
   testId?: string;
-};
+} & Pick<BaseProps, 'onMarkdownLinkClick'>;
 
 export const Feature: React.FC<FeatureProps> = ({
   isIcon,
@@ -69,6 +71,7 @@ export const Feature: React.FC<FeatureProps> = ({
   title,
   desc,
   testId,
+  onMarkdownLinkClick,
 }) => (
   <FeatureBlock data-testid={testId}>
     {isIcon ? (
@@ -83,7 +86,10 @@ export const Feature: React.FC<FeatureProps> = ({
     )}
     {desc && (
       <div>
-        <StyledMarkdown text={desc} />
+        <StyledDescription
+          text={desc}
+          onMarkdownLinkClick={onMarkdownLinkClick}
+        />
       </div>
     )}
   </FeatureBlock>

--- a/packages/gamut-labs/src/landingPage/PageFeatures.tsx
+++ b/packages/gamut-labs/src/landingPage/PageFeatures.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import { Container } from '@codecademy/gamut';
-import { CTA, Title, Description, Feature, FeatureProps } from './';
+import {
+  CTA,
+  Title,
+  Description,
+  DescriptionContainer,
+  Feature,
+  FeatureProps,
+} from './index';
 import { mediaQueries } from '@codecademy/gamut-styles';
 import { BaseProps } from './types';
 
@@ -16,7 +23,10 @@ export type PageFeaturesProps = BaseProps & {
   /**
    * Array of features, which consist of image, image alt, title, and description
    */
-  features: Omit<FeatureProps, 'isIcon'>[];
+  features: Pick<
+    FeatureProps,
+    'imgSrc' | 'imgAlt' | 'title' | 'desc' | 'testId'
+  >[];
 
   /**
    * Whether an icon or a full size image should be rendered
@@ -31,11 +41,16 @@ export const PageFeatures: React.FC<PageFeaturesProps> = ({
   features,
   isIcon,
   testId,
+  onMarkdownLinkClick,
 }) => (
   <div data-testid={testId}>
     <div>
       {title && <Title isPageHeading={false}>{title}</Title>}
-      {desc && <Description text={desc} />}
+      {desc && (
+        <DescriptionContainer>
+          <Description text={desc} onMarkdownLinkClick={onMarkdownLinkClick} />
+        </DescriptionContainer>
+      )}
       {cta && (
         <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
           {cta.text}
@@ -44,7 +59,12 @@ export const PageFeatures: React.FC<PageFeaturesProps> = ({
     </div>
     <FlexContainer nowrap column>
       {features.map((feature) => (
-        <Feature {...feature} isIcon={isIcon} key={feature.title} />
+        <Feature
+          {...feature}
+          isIcon={isIcon}
+          key={feature.title}
+          onMarkdownLinkClick={onMarkdownLinkClick}
+        />
       ))}
     </FlexContainer>
   </div>

--- a/packages/gamut-labs/src/landingPage/PageFeatures.tsx
+++ b/packages/gamut-labs/src/landingPage/PageFeatures.tsx
@@ -47,7 +47,7 @@ export const PageFeatures: React.FC<PageFeaturesProps> = ({
     <div>
       {title && <Title isPageHeading={false}>{title}</Title>}
       {desc && (
-        <DescriptionContainer>
+        <DescriptionContainer data-testid={`${testId}-description`}>
           <Description text={desc} onMarkdownLinkClick={onMarkdownLinkClick} />
         </DescriptionContainer>
       )}

--- a/packages/gamut-labs/src/landingPage/PageHero.tsx
+++ b/packages/gamut-labs/src/landingPage/PageHero.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import { LayoutGrid, Column } from '@codecademy/gamut';
 import { breakpoints } from '@codecademy/gamut-styles';
-import { CTA, Title, Description } from './';
+import { CTA, Title, Description, DescriptionContainer } from './index';
 import { BaseProps } from './types';
 
 const RightColumn = styled(Column)`
@@ -36,6 +36,7 @@ export const PageHero: React.FC<PageHeroProps> = ({
   imgSrc,
   imgAlt = '',
   testId,
+  onMarkdownLinkClick,
 }) => (
   <LayoutGrid testId={testId}>
     <Column
@@ -45,7 +46,11 @@ export const PageHero: React.FC<PageHeroProps> = ({
       }}
     >
       {title && <Title isPageHeading>{title}</Title>}
-      {desc && <Description text={desc} />}
+      {desc && (
+        <DescriptionContainer>
+          <Description text={desc} onMarkdownLinkClick={onMarkdownLinkClick} />
+        </DescriptionContainer>
+      )}
       {cta && (
         <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
           {cta.text}

--- a/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
+++ b/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { Container } from '@codecademy/gamut';
 import { mediaQueries } from '@codecademy/gamut-styles';
 
-import { CTA, Title, Description } from './';
+import { CTA, Title, Description, DescriptionContainer } from './index';
 import { BaseProps } from './types';
 
 const FlexContainer = styled(Container)`
@@ -28,9 +28,14 @@ export const PagePrefooter: React.FC<BaseProps> = ({
   desc,
   cta,
   testId,
+  onMarkdownLinkClick,
 }) => {
   const SectionTitle = title && <Title>{title}</Title>;
-  const Desc = desc && <Description text={desc} />;
+  const Desc = desc && (
+    <DescriptionContainer>
+      <Description text={desc} onMarkdownLinkClick={onMarkdownLinkClick} />
+    </DescriptionContainer>
+  );
 
   return cta ? (
     <FlexContainer nowrap column justify="spaceBetween">

--- a/packages/gamut-labs/src/landingPage/__tests__/FeaturesSection-test.tsx
+++ b/packages/gamut-labs/src/landingPage/__tests__/FeaturesSection-test.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import {
-  PageFeatures,
-  PageFeaturesProps,
-  CTA,
-  Description,
-  Title,
-  Feature,
-} from '..';
+import { PageFeatures, PageFeaturesProps, CTA, Title, Feature } from '..';
 
 const renderComponent = (overrides: Partial<PageFeaturesProps> = {}) => {
   const props = {
@@ -38,13 +31,18 @@ describe('PageFeatures', () => {
   });
 
   it('renders a description when desc prop is provided', () => {
-    const wrapper = renderComponent({ desc: 'Test Description' });
-    expect(wrapper.find(Description).prop('text')).toEqual('Test Description');
+    const wrapper = renderComponent({
+      desc: 'Test Description',
+      testId: 'test',
+    });
+    expect(
+      wrapper.find('div[data-testid="test-description"]').text()
+    ).toContain('Test Description');
   });
 
   it('does not render a description when desc prop is not provided', () => {
     const wrapper = renderComponent();
-    expect(wrapper.find(Description)).toHaveLength(0);
+    expect(wrapper.find('div[data-testid="test-description"]')).toHaveLength(0);
   });
 
   it('renders a cta button when cta prop is provided', () => {

--- a/packages/gamut-labs/src/landingPage/types.tsx
+++ b/packages/gamut-labs/src/landingPage/types.tsx
@@ -5,6 +5,10 @@ export type BaseProps = {
    */
   desc?: string;
   /**
+   * Callback when a markdown anchor tag is clicked
+   */
+  onMarkdownLinkClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+  /**
    * text: button text
    *
    * href: url to navigate to when clicking the button


### PR DESCRIPTION
(**NOTE: Dependent on & to be merged after: https://github.com/Codecademy/client-modules/pull/1228**)
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Refactors `Description` to use an override in its `Markdown` component for `a` tags. The override is a `MarkdownAnchor` with an additional `onClick` prop, to be able to pass a `onMarkdownLinkClick` callback function to the `<a/>` elements.
<!--- END-CHANGELOG-DESCRIPTION -->

#### Why?
For our [landing page components](https://github.com/Codecademy/client-modules/tree/main/packages/gamut-labs/src/landingPage), we want to track clicks for links rendered inside markdown when building the pages in static sites.

#### Primary Change
https://github.com/Codecademy/client-modules/blob/9eef59bc5ae744a83243cbf1c430e68b86278b22/packages/gamut-labs/src/landingPage/Description.tsx#L24-L46

### Testing
You can test implementation by going to https://tayra.codecademy.com/pages/a-test-page and clicking on a markdown link.
Open the console and see network calls for tracking being sent.

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket:  [REACH-453](https://codecademy.atlassian.net/browse/REACH-453)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change