### PR TITLE
fix(Modal): Ensure that the overlay content can be used as the focus target

### DIFF
--- a/packages/styleguide/.storybook/main.ts
+++ b/packages/styleguide/.storybook/main.ts
@@ -51,6 +51,10 @@ module.exports = {
           '../../gamut-system/src'
         ),
         '@codecademy/gamut$': path.resolve(__dirname, '../../gamut/src'),
+        '@codecademy/gamut-labs$': path.resolve(
+          __dirname,
+          '../../gamut-labs/src'
+        ),
         '@codecademy/gamut-illustrations$': path.resolve(
           __dirname,
           '../../gamut-illustrations/src'

--- a/packages/styleguide/stories/Molecules/Modal.stories.mdx
+++ b/packages/styleguide/stories/Molecules/Modal.stories.mdx
@@ -1,7 +1,7 @@
 import { ButtonDeprecated, Modal, Overlay } from '@codecademy/gamut/src';
 import title from '@codecademy/macros/lib/title.macro';
 import { Canvas, Meta, Props, Story } from '@storybook/addon-docs/dist/blocks';
-import { useState } from '@storybook/addons';
+import { useState } from 'react';
 
 <Meta
   title={title}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Moves focus-trap up a level and manually handles `clickOutside` behavior so that the first child of an Overlay can be the focus target (the default for Modal). 
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
