### PR TITLE
fix: revert "feat: add testId prop to Container (#1242)"

### DIFF
--- a/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
+++ b/packages/gamut-labs/src/landingPage/PagePrefooter.tsx
@@ -36,7 +36,7 @@ export const PagePrefooter: React.FC<BaseProps> = ({
   );
 
   return cta ? (
-    <FlexContainer testId={testId} nowrap column justify="spaceBetween">
+    <FlexContainer data-testid={testId} nowrap column justify="spaceBetween">
       <FlexContent>
         {SectionTitle}
         {Desc}

--- a/packages/gamut/src/FlexBox/Container.tsx
+++ b/packages/gamut/src/FlexBox/Container.tsx
@@ -19,7 +19,6 @@ const internalProps = [
   'align',
   'justify',
   'alignSelf',
-  'testId',
 ];
 
 type ContainerPosition =
@@ -69,7 +68,6 @@ export interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
    *  (cannot be used with: `nowrap`)
    * */
   wrap?: boolean;
-  testId?: string;
 }
 
 export class Container extends React.Component<ContainerProps> {
@@ -103,11 +101,7 @@ export class Container extends React.Component<ContainerProps> {
     const propsToTransfer = omit(this.props, internalProps);
 
     return (
-      <div
-        {...propsToTransfer}
-        className={classes}
-        data-testid={this.props.testId}
-      >
+      <div {...propsToTransfer} className={classes}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION

### Overview

<!--- CHANGELOG-DESCRIPTION -->

This reverts the change to add an explicit `testId` prop to `Container`, since it actually already supports `data-testid`.

<!--- END-CHANGELOG-DESCRIPTION -->
