### PR TITLE
fix: actually use testId prop in prefooter

### DIFF
--- a/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
+++ b/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
@@ -28,6 +28,7 @@ export const PagePrefooter: React.FC<BaseProps> = ({
   desc,
   cta,
   onAnchorClick,
+  testId,
 }) => {
   const SectionTitle = title && <Title>{title}</Title>;
   const Desc = desc && (
@@ -35,7 +36,7 @@ export const PagePrefooter: React.FC<BaseProps> = ({
   );
 
   return cta ? (
-    <FlexContainer nowrap column justify="spaceBetween">
+    <FlexContainer testId={testId} nowrap column justify="spaceBetween">
       <FlexContent>
         {SectionTitle}
         {Desc}
@@ -45,7 +46,7 @@ export const PagePrefooter: React.FC<BaseProps> = ({
       </StyledCTA>
     </FlexContainer>
   ) : (
-    <div>
+    <div data-testid={testId}>
       {SectionTitle}
       {Desc}
     </div>


### PR DESCRIPTION
### Overview

data-testid is helpful for e2e smoketesting, and we're already passing the prop in the dynamic renderer (it just isn't being applied lol woops)

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-452](https://codecademy.atlassian.net/browse/REACH-452)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
