### PR TITLE
fix(GlobalHeader): Change focus outline color and add export

### DIFF
--- a/packages/gamut-labs/src/experimental/AppHeader/AppHeaderElements/SharedStyles.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeader/AppHeaderElements/SharedStyles.tsx
@@ -6,7 +6,7 @@ export const focusStyles = css`
     outline: none;
   }
   &:focus-visible {
-    outline: 0.3rem auto ${colors.hyper};
+    outline: 0.3rem auto ${colors.navy};
   }
 `;
 

--- a/packages/gamut-labs/src/experimental/AppHeader/index.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeader/index.tsx
@@ -26,13 +26,8 @@ export type AppHeaderItemsProp = {
   right: AppHeaderItem[];
 };
 
-const AppHeaderTextButton = styled(TextButton)`
-  ${focusStyles}
-`;
-
-const AppHeaderFillButton = styled(FillButton)`
-  ${focusStyles}
-`;
+const AppHeaderTextButton = styled(TextButton)(focusStyles);
+const AppHeaderFillButton = styled(FillButton)(focusStyles);
 
 const mapItemToElement = (
   item: AppHeaderItem,

--- a/packages/gamut-labs/src/experimental/AppHeader/index.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeader/index.tsx
@@ -4,10 +4,12 @@ import {
   FillButton,
   TextButton,
 } from '@codecademy/gamut';
+import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
 
 import { AppHeaderDropdown, AppHeaderLink, AppHeaderLogo } from '..';
 import { AppHeaderTab } from './AppHeaderElements/AppHeaderTab';
+import { focusStyles } from './AppHeaderElements/SharedStyles';
 import {
   AppHeaderClickHandler,
   AppHeaderItem,
@@ -23,6 +25,14 @@ export type AppHeaderItemsProp = {
   left: AppHeaderItem[];
   right: AppHeaderItem[];
 };
+
+const AppHeaderTextButton = styled(TextButton)`
+  ${focusStyles}
+`;
+
+const AppHeaderFillButton = styled(FillButton)`
+  ${focusStyles}
+`;
 
 const mapItemToElement = (
   item: AppHeaderItem,
@@ -52,25 +62,25 @@ const mapItemToElement = (
     case 'text-button':
       return (
         <AppHeaderTab key={item.id}>
-          <TextButton
+          <AppHeaderTextButton
             data-testid={item.dataTestId}
             href={item.href}
             onClick={(event: React.MouseEvent) => onClick(event, item)}
           >
             {item.text}
-          </TextButton>
+          </AppHeaderTextButton>
         </AppHeaderTab>
       );
     case 'fill-button':
       return (
         <AppHeaderTab key={item.id}>
-          <FillButton
+          <AppHeaderFillButton
             data-testid={item.dataTestId}
             href={item.href}
             onClick={(event: React.MouseEvent) => onClick(event, item)}
           >
             {item.text}
-          </FillButton>
+          </AppHeaderFillButton>
         </AppHeaderTab>
       );
   }

--- a/packages/gamut-labs/src/experimental/index.ts
+++ b/packages/gamut-labs/src/experimental/index.ts
@@ -5,3 +5,4 @@ export * from './AppHeader';
 export * from './AppHeader/AppHeaderElements/AppHeaderLogo';
 export * from './AppHeader/AppHeaderElements/AppHeaderLink';
 export * from './AppHeader/AppHeaderElements/AppHeaderDropdown';
+export * from './GlobalHeader';

--- a/packages/styleguide/stories/Labs/Experimental/Molecules/GlobalHeader.stories.mdx
+++ b/packages/styleguide/stories/Labs/Experimental/Molecules/GlobalHeader.stories.mdx
@@ -1,6 +1,6 @@
 import { Box, IconButton } from '@codecademy/gamut/src';
 import { BellIcon, PersonIcon, SearchIcon } from '@codecademy/gamut-icons/src';
-import { GlobalHeader } from '@codecademy/gamut-labs/src/experimental/GlobalHeader/index.tsx';
+import { GlobalHeader } from '@codecademy/gamut-labs/src';
 import { Canvas, Meta, Props, Story } from '@storybook/addon-docs/dist/blocks';
 
 <Meta


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Changes GlobalHeader components focus outline to navy and add GlobalHeader to gamut-labs exports.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
