### PR TITLE
fix: corrected NotificationList empty state to only show outline in focus-visible

### DIFF
--- a/packages/gamut/src/NotificationList/styles/index.module.scss
+++ b/packages/gamut/src/NotificationList/styles/index.module.scss
@@ -18,4 +18,8 @@
   background: none;
   border: none;
   text-align: center;
+
+  &:focus:not(&:focus-visible) {
+    outline: none;
+  }
 }


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Changes the empty text style for `NotificationList` to only show focus outline when in `:focus-visible`.

<!--- END-CHANGELOG-DESCRIPTION -->

`NotificationList` uses a button in a weird way to allow its focus-trap to not crash. The thing is going to get cleaned up soon, so this is just a quick quality of life fix in the interim.

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
