### PR TITLE
build: Set ^4.0.0 for version of lodash peer dependency

### DIFF
--- a/packages/gamut-system/package.json
+++ b/packages/gamut-system/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "csstype": ">=3.0.0",
-    "lodash": "^>=4.0.0"
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "@emotion/jest": "^11.1.0",


### PR DESCRIPTION
### Overview
I changed 
```json
"lodash": "^>=4.0.0"
```
`=>`
```json
"lodash": "^4.0.0"
```

Kept seeing these warnings in static sites and monolith yarn install logs despite [`"lodash": "^4.17.19",`] in the monolith's package.json (https://github.com/codecademy-engineering/Codecademy/blob/develop/package.json#L64)
```bash
warning " > @codecademy/gamut-system@0.5.0" has incorrect peer dependency "lodash@^>=4.0.0".
```

### Changes
<!--- CHANGELOG-DESCRIPTION -->
Sets `^4.0.0` as the version for peer dependency `lodash`.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] ~Related to designs:~
- [ ] ~Related to JIRA ticket: ABC-123~
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
