### PR TITLE
feat: also export types from gamut-illustrations

### DIFF
--- a/packages/gamut-illustrations/src/index.ts
+++ b/packages/gamut-illustrations/src/index.ts
@@ -1,2 +1,3 @@
 export * from './BrowserLock';
 export * from './NumberBlocks';
+export * from './types';


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Also export the gamut-illustrations types file (so, `IllustrationProps`) so consumers can import it.

<!--- END-CHANGELOG-DESCRIPTION -->

One last thing; I noticed it'd be easier for me to set up the confirm page illustrations...

### PR Checklist

- ~[ ] Related to designs:~
- ~[ ] Related to JIRA ticket: ABC-123~
- ~[ ] I have run this code to verify it works~
- ~[ ] This PR includes unit tests for the code change~
