### PR TITLE
fix(FillButton): corrected hover styles on FillButton in dark mode

### DIFF
--- a/packages/gamut-styles/src/variables/colors.ts
+++ b/packages/gamut-styles/src/variables/colors.ts
@@ -18,6 +18,7 @@ export const swatches = {
   },
   yellow: {
     '0': '#FFFAE5',
+    '400': '#CCA900',
     '500': '#FFD300',
   },
   pink: {

--- a/packages/gamut/src/Button/FillButton.tsx
+++ b/packages/gamut/src/Button/FillButton.tsx
@@ -1,4 +1,3 @@
-import { swatches } from '@codecademy/gamut-styles';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
@@ -18,7 +17,7 @@ const FillButtonInner = styled(ButtonInner)<ButtonProps>(
       padding: 0.75rem 1rem;
 
       ${FillButtonOuter}:hover & {
-        background-color: ${swatches.hyper['400']};
+        background-color: ${modeColors.backgroundDull};
       }
 
       ${FillButtonOuter}:disabled &,

--- a/packages/gamut/src/Button/shared.ts
+++ b/packages/gamut/src/Button/shared.ts
@@ -9,6 +9,7 @@ export type ButtonProps = HTMLProps<HTMLLinkElement> &
 export const modeColorGroups = {
   dark: {
     background: colors.yellow,
+    backgroundDull: colors.yellow[400],
     backgroundEmphasized: swatches.gray[900],
     backgroundMuted: swatches.gray[600],
     foregroundMuted: swatches.gray[200],
@@ -17,6 +18,7 @@ export const modeColorGroups = {
   },
   light: {
     background: colors.hyper,
+    backgroundDull: swatches.hyper[400],
     backgroundEmphasized: swatches.gray[100],
     backgroundMuted: swatches.gray[200],
     foregroundMuted: swatches.gray[600],

--- a/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
@@ -42,6 +42,8 @@ import { StoryStatus } from '~styleguide/blocks';
 We have several versions of buttons that you can use.
 Each supports a _light_ and _dark_ mode.
 
+See the [Figma designs](https://www.figma.com/file/N6TfoPI5OA7GanX6Zl8nWj/Buttons-%E2%9C%85?node-id=268%3A0) for a nice grid view of all the variants.
+
 ## CTA Button
 
 <Canvas>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Correct `FillButton`'s hover color in dark mode to be a duller yellow instead of a hyper.

<!--- END-CHANGELOG-DESCRIPTION -->

Also adds a link to the Figma doc in Storybook.

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/N6TfoPI5OA7GanX6Zl8nWj/Buttons-%E2%9C%85?node-id=268%3A0
- [x] Related to JIRA ticket: WEB-1197
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
