### PR TITLE
feat: add vertical and horizontal offsets to the popover component

### DIFF
--- a/packages/gamut-labs/src/experimental/Popover/__tests__/Popover-test.tsx
+++ b/packages/gamut-labs/src/experimental/Popover/__tests__/Popover-test.tsx
@@ -172,7 +172,7 @@ describe('Popover', () => {
     expect(screen.queryByTestId('popover-beak')).toBeInTheDocument();
   });
 
-  it("positions with default 'below', 'left', '20' value when position, align, offset props are not provided respectively", () => {
+  it("positions with default 'below', 'left', '20', '0' value when position, align, verticalOffset, horizontalOffset props are not provided respectively", () => {
     Object.defineProperty(window, 'scrollY', { value: 1 });
     Object.defineProperty(window, 'scrollX', { value: 1 });
 
@@ -210,7 +210,7 @@ describe('Popover', () => {
     });
   });
 
-  it('positions with given offset value when provided', () => {
+  it('positions with given verticalOffset value when provided', () => {
     Object.defineProperty(window, 'scrollY', { value: 1 });
     Object.defineProperty(window, 'scrollX', { value: 1 });
 
@@ -218,7 +218,7 @@ describe('Popover', () => {
       isOpen: true,
       position: 'above',
       align: 'right',
-      offset: 29,
+      verticalOffset: 29,
     });
 
     expect(
@@ -231,6 +231,27 @@ describe('Popover', () => {
     });
   });
 
+  it('positions with given horizontalOffset value when provided', () => {
+    Object.defineProperty(window, 'scrollY', { value: 1 });
+    Object.defineProperty(window, 'scrollX', { value: 1 });
+
+    const wrapped = mountPopover({
+      isOpen: true,
+      position: 'above',
+      align: 'right',
+      horizontalOffset: 30,
+    });
+
+    expect(
+      wrapped.find('[data-testid="popover-content-container"]').props()
+    ).toMatchObject({
+      style: {
+        top: 240,
+        left: 871,
+      },
+    });
+  });
+
   it('positions round to whole number when ', () => {
     Object.defineProperty(window, 'scrollY', { value: 1.5 });
     Object.defineProperty(window, 'scrollX', { value: 1.5 });
@@ -239,7 +260,7 @@ describe('Popover', () => {
       isOpen: true,
       position: 'above',
       align: 'right',
-      offset: 30,
+      verticalOffset: 30,
     });
 
     expect(

--- a/packages/gamut-labs/src/experimental/Popover/index.tsx
+++ b/packages/gamut-labs/src/experimental/Popover/index.tsx
@@ -76,7 +76,7 @@ export const Popover: React.FC<PopoverProps> = ({
       below: Math.round(targetRect.top + targetRect.height + verticalOffset),
     };
     const alignments = {
-      right: Math.round(window.scrollX + targetRect.right - horizontalOffset),
+      right: Math.round(window.scrollX + targetRect.right + horizontalOffset),
       left: Math.round(window.scrollX + targetRect.left + horizontalOffset),
     };
     return {

--- a/packages/gamut-labs/src/experimental/Popover/index.tsx
+++ b/packages/gamut-labs/src/experimental/Popover/index.tsx
@@ -77,7 +77,7 @@ export const Popover: React.FC<PopoverProps> = ({
     };
     const alignments = {
       right: Math.round(window.scrollX + targetRect.right + horizontalOffset),
-      left: Math.round(window.scrollX + targetRect.left + horizontalOffset),
+      left: Math.round(window.scrollX + targetRect.left - horizontalOffset),
     };
     return {
       top: positions[position],

--- a/packages/gamut-labs/src/experimental/Popover/index.tsx
+++ b/packages/gamut-labs/src/experimental/Popover/index.tsx
@@ -14,9 +14,13 @@ export type PopoverProps = {
    */
   align?: 'left' | 'right';
   /**
-   * Number of pixels to offset the popover from the source component.
+   * Number of pixels to offset the popover vertically from the source component.
    */
-  offset?: number;
+  verticalOffset?: number;
+  /**
+   * Number of pixels to offset the popover horizontally from the source component.
+   */
+  horizontalOffset?: number;
   /**
    * Whether to add outline style (i.e. used for dropdowns).
    */
@@ -50,7 +54,8 @@ export const Popover: React.FC<PopoverProps> = ({
   children,
   className,
   align = 'left',
-  offset = 20,
+  verticalOffset = 20,
+  horizontalOffset = 0,
   outline = false,
   position = 'below',
   beak,
@@ -67,18 +72,18 @@ export const Popover: React.FC<PopoverProps> = ({
     if (!targetRect) return {};
 
     const positions = {
-      above: Math.round(targetRect.top - offset),
-      below: Math.round(targetRect.top + targetRect.height + offset),
+      above: Math.round(targetRect.top - verticalOffset),
+      below: Math.round(targetRect.top + targetRect.height + verticalOffset),
     };
     const alignments = {
-      right: Math.round(window.scrollX + targetRect.right),
-      left: Math.round(window.scrollX + targetRect.left),
+      right: Math.round(window.scrollX + targetRect.right - horizontalOffset),
+      left: Math.round(window.scrollX + targetRect.left + horizontalOffset),
     };
     return {
       top: positions[position],
       left: alignments[align],
     };
-  }, [targetRect, offset, align, position]);
+  }, [targetRect, verticalOffset, horizontalOffset, align, position]);
 
   useEffect(() => {
     setTargetRect(targetRef?.current?.getBoundingClientRect());


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
- Replaced offset prop on Popover component with verticalOffset and horizontalOffset 
- These two new props will allow clients to shift the Popover vertically and horizontally from the source
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: EGG-311
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
