### PR TITLE
feat(Landing Page Components): Allow passing callback for link clicks inside Markdown

### DIFF
--- a/packages/gamut-labs/src/landingPage/Description.tsx
+++ b/packages/gamut-labs/src/landingPage/Description.tsx
@@ -2,6 +2,8 @@ import { Markdown } from '@codecademy/gamut';
 import styled from '@emotion/styled';
 import React from 'react';
 
+import { BaseProps } from './types';
+
 const DescriptionContainer = styled.div`
   margin: 2rem 0 0;
   max-width: 38rem;
@@ -11,14 +13,15 @@ export type DescriptionProps = {
   text: string;
   className?: string;
   testId?: string;
-};
+} & Pick<BaseProps, 'onAnchorClick'>;
 
 export const Description: React.FC<DescriptionProps> = ({
   text,
   className,
   testId,
+  onAnchorClick,
 }) => (
   <DescriptionContainer className={className} data-testid={testId}>
-    <Markdown text={text} />
+    <Markdown text={text} onAnchorClick={onAnchorClick} />
   </DescriptionContainer>
 );

--- a/packages/gamut-labs/src/landingPage/Feature.tsx
+++ b/packages/gamut-labs/src/landingPage/Feature.tsx
@@ -3,6 +3,8 @@ import { mediaQueries } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
 import React from 'react';
 
+import { BaseProps } from './types';
+
 const Icon = styled.img`
   width: 4rem;
   margin-top: 3rem;
@@ -47,19 +49,7 @@ export type FeatureProps = {
    * Feature image alt text (for screen readers)
    */
   imgAlt?: string;
-
-  /**
-   * Feature title text
-   */
-  title?: string;
-
-  /**
-   * Feature body text as markdown
-   */
-  desc?: string;
-
-  testId?: string;
-};
+} & Pick<BaseProps, 'title' | 'desc' | 'onAnchorClick' | 'testId'>;
 
 export const Feature: React.FC<FeatureProps> = ({
   isIcon,
@@ -67,6 +57,7 @@ export const Feature: React.FC<FeatureProps> = ({
   imgAlt = '',
   title,
   desc,
+  onAnchorClick,
   testId,
 }) => (
   <FeatureBlock data-testid={testId}>
@@ -82,7 +73,7 @@ export const Feature: React.FC<FeatureProps> = ({
     )}
     {desc && (
       <div>
-        <StyledMarkdown text={desc} />
+        <StyledMarkdown text={desc} onAnchorClick={onAnchorClick} />
       </div>
     )}
   </FeatureBlock>

--- a/packages/gamut-labs/src/landingPage/PageFeatures.tsx
+++ b/packages/gamut-labs/src/landingPage/PageFeatures.tsx
@@ -16,7 +16,10 @@ export type PageFeaturesProps = BaseProps & {
   /**
    * Array of features, which consist of image, image alt, title, and description
    */
-  features: Omit<FeatureProps, 'isIcon'>[];
+  features: Pick<
+    FeatureProps,
+    'imgSrc' | 'imgAlt' | 'title' | 'desc' | 'testId'
+  >[];
 
   /**
    * Whether an icon or a full size image should be rendered
@@ -31,11 +34,12 @@ export const PageFeatures: React.FC<PageFeaturesProps> = ({
   features,
   isIcon,
   testId,
+  onAnchorClick,
 }) => (
   <div data-testid={testId}>
     <div>
       {title && <Title isPageHeading={false}>{title}</Title>}
-      {desc && <Description text={desc} />}
+      {desc && <Description text={desc} onAnchorClick={onAnchorClick} />}
       {cta && (
         <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
           {cta.text}
@@ -44,7 +48,12 @@ export const PageFeatures: React.FC<PageFeaturesProps> = ({
     </div>
     <FlexContainer nowrap column>
       {features.map((feature) => (
-        <Feature {...feature} isIcon={isIcon} key={feature.title} />
+        <Feature
+          {...feature}
+          isIcon={isIcon}
+          key={feature.title}
+          onAnchorClick={onAnchorClick}
+        />
       ))}
     </FlexContainer>
   </div>

--- a/packages/gamut-labs/src/landingPage/PageHero.tsx
+++ b/packages/gamut-labs/src/landingPage/PageHero.tsx
@@ -36,6 +36,7 @@ export const PageHero: React.FC<PageHeroProps> = ({
   imgSrc,
   imgAlt = '',
   testId,
+  onAnchorClick,
 }) => (
   <LayoutGrid testId={testId}>
     <Column
@@ -45,7 +46,7 @@ export const PageHero: React.FC<PageHeroProps> = ({
       }}
     >
       {title && <Title isPageHeading>{title}</Title>}
-      {desc && <Description text={desc} />}
+      {desc && <Description text={desc} onAnchorClick={onAnchorClick} />}
       {cta && (
         <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
           {cta.text}

--- a/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
+++ b/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
@@ -27,10 +27,12 @@ export const PagePrefooter: React.FC<BaseProps> = ({
   title,
   desc,
   cta,
-  testId,
+  onAnchorClick,
 }) => {
   const SectionTitle = title && <Title>{title}</Title>;
-  const Desc = desc && <Description text={desc} />;
+  const Desc = desc && (
+    <Description text={desc} onAnchorClick={onAnchorClick} />
+  );
 
   return cta ? (
     <FlexContainer nowrap column justify="spaceBetween">

--- a/packages/gamut-labs/src/landingPage/__tests__/Hero-test.tsx
+++ b/packages/gamut-labs/src/landingPage/__tests__/Hero-test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { PageHero } from '..';
@@ -12,6 +12,23 @@ describe('PageHero', () => {
   it('should render a description when one is provided', () => {
     const wrapper = render(<PageHero desc="desc" />);
     wrapper.getByText('desc');
+  });
+
+  it('can pass a callback for when anchor tags in the description are clicked', () => {
+    const testOnClick = jest.fn();
+
+    const wrapper = render(
+      <PageHero
+        desc="[Rob Thomas of Matchbox Twenty](https://en.wikipedia.org/wiki/Rob_Thomas_(musician))"
+        onAnchorClick={testOnClick}
+      />
+    );
+
+    const link = wrapper.getByText('Rob Thomas of Matchbox Twenty');
+
+    fireEvent.click(link);
+
+    expect(testOnClick).toHaveBeenCalledTimes(1);
   });
 
   it('should render a button when cta prop is provided', () => {

--- a/packages/gamut-labs/src/landingPage/__tests__/Hero-test.tsx
+++ b/packages/gamut-labs/src/landingPage/__tests__/Hero-test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 import { PageHero } from '..';

--- a/packages/gamut-labs/src/landingPage/types.tsx
+++ b/packages/gamut-labs/src/landingPage/types.tsx
@@ -1,9 +1,13 @@
 export type BaseProps = {
   title?: string;
   /**
-   * Main body text (can include markdown)
+   * Body text as markdown
    */
   desc?: string;
+  /**
+   * Callback when a markdown anchor tag is clicked
+   */
+  onAnchorClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
   /**
    * text: button text
    *

--- a/packages/styleguide/stories/Labs/LandingPage/Organisms/PageHero.stories.mdx
+++ b/packages/styleguide/stories/Labs/LandingPage/Organisms/PageHero.stories.mdx
@@ -10,6 +10,8 @@ import { PageHero } from '@codecademy/gamut-labs/src';
       "I'd rather be listening to Grammy-Award winning 1999 hit Smooth by Santana",
     desc:
       'feat. [Rob Thomas of Matchbox Twenty](https://en.wikipedia.org/wiki/Rob_Thomas_(musician)) off the multi-platinum album',
+    onAnchorClick: () =>
+      console.log('You clicked me an anchor tag inside Markdown!'),
     cta: {
       text: 'Supernatural',
       href:


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Adds `onAnchorClick` to the `BaseProps` and for the `Feature` component to allow passing an `onAnchorClick` callback for descriptions rendered with Markdown.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist
- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-453](https://codecademy.atlassian.net/browse/REACH-453)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change


### Testing
1. https://5fd7bb7be9996200bdccaefe--gamut-preview.netlify.app/storybook/?path=/docs/labs-landingpage-organisms-pagehero--with-cta
2. Open Console
3. Click on `Rob Thomas of Matchbox Twenty `
4. See message output