### PR TITLE
fix(ToolTip): A11y Update

### DIFF
--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -73,7 +73,7 @@ const ToolTipContainer = styled.div<ToolTipContainerProps>`
   }
 
   ${TargetContainer}:hover + &,
-  ${TargetContainer}:focus + &,
+  ${TargetContainer}:focus-within + &,
   &:hover {
     opacity: 1;
     visibility: visible;
@@ -211,6 +211,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
         position={position}
         role="tooltip"
         mode={mode}
+        aria-live="polite"
       >
         <ToolTipBody mode={mode}>{children}</ToolTipBody>
       </ToolTipContainer>

--- a/packages/styleguide/stories/Atoms/ToolTip.stories.mdx
+++ b/packages/styleguide/stories/Atoms/ToolTip.stories.mdx
@@ -31,9 +31,6 @@ such as extra requirements for a form surfaced from an informative (i) icon.
 They dissapear when the focus or hover are no longer active.
 Great for surfacing additional information that may or may not be relevant _without_ cluttering the core interface.
 
-> Tooltips cannot contain clickable elements.
-> If your solution requires clickable elements, we suggest using a “Popover” instead.
-
 <Canvas>
   <Story name="ToolTip">
     {(args) => (


### PR DESCRIPTION
### Overview
Keyboard-only users were not able to activate the tooltip. Screenreader users did not have the tooltip narrated to them.

<!--- CHANGELOG-DESCRIPTION -->
Change `focus` to  `focus-within` & adds `aria-live: polite` for ToolTip contents.
Removes storybook comment on non-clickable elements allowed within.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: REACH-774
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change


### Testing
1. Turn on VoiceOver on Mac (or ChromeVox extension for Chrome/any alternative)
2. https://606dbfd55f00601ac8e7c74b--gamut-preview.netlify.app/storybook/?path=/docs/atoms-tooltip--tool-tip
3. Keyboard nav to over the tooltips


<img width="663" alt="Screen Shot 2021-04-07 at 10 29 24 AM" src="https://user-images.githubusercontent.com/17210163/113883449-28c2c200-978c-11eb-89c4-c97a135f6edc.png">
