### PR TITLE
fix: added npmignore and module field for gamut-tests

### DIFF
--- a/packages/gamut-tests/.npmignore
+++ b/packages/gamut-tests/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+src/
+*.ts
+*.tsx
+!*.d.ts

--- a/packages/gamut-tests/package.json
+++ b/packages/gamut-tests/package.json
@@ -15,6 +15,7 @@
   "version": "1.1.0",
   "license": "MIT",
   "main": "./dist/index.js",
+  "module": "dist/index.js",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

The `.npmignore` is missing so the published package doesn't have a `dist/`.

<!--- END-CHANGELOG-DESCRIPTION -->

I don't know that the `module` is necessary but figured we might as well.
