### PR TITLE
feat(Variance): base => _ for un scoped style [WEB-1381]

### DIFF
--- a/packages/variance/src/__tests__/component-test.tsx
+++ b/packages/variance/src/__tests__/component-test.tsx
@@ -52,7 +52,9 @@ describe('style props', () => {
     const renderView = renderer
       .create(
         <ThemeProvider theme={theme}>
-          <Test margin={[4, 8, 16]}>Hello</Test>
+          <Test margin={[4, 8, 16]} padding={{ _: 0 }}>
+            Hello
+          </Test>
         </ThemeProvider>
       )
       .toJSON();

--- a/packages/variance/src/__tests__/variance-test.ts
+++ b/packages/variance/src/__tests__/variance-test.ts
@@ -109,11 +109,11 @@ describe('style props', () => {
       });
     });
     it('renders media map arrays styles', () => {
-      const sizes = { base: 4, xs: 8, sm: 16, md: 24, lg: 32, xl: 48 } as const;
+      const sizes = { _: 4, xs: 8, sm: 16, md: 24, lg: 32, xl: 48 } as const;
       const rem = (val: number) => `${val / 16}rem`;
 
       expect(space({ margin: sizes, theme })).toEqual({
-        margin: rem(sizes.base),
+        margin: rem(sizes._),
         XS: {
           margin: rem(sizes.xs),
         },
@@ -132,12 +132,12 @@ describe('style props', () => {
       });
     });
     it('renders media map arrays styles', () => {
-      const sizes = { base: 4, xs: 8, sm: 16, md: 24, lg: 32, xl: 48 } as const;
+      const sizes = { _: 4, xs: 8, sm: 16, md: 24, lg: 32, xl: 48 } as const;
       const rem = (val: number) => `${val / 16}rem`;
 
       expect(space({ margin: sizes, padding: sizes, theme })).toEqual({
-        margin: rem(sizes.base),
-        padding: rem(sizes.base),
+        margin: rem(sizes._),
+        padding: rem(sizes._),
         XS: {
           margin: rem(sizes.xs),
           padding: rem(sizes.xs),

--- a/packages/variance/src/core.ts
+++ b/packages/variance/src/core.ts
@@ -50,7 +50,7 @@ export const variance = {
                 );
               // handle any props configured with the responsive notation
               case 'object':
-                // If it is an array the order of values is smallest to largest: [base, xs, ...]
+                // If it is an array the order of values is smallest to largest: [_, xs, ...]
                 if (isMediaArray(value)) {
                   return merge(
                     styles,

--- a/packages/variance/src/types/props.ts
+++ b/packages/variance/src/types/props.ts
@@ -32,7 +32,7 @@ export interface MediaQueryArray<T> {
   5?: T;
 }
 export interface MediaQueryMap<T> {
-  base?: T;
+  _?: T;
   xs?: T;
   sm?: T;
   md?: T;

--- a/packages/variance/src/utils/responsive.ts
+++ b/packages/variance/src/utils/responsive.ts
@@ -9,7 +9,7 @@ import {
   ThemeProps,
 } from '../types/props';
 
-const BREAKPOINT_KEYS = ['base', 'xs', 'sm', 'md', 'lg', 'xl'];
+const BREAKPOINT_KEYS = ['_', 'xs', 'sm', 'md', 'lg', 'xl'];
 
 /**
  * Destructures the themes breakpoints into an ordered structure to traverse
@@ -51,9 +51,9 @@ export const objectParser: ResponsiveParser<MediaQueryMap<string | number>> = (
 ) => {
   const styles: CSSObject = {};
   const { styleFn, prop } = config;
-  const { base, ...rest } = value;
+  const { _, ...rest } = value;
   // the keyof 'base' is base styles
-  if (base) Object.assign(styles, styleFn(base, prop, props));
+  if (_) Object.assign(styles, styleFn(_, prop, props));
 
   // Map over remaining keys and merge the corresponding breakpoint styles
   // for that property.
@@ -76,9 +76,9 @@ export const arrayParser: ResponsiveParser<(string | number)[]> = (
 ): CSSObject => {
   const styles: CSSObject = {};
   const { styleFn, prop } = config;
-  const [base, ...rest] = value;
+  const [_, ...rest] = value;
   // the first index is base styles
-  if (base) Object.assign(styles, styleFn(base, prop, props));
+  if (_) Object.assign(styles, styleFn(_, prop, props));
 
   // Map over each value in the array and merge the corresponding breakpoint styles
   // for that property.


### PR DESCRIPTION
### [Variance Migration Doc](https://www.notion.so/codecademy/Variance-Migration-a675bbc31b584fec9dfff72c0364b194)

<!--- CHANGELOG-DESCRIPTION -->
Change variance's responsive object syntax unscoped key `base`  to `_` to match other frameworks as underscore denotes a behavior that is unrelated to the rest of the keys and saves 3 characters to probable prop bloat.

```tsx
// before
<Box p={{ base: 4, md: 8 }} />
// after
<Box p={{ _: 4, md: 8 }} />
```
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: WEB-1381
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
