### PR TITLE
fix(Notifications): export notification type

### DIFF
--- a/packages/gamut/src/index.tsx
+++ b/packages/gamut/src/index.tsx
@@ -36,7 +36,7 @@ export * from './Modal';
 export * from './NotificationList';
 export * from './NotificationList/NotificationIcon';
 export * from './NotificationList/NotificationItem';
-export { Notification } from './NotificationList/typings';
+export type { Notification } from './NotificationList/typings';
 export * from './NotificationListNew';
 export * from './NotificationListNew/NotificationItemNew';
 export * from './Overlay';

--- a/packages/gamut/src/index.tsx
+++ b/packages/gamut/src/index.tsx
@@ -36,6 +36,7 @@ export * from './Modal';
 export * from './NotificationList';
 export * from './NotificationList/NotificationIcon';
 export * from './NotificationList/NotificationItem';
+export { Notification } from './NotificationList/typings';
 export * from './NotificationListNew';
 export * from './NotificationListNew/NotificationItemNew';
 export * from './Overlay';


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
When working on the desk check/bug bash feedback for Persistent Notifications, I noticed the new notifications component in the monolith is importing type "Notification" from  `'@codecademy/gamut/dist/NotificationList/typings'`
see: https://github.com/codecademy-engineering/Codecademy/blob/develop/webpack/assets/components/Notifications/NotificationsList/index.tsx#L7


so I'm making this fix to export it from the gamut src directory instead

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: EGG-895
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
