### PR TITLE
chore: remove redundant react-anonymous-display-name in Babel configs

### DIFF
--- a/packages/gamut-icons/babel.config.js
+++ b/packages/gamut-icons/babel.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
-  plugins: ['react-anonymous-display-name'],
   include: ['./src/**/*'],
   ignore: ['__tests__', './**/*.d.ts'],
 };

--- a/packages/gamut-labs/babel.config.js
+++ b/packages/gamut-labs/babel.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
   plugins: [
-    'react-anonymous-display-name',
     [
       '@emotion',
       {

--- a/packages/gamut/babel.config.js
+++ b/packages/gamut/babel.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
   plugins: [
-    'react-anonymous-display-name',
     [
       '@emotion',
       {

--- a/packages/markdown-overrides/babel.config.js
+++ b/packages/markdown-overrides/babel.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
-  plugins: ['react-anonymous-display-name'],
   include: ['./src/**/*'],
   ignore: ['__tests__', './**/*.d.ts'],
 };

--- a/packages/styleguide/.storybook/babel.config.js
+++ b/packages/styleguide/.storybook/babel.config.js
@@ -2,7 +2,6 @@ module.exports = {
   presets: ['codecademy', '@babel/preset-typescript'],
   plugins: [
     'macros',
-    'react-anonymous-display-name',
     [
       '@emotion',
       {


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Removed redundant react-anonymous-display-name in Babel configs now that it's in the Codecademy preset.

<!--- END-CHANGELOG-DESCRIPTION -->
