### PR TITLE
fix(global header): for monolith migration work

### DIFF
--- a/packages/gamut-labs/src/experimental/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
@@ -27,6 +27,7 @@ export const AppHeaderLink: React.FC<AppHeaderLinkProps> = ({
   return (
     <AppHeaderLinkButtonOuter
       data-testid={item.dataTestId}
+      data-intellimize={item.dataIntellimizeId}
       href={item.href}
       onClick={(event) => action(event, item)}
       target={item.newTab ? 'blank' : ''}

--- a/packages/gamut-labs/src/experimental/AppHeader/AppHeaderElements/types.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeader/AppHeaderElements/types.tsx
@@ -11,6 +11,7 @@ export type AppHeaderItem =
   | AppHeaderRenderElementItem;
 
 type AppHeaderBaseItem = {
+  dataIntellimizeId?: string;
   dataTestId?: string;
   id: string;
 };

--- a/packages/gamut-labs/src/experimental/AppHeaderMobile/AppHeaderLinkMobile/index.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeaderMobile/AppHeaderLinkMobile/index.tsx
@@ -51,6 +51,7 @@ export const AppHeaderLinkMobile: React.FC<AppHeaderLinkMobileProps> = ({
     <SeparatorOuter topSeparator={topSeparator}>
       <SeparatorInner topSeparator={topSeparator}>
         <AppHeaderLinkButtonOuter
+          data-intellimize={item.dataIntellimizeId}
           data-testid={item.dataTestId}
           href={item.href}
           onClick={(event) => action(event, item)}

--- a/packages/gamut-labs/src/experimental/AppHeaderMobile/AppHeaderMainMenuMobile/index.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeaderMobile/AppHeaderMainMenuMobile/index.tsx
@@ -56,11 +56,10 @@ export const AppHeaderMainMenuMobile: React.FC<AppHeaderMainMenuMobileProps> = (
         );
       case 'fill-button':
         return (
-          <FlexBox justifyContent="center" marginTop={32}>
+          <FlexBox justifyContent="center" marginTop={32} key={item.id}>
             <AppHeaderFillButton
               data-testid={item.dataTestId}
               href={item.href}
-              key={item.id}
               onClick={(event: React.MouseEvent) => action(event, item)}
             >
               {item.text}
@@ -69,11 +68,10 @@ export const AppHeaderMainMenuMobile: React.FC<AppHeaderMainMenuMobileProps> = (
         );
       case 'text-button':
         return (
-          <FlexBox justifyContent="center" marginTop={16}>
+          <FlexBox justifyContent="center" marginTop={16} key={item.id}>
             <AppHeaderTextButton
               data-testid={item.dataTestId}
               href={item.href}
-              key={item.id}
               onClick={(event: React.MouseEvent) => action(event, item)}
             >
               {item.text}

--- a/packages/gamut-labs/src/experimental/AppHeaderMobile/index.tsx
+++ b/packages/gamut-labs/src/experimental/AppHeaderMobile/index.tsx
@@ -120,7 +120,7 @@ export const AppHeaderMobile: React.FC<AppHeaderMobileProps> = ({
               </FlexBox>
             </AppBarSection>
           </StyledAppBar>
-          <Box paddingX={16}>
+          <Box paddingX={{ base: 16, sm: 32 }}>
             <AppHeaderMainMenuMobile
               items={items.mainMenu}
               action={action}

--- a/packages/gamut-labs/src/experimental/GlobalHeader/GlobalHeaderItems.tsx
+++ b/packages/gamut-labs/src/experimental/GlobalHeader/GlobalHeaderItems.tsx
@@ -242,6 +242,7 @@ const profileHelpCenter: AppHeaderLinkItem = {
 
 const profileAdmin: AppHeaderLinkItem = {
   id: 'admin',
+  dataTestId: 'admin-link',
   href: '/admin',
   trackingTarget: 'avatar_admin',
   text: 'Admin',

--- a/packages/gamut-labs/src/experimental/GlobalHeader/GlobalHeaderItems.tsx
+++ b/packages/gamut-labs/src/experimental/GlobalHeader/GlobalHeaderItems.tsx
@@ -43,6 +43,7 @@ export const proLogo: AppHeaderLogoItem = {
 
 export const myHome: AppHeaderLinkItem = {
   dataTestId: 'header-home',
+  dataIntellimizeId: 'header-home',
   icon: HouseEntranceIcon,
   id: 'my-home',
   text: 'My Home',
@@ -53,6 +54,7 @@ export const myHome: AppHeaderLinkItem = {
 
 export const courseCatalog: AppHeaderLinkItem = {
   dataTestId: 'header-catalog',
+  dataIntellimizeId: 'header-catalog',
   icon: BookFlipPageIcon,
   id: 'course-catalog',
   text: 'Catalog',
@@ -168,6 +170,7 @@ export const pricingDropdown: AppHeaderSimpleDropdownItem = {
 export const forBusiness: AppHeaderLinkItem = {
   icon: BriefcaseIcon,
   id: 'for-business',
+  dataIntellimizeId: 'header-business',
   trackingTarget: 'topnav_business',
   text: 'For Business',
   href: '/business',

--- a/packages/gamut-labs/src/experimental/GlobalHeader/types.tsx
+++ b/packages/gamut-labs/src/experimental/GlobalHeader/types.tsx
@@ -27,9 +27,11 @@ type LoggedInHeader = BaseHeader & {
   user: User;
 };
 
+export type AnonHeaderVariant = 'landing' | 'login' | 'signup';
+
 export type AnonHeader = BaseHeader & {
   type: 'anon';
-  variant?: 'landing' | 'login' | 'signup';
+  variant?: AnonHeaderVariant;
 };
 
 export type FreeHeader = LoggedInHeader & {


### PR DESCRIPTION
### Overview
As I'm working on EGG-536 Migrate Monolith to Use the Global Header, I have come across a few small updates needed in client modules. 

I'll mark them here as I go. My plan is to use the alpha build from this PR in the[ monolith branch](https://github.com/codecademy-engineering/Codecademy/pull/22024) to confirm these updates fix the problems I'm seeing there.  I will make sure to keep this branch up to date with main!

- Key on items in the Main Mobile Menu wasn't on the highest element in the list. I made the change to move it up from the app header item to the Flexbox container.  The key issue caused an AnonymousAppHeader unit [test](https://app.circleci.com/pipelines/github/codecademy-engineering/Codecademy/74019/workflows/138d5895-6e87-49e8-8795-9b8bfc6ecbfe/jobs/1155052/tests#failed-test-5) on my monolith branch  to fail. 
- Profile dropdown's "Admin" link was missing `data-testid: 'admin'` causing the [Users e2e](https://app.circleci.com/pipelines/github/codecademy-engineering/Codecademy/74019/workflows/138d5895-6e87-49e8-8795-9b8bfc6ecbfe/jobs/1155086) test to fail on my monolith branch
- add data-intellimize id's to 3 app header links (header-catalog, header-business, header-home); these exist in the monolith right now and would be lost with the transition to using the global header unless i add to gamut-labs. I reached out to see if these properties were still being used, and they are. An external team uses these attributes to run experiments. the business team made the decision to use a custom attribute `data-intellimize`for clarity purposes
- made app header mobile padding responsive so it lines up with the app bar used for the header

Testing --
If you go to the [storybook preview of the global header](https://603ea939dd5c4c2b899cac2a--gamut-preview.netlify.app/storybook/?path=/docs/labs-experimental-molecules-globalheader--global-header), if you inspect the "my home" "catalog" and "business" links, you should see the attribute data-intellimize = "header-home" "header-catalog" "header-business"

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [EGG-536](https://codecademy.atlassian.net/browse/EGG-536)
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
