### PR TITLE
fix: landing page descriptions margin-top adjustments

### DIFF
--- a/packages/gamut-labs/src/landingPage/Description.tsx
+++ b/packages/gamut-labs/src/landingPage/Description.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { BaseProps } from './types';
 
 const DescriptionContainer = styled.div`
-  margin: 2rem 0 0;
+  margin: 1rem 0 0;
   max-width: 38rem;
 `;
 

--- a/packages/gamut-labs/src/landingPage/Feature.tsx
+++ b/packages/gamut-labs/src/landingPage/Feature.tsx
@@ -19,6 +19,7 @@ const Image = styled.img`
 
 const StyledMarkdown = styled(Markdown)`
   font-size: 1rem;
+  margin: 1rem 0 0;
 `;
 
 const FeatureBlock = styled.div`


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Adjust margin-top of descriptions in 2 places within landing page components, per design feedback.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/2aBlW1pgFt5PT6soRu1HXy/%E2%9C%8F%EF%B8%8F-Landing-Page-Templates---Unification?node-id=244%3A663
- [x] Related to JIRA ticket: [REACH-520](https://codecademy.atlassian.net/browse/REACH-520)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
