### PR TITLE
fix(video): include wrapper in type

### DIFF
--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -13,6 +13,12 @@ const OverlayPlayButton = () => {
   );
 };
 
+/**
+ * @remarks ReactPlayer has optional key 'wrapper' that we require for the onReady callback
+ */
+
+export type ReactPlayerWithWrapper = ReactPlayer & { wrapper: HTMLElement };
+
 export type VideoProps = {
   videoUrl: string;
   videoTitle?: string;
@@ -22,7 +28,7 @@ export type VideoProps = {
   loop?: boolean;
   muted?: boolean;
   className?: string;
-  onReady?: (player: ReactPlayer & { wrapper: HTMLElement }) => void;
+  onReady?: (player: ReactPlayerWithWrapper) => void;
   onPlay?: () => void;
 };
 
@@ -53,7 +59,7 @@ export const Video: React.FC<VideoProps> = ({
         loop={loop}
         muted={muted}
         playIcon={<OverlayPlayButton />}
-        onReady={(player: ReactPlayer & { wrapper: HTMLElement }) => {
+        onReady={(player: ReactPlayerWithWrapper) => {
           onReady?.(player);
           setLoading(false);
         }}

--- a/packages/gamut/src/Video/index.tsx
+++ b/packages/gamut/src/Video/index.tsx
@@ -22,7 +22,7 @@ export type VideoProps = {
   loop?: boolean;
   muted?: boolean;
   className?: string;
-  onReady?: (player: ReactPlayer) => void;
+  onReady?: (player: ReactPlayer & { wrapper: HTMLElement }) => void;
   onPlay?: () => void;
 };
 
@@ -53,7 +53,7 @@ export const Video: React.FC<VideoProps> = ({
         loop={loop}
         muted={muted}
         playIcon={<OverlayPlayButton />}
-        onReady={(player: ReactPlayer) => {
+        onReady={(player: ReactPlayer & { wrapper: HTMLElement }) => {
           onReady?.(player);
           setLoading(false);
         }}


### PR DESCRIPTION
### Overview

This way the consumer (monolith) won't need to import from react-videoplayer (& we wont need that package in the monolith at all)

https://github.com/codecademy-engineering/Codecademy/blob/develop/webpack/assets/components/VideoModal/index.tsx#L53

Result of debugging with @JoshuaKGoldberg 

- I updated gamut package numbers
- yarn compile in monolith failing bc version of react-videoplayer was different than in gamut
- interim fix was to upgrade monolith version to match what was in gamut https://github.com/codecademy-engineering/Codecademy/pull/22305/commits/5f47b4e379e00a5602242f9e7dcb4cc1bd65e330
-  
<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
