### PR TITLE
fix(icons): remove rectangle from filled caret icon

### DIFF
--- a/packages/gamut-icons/src/svg/arrow-chevron-down-filled-icon.svg
+++ b/packages/gamut-icons/src/svg/arrow-chevron-down-filled-icon.svg
@@ -1,5 +1,5 @@
 <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<defs><style>.cls-1{fill:currentColor;}</style></defs>
 <title>filled-arrow-down</title>
-<rect width="8" height="8" fill="white"/>
-<path d="M7.06574 1.5L4 6.09861L0.934259 1.5H7.06574Z" />
+<path class="cls-1" d="M7.06574 1.5L4 6.09861L0.934259 1.5H7.06574Z" />
 </svg>


### PR DESCRIPTION
### Overview
This icon had a perma white background, which was probably some export artifact.  This removes it and adds some fill color forwarding.

<!--- CHANGELOG-DESCRIPTION -->
* removes erroneous white rectangle from caret icon.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
