### PR TITLE
feat: added focus-visible to newer buttons and similar

### DIFF
--- a/packages/gamut/src/AccordionButton/styles.module.scss
+++ b/packages/gamut/src/AccordionButton/styles.module.scss
@@ -18,7 +18,7 @@
     font-weight: normal;
     transition: background-color 0.15s ease-in-out;
 
-    &:focus {
+    &:focus-visible {
       border-color: $color-yellow-800;
     }
 

--- a/packages/gamut/src/Alert/styles.module.scss
+++ b/packages/gamut/src/Alert/styles.module.scss
@@ -88,7 +88,7 @@ $themeColors: (
       color: darken(map-get($map, "color"), 20%);
     }
 
-    &:focus,
+    &:focus-visible,
     &:active {
       box-shadow: 0 0 0 2px map-get($map, "color");
     }

--- a/packages/gamut/src/Banner/styles.module.scss
+++ b/packages/gamut/src/Banner/styles.module.scss
@@ -46,7 +46,7 @@ $close-button-color: fade-out($color-gray-900, 0.4);
   padding: 0.75rem;
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background-color: fade-out($color-gray-900, 0.94);
     box-shadow: none;
     color: $close-button-color;

--- a/packages/gamut/src/Button/ButtonOutline.tsx
+++ b/packages/gamut/src/Button/ButtonOutline.tsx
@@ -36,7 +36,7 @@ const StyledButtonOutline = styled('button', {
       user-select: none;
     }
 
-    &:focus {
+    &:focus-visible {
       box-shadow: 0 0 0 2px ${modeColors.background};
       outline: none;
     }


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Used `:focus-visible` instead of `:focus` in what feels like the remainder of relevant buttons that should have it.

<!--- END-CHANGELOG-DESCRIPTION -->

That's:

* The new buttons (amusing that they're getting it after the old SCSS ones)
* Accordion buttons
* Alert buttons
* Banner buttons


### PR Checklist

- [x] Related to designs: https://www.figma.com/file/N6TfoPI5OA7GanX6Zl8nWj/Buttons-%E2%9C%85?node-id=268%3A0
- [x] Related to JIRA ticket: WEB-1152
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
