### PR TITLE
fix(NotificationItemNew): dismiss icon hover

### DIFF
--- a/packages/gamut/src/Button/TextButton.tsx
+++ b/packages/gamut/src/Button/TextButton.tsx
@@ -6,7 +6,7 @@ import { ButtonInner } from './ButtonInner';
 import { ButtonOutline } from './ButtonOutline';
 import { buttonSizing, modeColorGroups, SizedButtonProps } from './shared';
 
-export const TextButtonInner = styled(ButtonInner)<SizedButtonProps>(
+const TextButtonInner = styled(ButtonInner)<SizedButtonProps>(
   buttonSizing,
   ({ mode = 'light', variant = 'primary', theme }) => {
     const modeColors = modeColorGroups[mode][variant];

--- a/packages/gamut/src/Button/TextButton.tsx
+++ b/packages/gamut/src/Button/TextButton.tsx
@@ -6,7 +6,7 @@ import { ButtonInner } from './ButtonInner';
 import { ButtonOutline } from './ButtonOutline';
 import { buttonSizing, modeColorGroups, SizedButtonProps } from './shared';
 
-const TextButtonInner = styled(ButtonInner)<SizedButtonProps>(
+export const TextButtonInner = styled(ButtonInner)<SizedButtonProps>(
   buttonSizing,
   ({ mode = 'light', variant = 'primary', theme }) => {
     const modeColors = modeColorGroups[mode][variant];

--- a/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
+++ b/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
@@ -53,18 +53,6 @@ const StyledImg = styled.img`
   width: 3rem;
 `;
 
-/* this targeted hover effect is needed for a specific case (dismiss icon is within another link, with its own background color change on hover)
- this practice should not be replicated elsewhere */
-const StyledIconButton = styled(IconButton)`
-  z-index: 1;
-  &:hover {
-    span {
-      background-color: ${({ theme }) =>
-        theme.colors['gray-300']}; // this will break on darkmode
-    }
-  }
-`;
-
 const DateText = styled(Text)`
   margin-left: 4px;
   color: ${({ theme }) => theme.colors['gray-600']};
@@ -120,13 +108,14 @@ export const NotificationItemNew: React.FC<NotificationItemNewProps> = ({
   );
 
   const dismissIcon: ReactElement = (
-    <StyledIconButton
+    <IconButton
       icon={MiniDeleteIcon}
       color={colors.navy}
       onClick={handleDismiss}
       aria-label="dismiss notification"
       size="small"
       variant="secondary"
+      z-index={1}
     />
   );
 
@@ -134,6 +123,7 @@ export const NotificationItemNew: React.FC<NotificationItemNewProps> = ({
     <FlexBox
       paddingY={24}
       paddingX={32}
+      alignItems="flex-start"
       justifyContent="space-between"
       position="relative"
     >
@@ -152,7 +142,9 @@ export const NotificationItemNew: React.FC<NotificationItemNewProps> = ({
       ) : (
         <>{notificationContent}</>
       )}
-      {handleDismiss && dismissIcon}
+      <FlexBox alignItems="flex-start" zIndex={1}>
+        {handleDismiss && dismissIcon}
+      </FlexBox>
     </FlexBox>
   );
 };

--- a/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
+++ b/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
@@ -17,10 +17,32 @@ import { Notification } from '../NotificationList/typings';
 const StyledLink = styled.a`
   text-decoration: none;
   display: block;
-
+  z-index: 1;
+  &:before,
+  &:after {
+    top: -1px;
+    left: 0;
+    z-index: 0;
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: calc(100% + 2px);
+    transition: background 250ms;
+  }
+  &:focus {
+    outline: none;
+  }
+  &:focus-visible {
+    &:after {
+      border-radius: 4px;
+      border: 2px solid ${({ theme }) => theme.colors.navy};
+    }
+  }
   &:hover {
     text-decoration: none;
-    background-color: ${({ theme }) => theme.colors['gray-100']};
+    &:before {
+      background-color: ${({ theme }) => theme.colors['gray-100']};
+    }
   }
 `;
 
@@ -34,10 +56,11 @@ const StyledImg = styled.img`
 /* this targeted hover effect is needed for a specific case (dismiss icon is within another link, with its own background color change on hover)
  this practice should not be replicated elsewhere */
 const StyledIconButton = styled(IconButton)`
+  z-index: 1;
   &:hover {
     span {
       background-color: ${({ theme }) =>
-        theme.colors['gray-300']} !important; // this will break on darkmode
+        theme.colors['gray-300']}; // this will break on darkmode
     }
   }
 `;
@@ -60,13 +83,7 @@ export const NotificationItemNew: React.FC<NotificationItemNewProps> = ({
 }) => {
   const { date, imageUrl, link, text, type } = notification;
 
-  const dismissNotification = (event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    handleDismiss && handleDismiss();
-  };
-
-  const getIcon = () => {
+  const renderIcon = () => {
     if (imageUrl) {
       return <StyledImg src={imageUrl} alt="" />;
     }
@@ -88,49 +105,54 @@ export const NotificationItemNew: React.FC<NotificationItemNewProps> = ({
     return <Bell aria-hidden height={48} width={48} />;
   };
 
-  const renderNotificationContent = (): ReactElement => {
-    return (
-      <FlexBox paddingY={24} justifyContent="space-between" paddingX={32}>
-        {getIcon()}
-        <Box flexBasis={0} flexGrow={1} paddingLeft={12} textColor="navy">
-          <Text as="span" fontSize="sm">
-            {text}
-          </Text>
-          <DateText as="span" fontSize="sm">
-            {date}
-          </DateText>
-        </Box>
-        {handleDismiss && (
-          <FlexBox alignSelf="end" paddingLeft={8}>
-            <StyledIconButton
-              icon={MiniDeleteIcon}
-              color={colors.navy}
-              onClick={dismissNotification}
-              aria-label="dismiss notification"
-              size="small"
-              variant="secondary"
-            />
-          </FlexBox>
-        )}
-      </FlexBox>
-    );
-  };
+  const notificationContent: ReactElement = (
+    <FlexBox zIndex={1} position="relative">
+      {renderIcon()}
+      <Box flexBasis={0} flexGrow={1} paddingLeft={12} textColor="navy">
+        <Text as="span" fontSize="sm">
+          {text}
+        </Text>
+        <DateText as="span" fontSize="sm">
+          {date}
+        </DateText>
+      </Box>
+    </FlexBox>
+  );
+
+  const dismissIcon: ReactElement = (
+    <StyledIconButton
+      icon={MiniDeleteIcon}
+      color={colors.navy}
+      onClick={handleDismiss}
+      aria-label="dismiss notification"
+      size="small"
+      variant="secondary"
+    />
+  );
 
   return (
-    <>
+    <FlexBox
+      paddingY={24}
+      paddingX={32}
+      justifyContent="space-between"
+      position="relative"
+    >
       {link ? (
-        <StyledLink
-          href={link}
-          aria-label={`${text}, ${date} ago`}
-          rel="noopener noreferrer"
-          target="_blank"
-          onClick={(event) => handleClick?.(event)}
-        >
-          {renderNotificationContent()}
-        </StyledLink>
+        <>
+          <StyledLink
+            href={link}
+            aria-label={`${text}, ${date} ago`}
+            rel="noopener noreferrer"
+            target="_blank"
+            onClick={(event) => handleClick?.(event)}
+          >
+            {notificationContent}
+          </StyledLink>
+        </>
       ) : (
-        <div>{renderNotificationContent()}</div>
+        <>{notificationContent}</>
       )}
-    </>
+      {handleDismiss && dismissIcon}
+    </FlexBox>
   );
 };

--- a/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
+++ b/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
@@ -12,6 +12,8 @@ import styled from '@emotion/styled';
 import React, { ReactElement } from 'react';
 
 import { Box, FlexBox, IconButton, Text } from '..';
+import { TextButtonInner } from '../Button';
+import { ButtonInner } from '../Button/ButtonInner';
 import { Notification } from '../NotificationList/typings';
 
 const StyledLink = styled.a`
@@ -35,9 +37,9 @@ const StyledImg = styled.img`
  this practice should not be replicated elsewhere */
 const StyledIconButton = styled(IconButton)`
   &:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-    span {
-      background-color: rgba(0, 0, 0, 0.05) !important;
+    ${TextButtonInner} {
+      background-color: ${({ theme }) =>
+        theme.colors['gray-300']} !important; // this will break on darkmode
     }
   }
 `;

--- a/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
+++ b/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
@@ -31,9 +31,14 @@ const StyledImg = styled.img`
   width: 3rem;
 `;
 
+/* this targeted hover effect is needed for a specific case (dismiss icon is within another link, with its own background color change on hover)
+ this practice should not be replicated elsewhere */
 const StyledIconButton = styled(IconButton)`
   &:hover {
     background-color: rgba(0, 0, 0, 0.05);
+    span {
+      background-color: rgba(0, 0, 0, 0.05) !important;
+    }
   }
 `;
 

--- a/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
+++ b/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
@@ -31,6 +31,12 @@ const StyledImg = styled.img`
   width: 3rem;
 `;
 
+const StyledIconButton = styled(IconButton)`
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+`;
+
 const DateText = styled(Text)`
   margin-left: 4px;
   color: ${({ theme }) => theme.colors['gray-600']};
@@ -91,7 +97,7 @@ export const NotificationItemNew: React.FC<NotificationItemNewProps> = ({
         </Box>
         {handleDismiss && (
           <FlexBox alignSelf="end" paddingLeft={8}>
-            <IconButton
+            <StyledIconButton
               icon={MiniDeleteIcon}
               color={colors.navy}
               onClick={dismissNotification}

--- a/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
+++ b/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
@@ -12,7 +12,6 @@ import styled from '@emotion/styled';
 import React, { ReactElement } from 'react';
 
 import { Box, FlexBox, IconButton, Text } from '..';
-import { TextButtonInner } from '../Button';
 import { Notification } from '../NotificationList/typings';
 
 const StyledLink = styled.a`
@@ -36,7 +35,7 @@ const StyledImg = styled.img`
  this practice should not be replicated elsewhere */
 const StyledIconButton = styled(IconButton)`
   &:hover {
-    ${TextButtonInner} {
+    span {
       background-color: ${({ theme }) =>
         theme.colors['gray-300']} !important; // this will break on darkmode
     }

--- a/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
+++ b/packages/gamut/src/NotificationListNew/NotificationItemNew.tsx
@@ -13,7 +13,6 @@ import React, { ReactElement } from 'react';
 
 import { Box, FlexBox, IconButton, Text } from '..';
 import { TextButtonInner } from '../Button';
-import { ButtonInner } from '../Button/ButtonInner';
 import { Notification } from '../NotificationList/typings';
 
 const StyledLink = styled.a`

--- a/packages/styleguide/stories/Molecules/NotificationListNew.stories.mdx
+++ b/packages/styleguide/stories/Molecules/NotificationListNew.stories.mdx
@@ -18,7 +18,7 @@ export const notificationList = [
     campaign: 'pro-trial',
     type: 'marketing_blast',
     date: '3 hours',
-    id: '123',
+    id: '1237',
     text:
       "It's your last day of Pro Trial! Sign up with Codecademy Pro to get helpful features like quizzes and projects and practice on the Codecademy Go mobile app!",
   },


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
add style for dismiss icon hover

To test: visit [NotificationListNew story ](https://6052261a3b0a95aa51169e73--gamut-preview.netlify.app/storybook/?path=/docs/molecules-notificationlistnew--notification-list-new)in the preview environment; hover over the dismiss icon on the Notification w/ a link. Confirm that you see the clickable area for the dismiss icon on hover. 

*Note: looks faint to me! but I used the styles @codecaaron suggested! Please let me know if I should modify

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket:[ EGG-893](https://codecademy.atlassian.net/browse/EGG-893)
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
