### PR TITLE
fix(global header): export global header types 

### DIFF
--- a/packages/gamut-labs/src/experimental/index.ts
+++ b/packages/gamut-labs/src/experimental/index.ts
@@ -12,3 +12,4 @@ export * from './AppHeaderMobile/AppHeaderLinkMobile';
 export * from './AppHeaderMobile/AppHeaderMainMenuMobile';
 export * from './AppHeaderMobile/AppHeaderSubMenuMobile';
 export * from './GlobalHeader';
+export * from './GlobalHeader/types';

--- a/packages/gamut-labs/src/experimental/index.ts
+++ b/packages/gamut-labs/src/experimental/index.ts
@@ -12,4 +12,4 @@ export * from './AppHeaderMobile/AppHeaderLinkMobile';
 export * from './AppHeaderMobile/AppHeaderMainMenuMobile';
 export * from './AppHeaderMobile/AppHeaderSubMenuMobile';
 export * from './GlobalHeader';
-export * from './GlobalHeader/types';
+export { AnonHeaderVariant } from './GlobalHeader/types';


### PR DESCRIPTION
### Overview

Addressing [feedback](https://github.com/codecademy-engineering/Codecademy/pull/22024#discussion_r585939943) on my monolith PR to import the AnonHeaderVariant from GlobalHeader instead of declaring a new type "Variant" in the monolith's App Header

In the [PR i just merged](https://github.com/Codecademy/client-modules/pull/1451), I forgot to export the GlobalHeader/types file so came across an error when trying to use the new type in my monolith feature branch

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: EGG-536
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
