### PR TITLE
fix: corrected gamut-system dependency in gamut-illustrations

### DIFF
--- a/packages/gamut-illustrations/package.json
+++ b/packages/gamut-illustrations/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@codecademy/gamut": "^19.5.0",
     "@codecademy/gamut-styles": "^7.6.2",
-    "@codecademy/gamut-system": "^0.1.6",
+    "@codecademy/gamut-system": "^0.2.1",
     "classnames": "^2.2.5"
   },
   "description": "Illustrations library for Codecademy",


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Bumped gamut-system dependency in gamut-illustrations to the latest, 0.2.1.

<!--- END-CHANGELOG-DESCRIPTION -->

Pretty sure this is some kind of odd timing issue, where the automation didn't bump the system version as needed.