### PR TITLE
feat(Toggle): adds a className prop to the Toggle component

### DIFF
--- a/packages/gamut/src/Toggle/index.tsx
+++ b/packages/gamut/src/Toggle/index.tsx
@@ -5,6 +5,7 @@ import styles from './styles/index.module.scss';
 
 export type ToggleProps = {
   checked?: boolean;
+  className?: string;
   onChange?: (...args: any[]) => any;
   label?: string;
   disabled?: boolean;
@@ -16,6 +17,7 @@ export class Toggle extends Component<ToggleProps, {}> {
   render() {
     const {
       checked,
+      className,
       onChange,
       label,
       disabled,
@@ -27,7 +29,7 @@ export class Toggle extends Component<ToggleProps, {}> {
         className={cx(styles.toggleButton, {
           [styles.toggled]: checked,
           [styles.disabled]: disabled,
-        })}
+        }, className)}
         arial-label={label}
         htmlFor={label}
       >

--- a/packages/gamut/src/Toggle/index.tsx
+++ b/packages/gamut/src/Toggle/index.tsx
@@ -26,10 +26,14 @@ export class Toggle extends Component<ToggleProps, {}> {
     } = this.props;
     return (
       <label
-        className={cx(styles.toggleButton, {
-          [styles.toggled]: checked,
-          [styles.disabled]: disabled,
-        }, className)}
+        className={cx(
+          styles.toggleButton,
+          {
+            [styles.toggled]: checked,
+            [styles.disabled]: disabled,
+          },
+          className
+        )}
         arial-label={label}
         htmlFor={label}
       >


### PR DESCRIPTION
### Overview

Adds support for a `className` prop in the `<Toggle>` component.

<!--- CHANGELOG-DESCRIPTION -->
Adds support for a className prop to the Toggle component.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change