### PR TITLE
fix(GlobalHeaderItems): add new tab true to external links

### DIFF
--- a/packages/gamut-labs/src/experimental/GlobalHeader/GlobalHeaderItems.tsx
+++ b/packages/gamut-labs/src/experimental/GlobalHeader/GlobalHeaderItems.tsx
@@ -83,6 +83,7 @@ export const resourcesDropdown: AppHeaderSimpleDropdownItem = {
     {
       id: 'blog',
       href: 'https://news.codecademy.com/',
+      newTab: true,
       trackingTarget: 'topnav_resources_blog',
       text: 'Blog',
       type: 'link',
@@ -101,6 +102,7 @@ export const communityDropdown: AppHeaderSimpleDropdownItem = {
       id: 'forums',
       href: 'https://discuss.codecademy.com/',
       trackingTarget: 'topnav_community_forums',
+      newTab: true,
       text: 'Forums',
       type: 'link',
     },
@@ -115,6 +117,7 @@ export const communityDropdown: AppHeaderSimpleDropdownItem = {
     {
       id: 'chapters',
       href: 'https://community.codecademy.com/',
+      newTab: true,
       trackingTarget: 'topnav_community_chapters',
       text: 'Chapters',
       type: 'link',
@@ -249,6 +252,7 @@ const profileCustomerSupport: AppHeaderLinkItem = {
 const profileReportBug: AppHeaderLinkItem = {
   id: 'report-bug',
   href: 'https://codecademy.atlassian.net/servicedesk/customer/portal/9',
+  newTab: true,
   trackingTarget: 'avatar_report_bug',
   text: 'Report a Bug [ADMIN]',
   type: 'link',


### PR DESCRIPTION
### Overview
We had missed adding "newTab: true" to a few of the app header items that should open in new tabs

all external links should open in a new tab 
ex. forums, chapters, blog, chat 

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
