### PR TITLE
fix(ProgressBar): Screenreaders narrate the progress twice

### DIFF
--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -152,7 +152,6 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
 }) => {
   return (
     <ProgressBarWrapper
-      aria-label={`Progress: ${percent}%`}
       aria-live="polite"
       role="figure"
       border={bordered ? 'bordered' : 'basic'}
@@ -175,7 +174,11 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
           width: `${Math.max(minimumPercent, percent)}%`,
         }}
       >
-        {size === 'large' && <DisplayedPercent>{percent}%</DisplayedPercent>}
+        {size === 'large' && (
+          <DisplayedPercent aria-label={`Progress: ${percent}%`}>
+            {percent}%
+          </DisplayedPercent>
+        )}
       </Bar>
     </ProgressBarWrapper>
   );


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Currently, screenreaders read the progress percentage twice, sounds like "5%, Progress: 5%". You can hear this behavior in the dashboard's (/learn) course cards.

The `aria-label` might need to be around the percentage text itself instead of in a parent element.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [EGG-731]
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
