### PR TITLE
ci: add auto assign reviewers config

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,7 @@
+# config for auto-request-review action
+# Sets up config for auto assigning reviewers based on code changes
+# See https://github.com/necojackarc/auto-request-review for more config options
+
+options:
+  ignore_draft: true
+  number_of_reviewers: 3

--- a/.github/workflows/auto-request-review.yml
+++ b/.github/workflows/auto-request-review.yml
@@ -1,0 +1,16 @@
+name: Auto Request Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml # Config file location override


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Adds github action that will auto assign reviewers to non-draft PRs based on who recently changed the code
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
