### PR TITLE
fix: guard against undefined body in Overlay

### DIFF
--- a/packages/gamut/src/Overlay/index.tsx
+++ b/packages/gamut/src/Overlay/index.tsx
@@ -42,7 +42,9 @@ export const Overlay: React.FC<OverlayProps> = ({
   isOpen,
 }) => {
   useIsomorphicLayoutEffect(() => {
-    document.body.style.overflow = isOpen ? 'hidden' : 'visible';
+    if (typeof document !== 'undefined') {
+      document.body.style.overflow = isOpen ? 'hidden' : 'visible';
+    }
   }, [isOpen]);
 
   if (!isOpen) return null;


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Guards the overflow effect in `Overlay` with a `typeof document !== "undefined"`.

<!--- END-CHANGELOG-DESCRIPTION -->

We're soon not going to have access to a JSDOM document in SSR on the monolith.
