### PR TITLE
feat(DeferredRender): port from monolith

### DIFF
--- a/packages/gamut-labs/src/experimental/DeferredRender/index.tsx
+++ b/packages/gamut-labs/src/experimental/DeferredRender/index.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+export type DeferredRenderProps = {
+  fallback?: React.ReactNode;
+};
+
+/**
+ * DeferredRender
+ *
+ * This is a simple component that just ensures that it's children don't render
+ * until this component is mounted.
+ *
+ * This is mainly used to prevent a component from rendering serverside.
+ */
+export const DeferredRender: React.FC<DeferredRenderProps> = ({
+  children,
+  fallback,
+}) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return <>{mounted ? children : fallback || null}</>;
+};

--- a/packages/gamut-labs/src/experimental/index.ts
+++ b/packages/gamut-labs/src/experimental/index.ts
@@ -1,7 +1,3 @@
-export * from './Coachmark';
-export * from './HubCard';
-export * from './Popover';
-export * from './Text';
 export * from './AppHeader';
 export * from './AppHeader/AppHeaderElements/AppHeaderDropdown';
 export * from './AppHeader/AppHeaderElements/types';
@@ -11,5 +7,10 @@ export * from './AppHeaderMobile';
 export * from './AppHeaderMobile/AppHeaderLinkMobile';
 export * from './AppHeaderMobile/AppHeaderMainMenuMobile';
 export * from './AppHeaderMobile/AppHeaderSubMenuMobile';
+export * from './DeferredRender';
+export * from './Coachmark';
 export * from './GlobalHeader';
+export * from './HubCard';
+export * from './Popover';
+export * from './Text';
 export { AnonHeaderVariant } from './GlobalHeader/types';


### PR DESCRIPTION
### Overview
For: https://github.com/Codecademy/client-modules/pull/1583 and https://github.com/Codecademy/client-modules/pull/1582 
Ports `DeferredRender` from our [monolith](https://github.com/codecademy-engineering/Codecademy/blob/develop/webpack/assets/components/DeferredRender/index.tsx).


This is a simple component that just ensures that it's children don't render until this component is mounted.
This is mainly used to prevent a component from rendering server-side.

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
