### PR TITLE
fix(Markdown): prevent re-renders caused by default prop

### DIFF
--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -59,7 +59,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
       overrides: userOverrides = {},
       skipDefaultOverrides = {},
       inline = false,
-      onAnchorClick = () => null,
+      onAnchorClick,
     } = this.props;
 
     if (!text) return null;
@@ -86,7 +86,6 @@ export class Markdown extends PureComponent<MarkdownProps> {
           component: (props: MarkdownAnchorProps) => (
             <MarkdownAnchor onClick={onAnchorClick} {...props} />
           ),
-          allowedAttributes: ['onClick'],
         }),
       !skipDefaultOverrides.table &&
         createTagOverride('table', {


### PR DESCRIPTION
### Overview

This default prop wasn't necessary because `undefined` in an onClick prop is equivalent to not setting the prop at all (as far as i know, it might not be 100% equivalent).

<!--- CHANGELOG-DESCRIPTION -->
Fixes unnecessary re-renders caused by a default function prop being applied to markdown anchors.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
