### PR TITLE
fix: remove deprecated elseif scss syntax

### DIFF
--- a/packages/gamut/src/ButtonDeprecated/styles/index.module.scss
+++ b/packages/gamut/src/ButtonDeprecated/styles/index.module.scss
@@ -33,8 +33,7 @@ fieldset[disabled] a.btn {
 @each $name, $color in $btn-swatches {
   @if $name == "brand-yellow" {
     @include button-variants($name, $color-black, $color);
-  }
-  @elseif lightness($color) > 68 {
+  } @else if lightness($color) > 68 {
     @include button-variants($name, $color-black, $color);
   } @else {
     @include button-variants($name, $color-white, $color);


### PR DESCRIPTION
### Overview

I noticed some errors for this property in our new Next.js app, not really a bug or anything, just a noisy warning we'll likely start seeing more if we upgrade Sass.

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
