### PR TITLE
fix(ToolTip): Revert A11y Update

### DIFF
--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -73,7 +73,7 @@ const ToolTipContainer = styled.div<ToolTipContainerProps>`
   }
 
   ${TargetContainer}:hover + &,
-  ${TargetContainer}:focus-within + &,
+  ${TargetContainer}:focus + &,
   &:hover {
     opacity: 1;
     visibility: visible;
@@ -211,7 +211,6 @@ export const ToolTip: React.FC<ToolTipProps> = ({
         position={position}
         role="tooltip"
         mode={mode}
-        aria-live="polite"
       >
         <ToolTipBody mode={mode}>{children}</ToolTipBody>
       </ToolTipContainer>

--- a/packages/styleguide/stories/Atoms/ToolTip.stories.mdx
+++ b/packages/styleguide/stories/Atoms/ToolTip.stories.mdx
@@ -31,6 +31,9 @@ such as extra requirements for a form surfaced from an informative (i) icon.
 They dissapear when the focus or hover are no longer active.
 Great for surfacing additional information that may or may not be relevant _without_ cluttering the core interface.
 
+> Tooltips cannot contain clickable elements.
+> If your solution requires clickable elements, we suggest using a “Popover” instead.
+
 <Canvas>
   <Story name="ToolTip">
     {(args) => (


### PR DESCRIPTION
This was my mistake in moving too fast, but I would love your input on the changes I just merged as part of
https://github.com/Codecademy/client-modules/pull/1604.

This PR reverts Codecademy/client-modules#1604 