### PR TITLE
fix: reduce column gaps on mobile for LP components

### DIFF
--- a/packages/gamut-labs/src/landingPage/PageFeatures.tsx
+++ b/packages/gamut-labs/src/landingPage/PageFeatures.tsx
@@ -64,7 +64,7 @@ const gridRenderEach = (
   const size = { xs: 12, sm: 12 / maxCols } as ResponsiveProperty<ColumnSizes>;
   /* eslint-disable react/no-array-index-key */
   return (
-    <LayoutGrid columnGap="xl">
+    <LayoutGrid columnGap={{ xs: 'sm', sm: 'xl' }}>
       {items.map((item, i) => (
         <Column key={i} size={size}>
           {itemRenderer(item)}

--- a/packages/gamut-labs/src/landingPage/PageHero.tsx
+++ b/packages/gamut-labs/src/landingPage/PageHero.tsx
@@ -46,7 +46,7 @@ export const PageHero: React.FC<PageHeroProps> = ({
   onAnchorClick,
 }) => {
   return (
-    <LayoutGrid testId={testId} rowGap="md" columnGap="lg">
+    <LayoutGrid testId={testId} rowGap="md" columnGap={{ xs: 'sm', sm: 'lg' }}>
       <LeftColumn
         size={{
           xs: 12,


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Reduces column gaps on mobile within the `PageHero` and `PageFeatures` landing page components so they don't overflow.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

### Description
Previously if you went to https://staging.codecademy.com/about/careers-v2 on mobile, you are able to scroll to the right and can see the value props overflowing. Using dev tools you can see that the grid is the cause and reducing the grid gaps on mobile will resolve this.
![Screen Shot 2021-02-11 at 5 53 37 PM](https://user-images.githubusercontent.com/8761638/107708784-177c9e00-6c92-11eb-8b09-217ea652f036.png)
![Screen Shot 2021-02-11 at 5 55 44 PM](https://user-images.githubusercontent.com/8761638/107708988-717d6380-6c92-11eb-8494-daa38ad2012c.png)


<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
