### PR TITLE
feat: added size prop for buttons

### DIFF
--- a/packages/gamut/src/Button/ButtonInner.tsx
+++ b/packages/gamut/src/Button/ButtonInner.tsx
@@ -4,7 +4,8 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const ButtonInner = styled('span', {
-  shouldForwardProp: (prop: string) => isPropValid(prop) && prop !== 'mode',
+  shouldForwardProp: (prop: string) =>
+    isPropValid(prop) && !['mode', 'size'].includes(prop),
 })(() => {
   return css`
     display: flex;

--- a/packages/gamut/src/Button/FillButton.tsx
+++ b/packages/gamut/src/Button/FillButton.tsx
@@ -4,17 +4,17 @@ import React from 'react';
 
 import { ButtonInner } from './ButtonInner';
 import { ButtonOutline } from './ButtonOutline';
-import { ButtonProps, modeColorGroups } from './shared';
+import { buttonSizing, modeColorGroups, SizedButtonProps } from './shared';
 
-const FillButtonInner = styled(ButtonInner)<ButtonProps>(
-  ({ mode = 'light' }: ButtonProps) => {
+const FillButtonInner = styled(ButtonInner)<SizedButtonProps>(
+  ({ mode = 'light', size }: SizedButtonProps) => {
     const modeColors = modeColorGroups[mode];
 
     return css`
       background-color: ${modeColors.background};
       border-radius: 3px;
       color: ${modeColors.foreground};
-      padding: 0.75rem 1rem;
+      ${buttonSizing(size)}
 
       ${FillButtonOuter}:hover & {
         background-color: ${modeColors.backgroundDull};
@@ -34,12 +34,14 @@ const FillButtonOuter = styled(ButtonOutline)`
   padding: 1px;
 `;
 
-export const FillButton: React.FC<React.ComponentProps<
-  typeof FillButtonOuter
->> = ({ children, mode, ...props }) => {
+export const FillButton: React.FC<
+  SizedButtonProps & React.ComponentProps<typeof FillButtonOuter>
+> = ({ children, mode, size, ...props }) => {
   return (
     <FillButtonOuter mode={mode} {...props}>
-      <FillButtonInner mode={mode}>{children}</FillButtonInner>
+      <FillButtonInner mode={mode} size={size}>
+        {children}
+      </FillButtonInner>
     </FillButtonOuter>
   );
 };

--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -1,19 +1,20 @@
 import { GamutIconProps } from '@codecademy/gamut-icons';
 import React from 'react';
 
+import { SizedButtonProps } from './shared';
 import { TextButton } from './TextButton';
 
-export type IconButtonProps = {
+export type IconButtonProps = SizedButtonProps & {
   children: never;
   icon: React.ComponentType<GamutIconProps>;
 };
 
 export const IconButton: React.FC<
   IconButtonProps & React.ComponentProps<typeof TextButton>
-> = ({ icon: Icon, ...props }) => {
+> = ({ icon: Icon, size, ...props }) => {
   return (
-    <TextButton {...props}>
-      <Icon size={24} />
+    <TextButton size={size} {...props}>
+      <Icon size={size === 'small' ? 12 : 24} />
     </TextButton>
   );
 };

--- a/packages/gamut/src/Button/StrokeButton.tsx
+++ b/packages/gamut/src/Button/StrokeButton.tsx
@@ -5,17 +5,17 @@ import React from 'react';
 
 import { ButtonInner } from './ButtonInner';
 import { ButtonOutline } from './ButtonOutline';
-import { ButtonProps, modeColorGroups } from './shared';
+import { buttonSizing, modeColorGroups, SizedButtonProps } from './shared';
 
-const StrokeButtonInner = styled(ButtonInner)<ButtonProps>(
-  ({ mode = 'light' }: ButtonProps) => {
+const StrokeButtonInner = styled(ButtonInner)<SizedButtonProps>(
+  ({ mode = 'light', size }: SizedButtonProps) => {
     const modeColors = modeColorGroups[mode];
 
     return css`
       border: 2px solid ${modeColors.background};
       border-radius: 3px;
       color: ${modeColors.background};
-      padding: 0.75rem 1rem;
+      ${buttonSizing(size)}
 
       ${StrokeButtonOuter}:hover & {
         background-color: ${modeColors.backgroundEmphasized};
@@ -41,12 +41,14 @@ const StrokeButtonOuter = styled(ButtonOutline)`
   padding: 1px;
 `;
 
-export const StrokeButton: React.FC<React.ComponentProps<
-  typeof StrokeButtonOuter
->> = ({ children, mode, ...props }) => {
+export const StrokeButton: React.FC<
+  SizedButtonProps & React.ComponentProps<typeof StrokeButtonOuter>
+> = ({ children, mode, size, ...props }) => {
   return (
     <StrokeButtonOuter mode={mode} {...props}>
-      <StrokeButtonInner mode={mode}>{children}</StrokeButtonInner>
+      <StrokeButtonInner mode={mode} size={size}>
+        {children}
+      </StrokeButtonInner>
     </StrokeButtonOuter>
   );
 };

--- a/packages/gamut/src/Button/TextButton.tsx
+++ b/packages/gamut/src/Button/TextButton.tsx
@@ -4,16 +4,16 @@ import React from 'react';
 
 import { ButtonInner } from './ButtonInner';
 import { ButtonOutline } from './ButtonOutline';
-import { ButtonProps, modeColorGroups } from './shared';
+import { buttonSizing, modeColorGroups, SizedButtonProps } from './shared';
 
-const TextButtonInner = styled(ButtonInner)<ButtonProps>(
-  ({ mode = 'light' }: ButtonProps) => {
+const TextButtonInner = styled(ButtonInner)<SizedButtonProps>(
+  ({ mode = 'light', size }: SizedButtonProps) => {
     const modeColors = modeColorGroups[mode];
 
     return css`
       border-radius: 3px;
       color: ${modeColors.background};
-      padding: 0.75rem 1rem;
+      ${buttonSizing(size)}
 
       ${TextButtonOuter}:hover & {
         background-color: ${modeColors.backgroundEmphasized};
@@ -37,12 +37,14 @@ const TextButtonOuter = styled(ButtonOutline)`
   padding: 1px;
 `;
 
-export const TextButton: React.FC<React.ComponentProps<
-  typeof TextButtonOuter
->> = ({ children, mode, ...props }) => {
+export const TextButton: React.FC<
+  SizedButtonProps & React.ComponentProps<typeof TextButtonOuter>
+> = ({ children, mode, size, ...props }) => {
   return (
     <TextButtonOuter mode={mode} {...props}>
-      <TextButtonInner mode={mode}>{children}</TextButtonInner>
+      <TextButtonInner mode={mode} size={size}>
+        {children}
+      </TextButtonInner>
     </TextButtonOuter>
   );
 };

--- a/packages/gamut/src/Button/shared.ts
+++ b/packages/gamut/src/Button/shared.ts
@@ -1,10 +1,27 @@
-import { colors, swatches } from '@codecademy/gamut-styles';
+import { colors, fontSize, swatches } from '@codecademy/gamut-styles';
 import type { HTMLProps } from 'react';
 
 export type ButtonProps = HTMLProps<HTMLLinkElement> &
   HTMLProps<HTMLButtonElement> & {
     mode?: 'dark' | 'light';
   };
+
+export type ButtonSize = 'normal' | 'small';
+
+export type SizedButtonProps = ButtonProps & {
+  size?: ButtonSize;
+};
+
+export const buttonSizing = (size?: ButtonSize) =>
+  size === 'small'
+    ? `
+      font-size: ${fontSize[14]};
+      padding: 0.35rem 0.5rem;
+    `
+    : `
+      font-size: ${fontSize[16]};
+      padding: 0.75rem 1rem;
+    `;
 
 export const modeColorGroups = {
   dark: {

--- a/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
@@ -17,10 +17,14 @@ import { StoryStatus } from '~styleguide/blocks';
   args={{
     children: 'Click Me',
     disabled: false,
-    mode: 'light',
     href: '',
+    mode: 'light',
+    size: 'normal',
   }}
   argTypes={{
+    href: {
+      description: 'If defined, component will use an anchor tag',
+    },
     mode: {
       description: 'Visual mode',
       control: {
@@ -28,8 +32,12 @@ import { StoryStatus } from '~styleguide/blocks';
         options: ['dark', 'light'],
       },
     },
-    href: {
-      description: 'If defined, component will use an anchor tag',
+    size: {
+      description: 'Visual size',
+      control: {
+        type: 'select',
+        options: ['normal', 'small'],
+      },
     },
   }}
   title="Atoms/Button"
@@ -43,6 +51,7 @@ We have several versions of buttons that you can use.
 Each supports a _light_ and _dark_ mode.
 
 See the [Figma designs](https://www.figma.com/file/N6TfoPI5OA7GanX6Zl8nWj/Buttons-%E2%9C%85?node-id=268%3A0) for a nice grid view of all the variants.
+All but CTA button support a size of either `normal` (default) or `small`.
 
 ## CTA Button
 

--- a/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
@@ -59,7 +59,7 @@ All but CTA button support a size of either `normal` (default) or `small`.
   <Story name="CTAButton">{(args) => <CTAButton {...args} />}</Story>
 </Canvas>
 
-<Props story="CTAButton" />
+<Props exclude={['size']} story="CTAButton" />
 
 ## Fill Button
 

--- a/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
+++ b/packages/styleguide/stories/Core/Atoms/Button/Button.stories.mdx
@@ -26,14 +26,12 @@ import { StoryStatus } from '~styleguide/blocks';
       description: 'If defined, component will use an anchor tag',
     },
     mode: {
-      description: 'Visual mode',
       control: {
         type: 'select',
         options: ['dark', 'light'],
       },
     },
     size: {
-      description: 'Visual size',
       control: {
         type: 'select',
         options: ['normal', 'small'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,6 +2147,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@codecademy/gamut-system@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@codecademy/gamut-system/-/gamut-system-0.1.6.tgz#40d84043cf0cf6d5734a07779164af16724fdb1d"
+  integrity sha512-xY2b/JYefFB1CAAyz69Qy/SKEqgtplwnoSgZ7zDLXlA+QBh9xhwqDDdZAJcpKKW7ajpl71G034rSkPdsfmfLVw==
+
 "@emotion/babel-plugin@11.0.0", "@emotion/babel-plugin@^11.0.0":
   version "11.0.0"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.0.0.tgz#e6f40fa81ef52775773a53d50220c597ebc5c2ef"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,11 +2147,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@codecademy/gamut-system@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.npmjs.org/@codecademy/gamut-system/-/gamut-system-0.1.6.tgz#40d84043cf0cf6d5734a07779164af16724fdb1d"
-  integrity sha512-xY2b/JYefFB1CAAyz69Qy/SKEqgtplwnoSgZ7zDLXlA+QBh9xhwqDDdZAJcpKKW7ajpl71G034rSkPdsfmfLVw==
-
 "@emotion/babel-plugin@11.0.0", "@emotion/babel-plugin@^11.0.0":
   version "11.0.0"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.0.0.tgz#e6f40fa81ef52775773a53d50220c597ebc5c2ef"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Added a `size` prop for buttons that defaults to `"normal"` but can also be `"small"`.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/N6TfoPI5OA7GanX6Zl8nWj/Buttons-%E2%9C%85?node-id=268%3A0
- [x] Related to JIRA ticket: WEB-1201
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Notes

smol: 
![Small button in storybook](https://user-images.githubusercontent.com/3335181/102121393-ee669b00-3e11-11eb-94f8-b97964aa26ca.png)
