### PR TITLE
feat(Markdown): Add onAnchorClick prop

### DIFF
--- a/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
@@ -2,6 +2,7 @@
 
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 
 import { Markdown } from '../index';
 
@@ -191,6 +192,23 @@ var test = true;
         <Markdown text={`<a href="http://google.com">google</a>`} />
       );
       expect(markdown.find('a[rel="noopener"]').length).toEqual(1);
+    });
+
+    it('Allows onClicks callbacks', () => {
+      const onClick = jest.fn();
+
+      const markdown = mount(
+        <Markdown
+          text={`<a data-testid="testLink" href="http://google.com">google</a>`}
+          onAnchorClick={onClick}
+        />
+      );
+
+      act(() => {
+        markdown.find(`a[href="http://google.com"]`).simulate('click');
+      });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -86,6 +86,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
           component: (props: MarkdownAnchorProps) => (
             <MarkdownAnchor onClick={onAnchorClick} {...props} />
           ),
+          allowedAttributes: ['onClick'],
         }),
       !skipDefaultOverrides.table &&
         createTagOverride('table', {

--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -12,8 +12,11 @@ import {
   standardOverrides,
 } from './libs/overrides';
 import { Iframe } from './libs/overrides/Iframe';
-import { MarkdownAnchor } from './libs/overrides/MarkdownAnchor';
-import { Table } from './libs/overrides/Table';
+import {
+  MarkdownAnchor,
+  MarkdownAnchorProps,
+} from './libs/overrides/MarkdownAnchor';
+import { Table, TableProps } from './libs/overrides/Table';
 import { createPreprocessingInstructions } from './libs/preprocessing';
 import { defaultSanitizationConfig } from './libs/sanitizationConfig';
 import styles from './styles/index.module.scss';
@@ -41,6 +44,10 @@ export type MarkdownProps = {
   skipDefaultOverrides?: SkipDefaultOverridesSettings;
   spacing?: 'loose' | 'tight' | 'none';
   text?: string;
+  /**
+   * Callback when a markdown anchor tag is clicked
+   */
+  onAnchorClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
 export class Markdown extends PureComponent<MarkdownProps> {
@@ -52,6 +59,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
       overrides: userOverrides = {},
       skipDefaultOverrides = {},
       inline = false,
+      onAnchorClick = () => null,
     } = this.props;
 
     if (!text) return null;
@@ -75,11 +83,13 @@ export class Markdown extends PureComponent<MarkdownProps> {
         }),
       !skipDefaultOverrides.a &&
         createTagOverride('a', {
-          component: MarkdownAnchor,
+          component: (props: MarkdownAnchorProps) => (
+            <MarkdownAnchor onClick={onAnchorClick} {...props} />
+          ),
         }),
       !skipDefaultOverrides.table &&
         createTagOverride('table', {
-          component: (props) => (
+          component: (props: TableProps) => (
             <Table maxHeight={spacing === 'tight' ? 180 : 500} {...props} />
           ),
           allowedAttributes: ['style'],


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Adds an `onAnchorClick` prop to the Markdown component for passing down to `<a/>` tags.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist
- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-453](https://codecademy.atlassian.net/browse/REACH-453)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

