### PR TITLE
fix: switch gamut-tests to an internal devDependency

### DIFF
--- a/packages/gamut-labs/package.json
+++ b/packages/gamut-labs/package.json
@@ -16,7 +16,6 @@
     "url": "git@github.com:Codecademy/client-modules.git"
   },
   "peerDependencies": {
-    "@codecademy/gamut-tests": "^1.0.0",
     "@emotion/react": "^11.1.4",
     "@emotion/styled": "^11.0.0",
     "react": ">=16.8.1",
@@ -26,10 +25,12 @@
     "@codecademy/gamut": "^25.4.1",
     "@codecademy/gamut-styles": "^8.2.0",
     "@codecademy/gamut-system": "^0.5.0",
-    "@codecademy/gamut-tests": "^2.1.3",
     "classnames": "^2.2.5",
     "react-hotkeys-hook": "^2.3.1",
     "react-use": "15.3.8"
+  },
+  "devDependencies": {
+    "@codecademy/gamut-tests": "^2.1.3"
   },
   "scripts": {
     "verify": "tsc --noEmit",

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -25,7 +25,6 @@
     "@codecademy/gamut-icons": "^4.0.0",
     "@codecademy/gamut-illustrations": "^0.7.2",
     "@codecademy/gamut-styles": "^8.2.0",
-    "@codecademy/gamut-tests": "^2.1.3",
     "@types/marked": "^1.1.0",
     "classnames": "^2.2.5",
     "focus-trap-react": "^8.4.1",
@@ -52,6 +51,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@codecademy/gamut-tests": "^2.1.3",
     "onchange": "^7.0.2"
   },
   "publishConfig": {


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Switched `@codecademy/gamut-tests` to an internal devDependency. 

<!--- END-CHANGELOG-DESCRIPTION -->

There was no good reason to make it a full `dependencies` member in the first place.
