### PR TITLE
fix(AccordionButton): bump specificity of accordion button styles

### DIFF
--- a/packages/gamut/src/AccordionButton/styles.module.scss
+++ b/packages/gamut/src/AccordionButton/styles.module.scss
@@ -1,6 +1,7 @@
 @import "~@codecademy/gamut-styles/utils";
 
-.accordionButton {
+// Ensure styles override base button component styles
+.accordionButton.accordionButton {
   align-items: center;
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
### Overview
We pretty much exhausted all other fixes for this, likely should have just been doing this for all style overrides of other gamut components.

<!--- CHANGELOG-DESCRIPTION -->
Bumped specificity for `AccordionButton` component styles to always override `ButtonDeprecatedBase` styles.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
