### PR TITLE
feat(tracking): Add a fullstory boolean to TrackingOptions type --REVERT

### DIFF
--- a/packages/tracking/src/types.ts
+++ b/packages/tracking/src/types.ts
@@ -85,8 +85,6 @@ export type BaseEventAnyData = BaseEventData & {
 export type TrackingOptions = {
   /** tells backend not to merge user-identifying data onto the event payload */
   gdprSafe?: boolean;
-  /** tells frontend to send details to fullstory, which only accepts client-side events */
-  fullstory?: boolean;
 };
 
 /**


### PR DESCRIPTION
We decided against adding tracking to the FE since it would create difficulties avoiding double-tracking, so this is now tech-debt.