### PR TITLE
fix: update sideEffects values to fix tree shaking issues with css

### DIFF
--- a/packages/gamut-illustrations/package.json
+++ b/packages/gamut-illustrations/package.json
@@ -36,9 +36,6 @@
     "build": "yarn build:clean && yarn build:compile && yarn build:types",
     "lernaBuildTask": "yarn build"
   },
-  "sideEffects": [
-    "./dist/**/[A-Z]**/[A-Z]*.js",
-    "./dist/**/[A-Z]**/index.js"
-  ],
+  "sideEffects": false,
   "version": "0.3.0"
 }

--- a/packages/gamut-illustrations/package.json
+++ b/packages/gamut-illustrations/package.json
@@ -37,8 +37,8 @@
     "lernaBuildTask": "yarn build"
   },
   "sideEffects": [
-    "dist/**/[A-Z]**/[A-Z]*.js",
-    "dist/**/[A-Z]**/index.js"
+    "./dist/**/[A-Z]**/[A-Z]*.js",
+    "./dist/**/[A-Z]**/index.js"
   ],
   "version": "0.3.0"
 }

--- a/packages/gamut-labs/package.json
+++ b/packages/gamut-labs/package.json
@@ -5,9 +5,7 @@
   "author": "Codecademy Engineering <dev@codecademy.com>",
   "sideEffects": [
     "**/*.css",
-    "**/*.scss",
-    "**/[A-Z]*.js",
-    "**/[A-Z]*/index.js"
+    "**/*.scss"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/gamut-labs/package.json
+++ b/packages/gamut-labs/package.json
@@ -4,10 +4,10 @@
   "version": "7.5.2",
   "author": "Codecademy Engineering <dev@codecademy.com>",
   "sideEffects": [
-    "*.css",
-    "*.scss",
-    "dist/**/[A-Z]**/[A-Z]*.js",
-    "dist/**/[A-Z]**/index.js"
+    "./dist/**/*.css",
+    "./dist/**/*.scss",
+    "./dist/**/[A-Z]**/[A-Z]*.js",
+    "./dist/**/[A-Z]**/index.js"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/gamut-labs/package.json
+++ b/packages/gamut-labs/package.json
@@ -6,8 +6,8 @@
   "sideEffects": [
     "**/*.css",
     "**/*.scss",
-    "**/[A-Z]*.{js,tsx}",
-    "**/[A-Z]*/**/index.{js,tsx}"
+    "**/[A-Z]*.js",
+    "**/[A-Z]*/index.js"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/gamut-labs/package.json
+++ b/packages/gamut-labs/package.json
@@ -4,10 +4,10 @@
   "version": "7.5.2",
   "author": "Codecademy Engineering <dev@codecademy.com>",
   "sideEffects": [
-    "./dist/**/*.css",
-    "./dist/**/*.scss",
-    "./dist/**/[A-Z]**/[A-Z]*.js",
-    "./dist/**/[A-Z]**/index.js"
+    "**/*.css",
+    "**/*.scss",
+    "**/[A-Z]*.{js,tsx}",
+    "**/[A-Z]*/**/index.{js,tsx}"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/gamut-styles/package.json
+++ b/packages/gamut-styles/package.json
@@ -3,6 +3,10 @@
   "description": "Styleguide & Component library for codecademy.com",
   "version": "7.6.2",
   "author": "Jake Hiller <jake@codecademy.com>",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -5,9 +5,7 @@
   "author": "Codecademy Engineering <dev@codecademy.com>",
   "sideEffects": [
     "**/*.css",
-    "**/*.scss",
-    "**/[A-Z]*.js",
-    "**/[A-Z]*/index.js"
+    "**/*.scss"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -4,10 +4,10 @@
   "version": "19.5.0",
   "author": "Codecademy Engineering <dev@codecademy.com>",
   "sideEffects": [
-    "**/*.css",
-    "**/*.scss",
-    "dist/**/[A-Z]**/[A-Z]*.js",
-    "dist/**/[A-Z]**/index.js"
+    "./dist/**/*.css",
+    "./dist/**/*.scss",
+    "./dist/**/[A-Z]**/[A-Z]*.js",
+    "./dist/**/[A-Z]**/index.js"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -6,8 +6,8 @@
   "sideEffects": [
     "**/*.css",
     "**/*.scss",
-    "**/[A-Z]*.{js,tsx}",
-    "**/[A-Z]*/**/index.{js,tsx}"
+    "**/[A-Z]*.js",
+    "**/[A-Z]*/index.js"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -4,10 +4,10 @@
   "version": "19.5.0",
   "author": "Codecademy Engineering <dev@codecademy.com>",
   "sideEffects": [
-    "./dist/**/*.css",
-    "./dist/**/*.scss",
-    "./dist/**/[A-Z]**/[A-Z]*.js",
-    "./dist/**/[A-Z]**/index.js"
+    "**/*.css",
+    "**/*.scss",
+    "**/[A-Z]*.{js,tsx}",
+    "**/[A-Z]*/**/index.{js,tsx}"
   ],
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/packages/markdown-overrides/package.json
+++ b/packages/markdown-overrides/package.json
@@ -4,10 +4,10 @@
   "version": "0.4.2",
   "author": "Codecademy Engineering",
   "sideEffects": [
-    "./dist/**/*.css",
-    "./dist/**/*.scss",
-    "./dist/**/[A-Z]**/[A-Z]*.js",
-    "./dist/**/[A-Z]**/index.js"
+    "**/*.css",
+    "**/*.scss",
+    "**/[A-Z]*.{js,tsx}",
+    "**/[A-Z]*/**/index.{js,tsx}"
   ],
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/markdown-overrides/package.json
+++ b/packages/markdown-overrides/package.json
@@ -3,6 +3,12 @@
   "description": "Markdown overrides React Components for Codecademy",
   "version": "0.4.2",
   "author": "Codecademy Engineering",
+  "sideEffects": [
+    "./dist/**/*.css",
+    "./dist/**/*.scss",
+    "./dist/**/[A-Z]**/[A-Z]*.js",
+    "./dist/**/[A-Z]**/index.js"
+  ],
   "main": "dist/index.js",
   "module": "dist/index.js",
   "repository": {

--- a/packages/markdown-overrides/package.json
+++ b/packages/markdown-overrides/package.json
@@ -5,9 +5,7 @@
   "author": "Codecademy Engineering",
   "sideEffects": [
     "**/*.css",
-    "**/*.scss",
-    "**/[A-Z]*.js",
-    "**/[A-Z]*/index.js"
+    "**/*.scss"
   ],
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/markdown-overrides/package.json
+++ b/packages/markdown-overrides/package.json
@@ -6,8 +6,8 @@
   "sideEffects": [
     "**/*.css",
     "**/*.scss",
-    "**/[A-Z]*.{js,tsx}",
-    "**/[A-Z]*/**/index.{js,tsx}"
+    "**/[A-Z]*.js",
+    "**/[A-Z]*/index.js"
   ],
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/styleguide/.storybook/main.ts
+++ b/packages/styleguide/.storybook/main.ts
@@ -1,6 +1,5 @@
 const path = require('path');
 const { configs } = require('@codecademy/webpack-config');
-const SideEffectsFlagPlugin = require('@codecademy/webpack-config/plugins/SideEffectsFlagPlugin');
 
 const getStories = require('./getStories');
 
@@ -68,7 +67,7 @@ module.exports = {
         '@codecademy/gamut$': path.resolve(__dirname, '../../gamut/src'),
       },
     };
-    config.plugins.push(new SideEffectsFlagPlugin());
+
     return config;
   },
 };

--- a/packages/styleguide/.storybook/main.ts
+++ b/packages/styleguide/.storybook/main.ts
@@ -1,6 +1,5 @@
 const path = require('path');
 const { configs } = require('@codecademy/webpack-config');
-
 const getStories = require('./getStories');
 
 // https://github.com/storybookjs/storybook/issues/12262#issuecomment-681953346

--- a/packages/styleguide/.storybook/main.ts
+++ b/packages/styleguide/.storybook/main.ts
@@ -1,5 +1,7 @@
 const path = require('path');
 const { configs } = require('@codecademy/webpack-config');
+const SideEffectsFlagPlugin = require('@codecademy/webpack-config/plugins/SideEffectsFlagPlugin');
+
 const getStories = require('./getStories');
 
 // https://github.com/storybookjs/storybook/issues/12262#issuecomment-681953346
@@ -66,7 +68,7 @@ module.exports = {
         '@codecademy/gamut$': path.resolve(__dirname, '../../gamut/src'),
       },
     };
-
+    config.plugins.push(new SideEffectsFlagPlugin());
     return config;
   },
 };

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -40,6 +40,7 @@
     "css-loader": "^3.5.2",
     "cssnano": "^4.1.10",
     "file-loader": "^3.0.1",
+    "glob-to-regexp": "^0.4.1",
     "mini-css-extract-plugin": "^0.12.0",
     "node-sass": "^4.13.0",
     "postcss-flexbugs-fixes": "^4.1.0",

--- a/packages/webpack-config/src/config/common.js
+++ b/packages/webpack-config/src/config/common.js
@@ -4,6 +4,7 @@ const merge = require('webpack-merge');
 const TerserPlugin = require('terser-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const loaders = require('../loaders');
+const SideEffectsFlagPlugin = require('@codecademy/webpack-config/plugins/SideEffectsFlagPlugin');
 const ENV = require('../lib/env');
 
 const commonConfig = (options = {}) => {
@@ -102,6 +103,12 @@ const commonConfig = (options = {}) => {
           }),
         ],
       },
+      plugins: [
+        /**
+         * Apply better side effects glob handling until webpack 5 is released
+         */
+        new SideEffectsFlagPlugin(),
+      ],
     });
   }
 

--- a/packages/webpack-config/src/config/common.js
+++ b/packages/webpack-config/src/config/common.js
@@ -87,6 +87,8 @@ const commonConfig = (options = {}) => {
       optimization: {
         moduleIds: 'hashed',
         minimize: true,
+        // Disabled until webpack 5 while we use our own side effects plugin
+        sideEffects: false,
         minimizer: minimizer || [
           new TerserPlugin({
             cache: true,

--- a/packages/webpack-config/src/config/common.js
+++ b/packages/webpack-config/src/config/common.js
@@ -4,7 +4,7 @@ const merge = require('webpack-merge');
 const TerserPlugin = require('terser-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const loaders = require('../loaders');
-const SideEffectsFlagPlugin = require('@codecademy/webpack-config/plugins/SideEffectsFlagPlugin');
+const SideEffectsFlagPlugin = require('../plugins/SideEffectsFlagPlugin');
 const ENV = require('../lib/env');
 
 const commonConfig = (options = {}) => {

--- a/packages/webpack-config/src/plugins/SideEffectsFlagPlugin.js
+++ b/packages/webpack-config/src/plugins/SideEffectsFlagPlugin.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /**
  * Temporary modified version of internal webpack plugin https://raw.githubusercontent.com/webpack/webpack/v4.44.2/lib/optimize/SideEffectsFlagPlugin.js
  * Modifications come directly from the Webpack 5 version of this plugin, so this can be discarded after the Webpack 5 upgrade
@@ -93,8 +94,8 @@ class SideEffectsFlagPlugin {
       cache = new Map();
       globToRegexpCache.set(compiler, cache);
     }
-    compiler.hooks.normalModuleFactory.tap('SideEffectsFlagPlugin', (nmf) => {
-      nmf.hooks.module.tap('SideEffectsFlagPlugin', (module, data) => {
+    compiler.hooks.normalModuleFactory.tap('CCSideEffectsFlagPlugin', (nmf) => {
+      nmf.hooks.module.tap('CCSideEffectsFlagPlugin', (module, data) => {
         const resolveData = data.resourceResolveData;
         if (
           resolveData &&
@@ -114,7 +115,7 @@ class SideEffectsFlagPlugin {
 
         return module;
       });
-      nmf.hooks.module.tap('SideEffectsFlagPlugin', (module, data) => {
+      nmf.hooks.module.tap('CCSideEffectsFlagPlugin', (module, data) => {
         if (data.settings.sideEffects === false) {
           module.factoryMeta.sideEffectFree = true;
         } else if (data.settings.sideEffects === true) {
@@ -122,9 +123,9 @@ class SideEffectsFlagPlugin {
         }
       });
     });
-    compiler.hooks.compilation.tap('SideEffectsFlagPlugin', (compilation) => {
+    compiler.hooks.compilation.tap('CCSideEffectsFlagPlugin', (compilation) => {
       compilation.hooks.optimizeDependencies.tap(
-        'SideEffectsFlagPlugin',
+        'CCSideEffectsFlagPlugin',
         (modules) => {
           /** @type {Map<Module, ReexportInfo>} */
           const reexportMaps = new Map();

--- a/packages/webpack-config/src/plugins/SideEffectsFlagPlugin.js
+++ b/packages/webpack-config/src/plugins/SideEffectsFlagPlugin.js
@@ -1,0 +1,340 @@
+/**
+ * Temporary modified version of internal webpack plugin https://raw.githubusercontent.com/webpack/webpack/v4.44.2/lib/optimize/SideEffectsFlagPlugin.js
+ * Modifications come directly from the Webpack 5 version of this plugin, so this can be discarded after the Webpack 5 upgrade
+ * Diff with the above file version to see modifications
+ */
+
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+'use strict';
+
+const glob2regexp = require('glob-to-regexp');
+const HarmonyExportImportedSpecifierDependency = require('webpack/lib/dependencies/HarmonyExportImportedSpecifierDependency');
+const HarmonyImportSideEffectDependency = require('webpack/lib/dependencies/HarmonyImportSideEffectDependency');
+const HarmonyImportSpecifierDependency = require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');
+
+const globToRegexpCache = new WeakMap();
+
+const globToRegexp = (glob, cache) => {
+  const cacheEntry = cache.get(glob);
+  if (cacheEntry !== undefined) return cacheEntry;
+  if (!glob.includes('/')) {
+    glob = `**/${glob}`;
+  }
+  const baseRegexp = glob2regexp(glob, { globstar: true, extended: true });
+  const regexpSource = baseRegexp.source;
+  const regexp = new RegExp('^(\\./)?' + regexpSource.slice(1));
+  cache.set(glob, regexp);
+  return regexp;
+};
+
+const getMappingFromInfo = (info, exportName) => {
+  const staticMappings = info.static.get(exportName);
+  if (staticMappings !== undefined) {
+    if (staticMappings.length === 1) return staticMappings[0];
+    return undefined;
+  }
+  const dynamicMappings = Array.from(info.dynamic).filter(
+    ([_, ignored]) => !ignored.has(exportName)
+  );
+  if (dynamicMappings.length === 1) {
+    return {
+      module: dynamicMappings[0][0],
+      exportName,
+      checked: true,
+    };
+  }
+  return undefined;
+};
+
+const addStaticReexport = (
+  info,
+  exportName,
+  module,
+  innerExportName,
+  checked
+) => {
+  let mappings = info.static.get(exportName);
+  if (mappings !== undefined) {
+    for (const mapping of mappings) {
+      if (mapping.module === module && mapping.exportName === innerExportName) {
+        mapping.checked = mapping.checked && checked;
+        return;
+      }
+    }
+  } else {
+    mappings = [];
+    info.static.set(exportName, mappings);
+  }
+  mappings.push({
+    module,
+    exportName: innerExportName,
+    checked,
+  });
+};
+
+const addDynamicReexport = (info, module, ignored) => {
+  const existingList = info.dynamic.get(module);
+  if (existingList !== undefined) {
+    for (const key of existingList) {
+      if (!ignored.has(key)) existingList.delete(key);
+    }
+  } else {
+    info.dynamic.set(module, new Set(ignored));
+  }
+};
+
+class SideEffectsFlagPlugin {
+  apply(compiler) {
+    let cache = globToRegexpCache.get(compiler);
+    if (cache === undefined) {
+      cache = new Map();
+      globToRegexpCache.set(compiler, cache);
+    }
+    compiler.hooks.normalModuleFactory.tap('SideEffectsFlagPlugin', (nmf) => {
+      nmf.hooks.module.tap('SideEffectsFlagPlugin', (module, data) => {
+        const resolveData = data.resourceResolveData;
+        if (
+          resolveData &&
+          resolveData.descriptionFileData &&
+          resolveData.relativePath
+        ) {
+          const { sideEffects } = resolveData.descriptionFileData;
+          const hasSideEffects = SideEffectsFlagPlugin.moduleHasSideEffects(
+            resolveData.relativePath,
+            sideEffects,
+            cache
+          );
+          if (!hasSideEffects) {
+            module.factoryMeta.sideEffectFree = true;
+          }
+        }
+
+        return module;
+      });
+      nmf.hooks.module.tap('SideEffectsFlagPlugin', (module, data) => {
+        if (data.settings.sideEffects === false) {
+          module.factoryMeta.sideEffectFree = true;
+        } else if (data.settings.sideEffects === true) {
+          module.factoryMeta.sideEffectFree = false;
+        }
+      });
+    });
+    compiler.hooks.compilation.tap('SideEffectsFlagPlugin', (compilation) => {
+      compilation.hooks.optimizeDependencies.tap(
+        'SideEffectsFlagPlugin',
+        (modules) => {
+          /** @type {Map<Module, ReexportInfo>} */
+          const reexportMaps = new Map();
+
+          // Capture reexports of sideEffectFree modules
+          for (const module of modules) {
+            /** @type {Dependency[]} */
+            const removeDependencies = [];
+            for (const dep of module.dependencies) {
+              if (dep instanceof HarmonyImportSideEffectDependency) {
+                if (dep.module && dep.module.factoryMeta.sideEffectFree) {
+                  removeDependencies.push(dep);
+                }
+              } else if (
+                dep instanceof HarmonyExportImportedSpecifierDependency
+              ) {
+                if (module.factoryMeta.sideEffectFree) {
+                  const mode = dep.getMode(true);
+                  if (
+                    mode.type === 'safe-reexport' ||
+                    mode.type === 'checked-reexport' ||
+                    mode.type === 'dynamic-reexport' ||
+                    mode.type === 'reexport-non-harmony-default' ||
+                    mode.type === 'reexport-non-harmony-default-strict' ||
+                    mode.type === 'reexport-named-default'
+                  ) {
+                    let info = reexportMaps.get(module);
+                    if (!info) {
+                      reexportMaps.set(
+                        module,
+                        (info = {
+                          static: new Map(),
+                          dynamic: new Map(),
+                        })
+                      );
+                    }
+                    const targetModule = dep._module;
+                    switch (mode.type) {
+                      case 'safe-reexport':
+                        for (const [key, id] of mode.map) {
+                          if (id) {
+                            addStaticReexport(
+                              info,
+                              key,
+                              targetModule,
+                              id,
+                              false
+                            );
+                          }
+                        }
+                        break;
+                      case 'checked-reexport':
+                        for (const [key, id] of mode.map) {
+                          if (id) {
+                            addStaticReexport(
+                              info,
+                              key,
+                              targetModule,
+                              id,
+                              true
+                            );
+                          }
+                        }
+                        break;
+                      case 'dynamic-reexport':
+                        addDynamicReexport(info, targetModule, mode.ignored);
+                        break;
+                      case 'reexport-non-harmony-default':
+                      case 'reexport-non-harmony-default-strict':
+                      case 'reexport-named-default':
+                        addStaticReexport(
+                          info,
+                          mode.name,
+                          targetModule,
+                          'default',
+                          false
+                        );
+                        break;
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          // Flatten reexports
+          for (const info of reexportMaps.values()) {
+            const dynamicReexports = info.dynamic;
+            info.dynamic = new Map();
+            for (const reexport of dynamicReexports) {
+              let [targetModule, ignored] = reexport;
+              for (;;) {
+                const innerInfo = reexportMaps.get(targetModule);
+                if (!innerInfo) break;
+
+                for (const [key, reexports] of innerInfo.static) {
+                  if (ignored.has(key)) continue;
+                  for (const { module, exportName, checked } of reexports) {
+                    addStaticReexport(info, key, module, exportName, checked);
+                  }
+                }
+
+                // Follow dynamic reexport if there is only one
+                if (innerInfo.dynamic.size !== 1) {
+                  // When there are more then one, we don't know which one
+                  break;
+                }
+
+                ignored = new Set(ignored);
+                for (const [innerModule, innerIgnored] of innerInfo.dynamic) {
+                  for (const key of innerIgnored) {
+                    if (ignored.has(key)) continue;
+                    // This reexports ends here
+                    addStaticReexport(info, key, targetModule, key, true);
+                    ignored.add(key);
+                  }
+                  targetModule = innerModule;
+                }
+              }
+
+              // Update reexport as all other cases has been handled
+              addDynamicReexport(info, targetModule, ignored);
+            }
+          }
+
+          for (const info of reexportMaps.values()) {
+            const staticReexports = info.static;
+            info.static = new Map();
+            for (const [key, reexports] of staticReexports) {
+              for (let mapping of reexports) {
+                for (;;) {
+                  const innerInfo = reexportMaps.get(mapping.module);
+                  if (!innerInfo) break;
+
+                  const newMapping = getMappingFromInfo(
+                    innerInfo,
+                    mapping.exportName
+                  );
+                  if (!newMapping) break;
+                  mapping = newMapping;
+                }
+                addStaticReexport(
+                  info,
+                  key,
+                  mapping.module,
+                  mapping.exportName,
+                  mapping.checked
+                );
+              }
+            }
+          }
+
+          // Update imports along the reexports from sideEffectFree modules
+          for (const pair of reexportMaps) {
+            const module = pair[0];
+            const info = pair[1];
+            let newReasons = undefined;
+            for (let i = 0; i < module.reasons.length; i++) {
+              const reason = module.reasons[i];
+              const dep = reason.dependency;
+              if (
+                (dep instanceof HarmonyExportImportedSpecifierDependency ||
+                  (dep instanceof HarmonyImportSpecifierDependency &&
+                    !dep.namespaceObjectAsContext)) &&
+                dep._id
+              ) {
+                const mapping = getMappingFromInfo(info, dep._id);
+                if (mapping) {
+                  dep.redirectedModule = mapping.module;
+                  dep.redirectedId = mapping.exportName;
+                  mapping.module.addReason(
+                    reason.module,
+                    dep,
+                    reason.explanation
+                      ? reason.explanation +
+                          ' (skipped side-effect-free modules)'
+                      : '(skipped side-effect-free modules)'
+                  );
+                  // removing the currect reason, by not adding it to the newReasons array
+                  // lazily create the newReasons array
+                  if (newReasons === undefined) {
+                    newReasons = i === 0 ? [] : module.reasons.slice(0, i);
+                  }
+                  continue;
+                }
+              }
+              if (newReasons !== undefined) newReasons.push(reason);
+            }
+            if (newReasons !== undefined) {
+              module.reasons = newReasons;
+            }
+          }
+        }
+      );
+    });
+  }
+
+  static moduleHasSideEffects(moduleName, flagValue, cache) {
+    switch (typeof flagValue) {
+      case 'undefined':
+        return true;
+      case 'boolean':
+        return flagValue;
+      case 'string':
+        return globToRegexp(flagValue, cache).test(moduleName);
+      case 'object':
+        return flagValue.some((glob) =>
+          SideEffectsFlagPlugin.moduleHasSideEffects(moduleName, glob, cache)
+        );
+    }
+  }
+}
+module.exports = SideEffectsFlagPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,6 +2147,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@codecademy/gamut-system@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@codecademy/gamut-system/-/gamut-system-0.1.6.tgz#40d84043cf0cf6d5734a07779164af16724fdb1d"
+  integrity sha512-xY2b/JYefFB1CAAyz69Qy/SKEqgtplwnoSgZ7zDLXlA+QBh9xhwqDDdZAJcpKKW7ajpl71G034rSkPdsfmfLVw==
+
 "@emotion/babel-plugin@11.0.0", "@emotion/babel-plugin@^11.0.0":
   version "11.0.0"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.0.0.tgz#e6f40fa81ef52775773a53d50220c597ebc5c2ef"
@@ -10603,6 +10608,11 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"


### PR DESCRIPTION
### Overview

Updated with new SideEffectsPlugin replacement (addition, really) that uses proper globbing.

The added code is a combination of the plugin from Webpack 4 and the globbing from webpack 5, and will be removed in the webpack 5 upgrade branch once i merge this in.

This will likely slow down production builds slightly, but i don't think it will be enough to notice.

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
