### PR TITLE
fix: Adding htmlFor prop to HiddenText

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -106,16 +106,18 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = (
     }
   };
 
-  const label = (
-    <StyledFormGroupLabel htmlFor={props.field.id || props.field.name}>
-      {props.field.label}
-    </StyledFormGroupLabel>
-  );
-
   return (
     <Column size={props.field.size}>
       <StyledFormGroup>
-        {props.field.hideLabel ? <HiddenText>{label}</HiddenText> : label}
+        {props.field.hideLabel ? (
+          <HiddenText as="label" htmlFor={props.field.id || props.field.name}>
+            {props.field.label}
+          </HiddenText>
+        ) : (
+          <StyledFormGroupLabel htmlFor={props.field.id || props.field.name}>
+            {props.field.label}
+          </StyledFormGroupLabel>
+        )}
         {props.error && (
           <FormError aria-live={props.isFirstError ? 'assertive' : 'off'}>
             {props.error}

--- a/packages/gamut/src/HiddenText/index.tsx
+++ b/packages/gamut/src/HiddenText/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const HiddenText = styled.span`
+export const HiddenText = styled.span<{ htmlFor?: string }>`
   display: inline-block;
   font-size: 0;
   height: 1px;


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
This PR adds in `htmlFor` prop to `<HiddenText />` inside `<GridFormInputGroup />` for accessibility reasons.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
