### PR TITLE
fix: update font sizes within LP components at smaller than xs

### DIFF
--- a/packages/gamut-labs/src/landingPage/Feature.tsx
+++ b/packages/gamut-labs/src/landingPage/Feature.tsx
@@ -28,7 +28,7 @@ export const FeaturedIcon: React.FC<FeaturedIconProps> = ({ src, alt }) => (
 export const FeaturedStat: React.FC = ({ children }) => (
   <Text
     as="div"
-    fontSize={{ xs: 44, lg: 64 }}
+    fontSize={{ base: 44, lg: 64 }}
     fontWeight="title"
     data-testid="feature-stat"
     textColor="navy"
@@ -46,7 +46,7 @@ export const FeaturedTitle: React.FC<FeaturedTitleProps> = ({
 }) => (
   <Text
     as={as || 'h3'}
-    fontSize={{ xs: 22, lg: 26 }}
+    fontSize={{ base: 22, lg: 26 }}
     fontWeight="title"
     textColor="navy"
   >

--- a/packages/gamut-labs/src/landingPage/Title.tsx
+++ b/packages/gamut-labs/src/landingPage/Title.tsx
@@ -28,12 +28,12 @@ export const Title: React.FC<TitleProps> = ({
       fontSize={
         isPageHeading
           ? {
-              xs: 34,
+              base: 34,
               sm: 44,
               lg: 64,
             }
           : {
-              xs: 26,
+              base: 26,
               lg: 34,
             }
       }


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Updates `Text` font sizes within landing page components to start at `base` instead of `xs`.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-605](https://codecademy.atlassian.net/browse/REACH-605)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

### Description
Previously, the font sizes specified only got applied at `xs` and larger so on mobile size screens, the font was super large or small and wonky. This change applies to the `Title` component used as the main title in the `PageHero`, `PageFeatures`, `PagePrefooter`, and `PageVideoGallery` components, and the subtitle and stats text within the `PageFeatures` component.

Before:
![Screen Shot 2021-02-10 at 3 05 55 PM](https://user-images.githubusercontent.com/8761638/107565288-8504cd80-6bb1-11eb-8f6b-3afe9e34b5f2.png)

After:
![Screen Shot 2021-02-10 at 3 06 01 PM](https://user-images.githubusercontent.com/8761638/107565304-8a621800-6bb1-11eb-9981-4d6ae3298d94.png)

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
