### PR TITLE
fix(markdown): delete onClick for MarkdownAnchor if not passed

### DIFF
--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -12,10 +12,7 @@ import {
   standardOverrides,
 } from './libs/overrides';
 import { Iframe } from './libs/overrides/Iframe';
-import {
-  MarkdownAnchor,
-  MarkdownAnchorProps,
-} from './libs/overrides/MarkdownAnchor';
+import { MarkdownAnchor } from './libs/overrides/MarkdownAnchor';
 import { Table, TableProps } from './libs/overrides/Table';
 import { createPreprocessingInstructions } from './libs/preprocessing';
 import { defaultSanitizationConfig } from './libs/sanitizationConfig';
@@ -59,7 +56,6 @@ export class Markdown extends PureComponent<MarkdownProps> {
       overrides: userOverrides = {},
       skipDefaultOverrides = {},
       inline = false,
-      onAnchorClick = () => null,
     } = this.props;
 
     if (!text) return null;
@@ -83,10 +79,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
         }),
       !skipDefaultOverrides.a &&
         createTagOverride('a', {
-          component: (props: MarkdownAnchorProps) => (
-            <MarkdownAnchor onClick={onAnchorClick} {...props} />
-          ),
-          allowedAttributes: ['onClick'],
+          component: (props) => <MarkdownAnchor {...props} />,
         }),
       !skipDefaultOverrides.table &&
         createTagOverride('table', {

--- a/packages/gamut/src/Markdown/libs/overrides/MarkdownAnchor/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/MarkdownAnchor/index.tsx
@@ -38,6 +38,5 @@ export const MarkdownAnchor: React.FC<MarkdownAnchorProps> = ({
   if (matchesOrigin(props.href) || !absoluteURLPattern.test(props.href)) {
     delete anchorProps.rel;
   }
-
   return <Anchor {...anchorProps}>{children}</Anchor>;
 };


### PR DESCRIPTION
### Overview
This [commit](https://github.com/Codecademy/client-modules/commit/110c263214e620c808abf5e9a1a91b8c2a7a7e96) introduced `onClick` for Markdown Anchors, but broke existing Markdown Anchors that did not pass an onClick handler. See https://www.codecademy.com/content-items/161643a7095649479b824e36f8127a76/exercises/writing-mutable-code-with-immer?latest_draft_applied=true&preview=true and try clicking on a narrative link as an example.

This PR removes the `onClick` default and deletes the prop if it is not passed.

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: https://codecademy.atlassian.net/browse/LX-4771
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
