### PR TITLE
fix(Storybook): Update meta links to storybooks standard color

### DIFF
--- a/packages/styleguide/.storybook/components/Page/index.tsx
+++ b/packages/styleguide/.storybook/components/Page/index.tsx
@@ -14,12 +14,12 @@ const Link = styled.a`
   line-height: 1;
   column-gap: 0.5rem;
   align-items: flex-start;
-  color: ${theme.colors.blue};
+  color: #1ea7fd;
   border-bottom: 2px solid transparent;
 
   &:hover {
     text-decoration: none;
-    border-bottom-color: ${theme.colors.blue};
+    border-bottom-color: #1ea7fd;
   }
 `;
 

--- a/packages/styleguide/.storybook/components/Page/index.tsx
+++ b/packages/styleguide/.storybook/components/Page/index.tsx
@@ -3,7 +3,6 @@ import { Description, DocsContext, Title } from '@storybook/addon-docs/blocks';
 import { Badge } from '../Badge';
 import { spacing } from '../styles';
 import { styled } from '@storybook/theming';
-import { theme } from '@codecademy/gamut-styles';
 import { OpenIcon } from '@codecademy/gamut-icons';
 import { Parameters } from '@storybook/addons';
 import { useKind } from '../TableOfContents/utils';


### PR DESCRIPTION
### Overview
A tiny change to appease my visual OCD.

<!--- CHANGELOG-DESCRIPTION -->
* Swaps color to storybook native.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
