### PR TITLE
fix(IconButton): make children prop optional

### DIFF
--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -1,11 +1,10 @@
 import { GamutIconProps } from '@codecademy/gamut-icons';
 import React from 'react';
-
 import { SizedButtonProps } from './shared';
 import { TextButton } from './TextButton';
 
 export type IconButtonProps = SizedButtonProps & {
-  children: never;
+  children?: never;
   icon: React.ComponentType<GamutIconProps>;
 };
 

--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -1,5 +1,6 @@
 import { GamutIconProps } from '@codecademy/gamut-icons';
 import React from 'react';
+
 import { SizedButtonProps } from './shared';
 import { TextButton } from './TextButton';
 


### PR DESCRIPTION
### Overview
Found a bug in IconButton while pairing with @codecaaron. 
<!--- CHANGELOG-DESCRIPTION -->
- updated children prop to be optional 
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
