### PR TITLE
fix: accessibility and key violations in GlobalFooter

### DIFF
--- a/packages/gamut-labs/src/experimental/GlobalFooter/FooterNavLinks/CompanyLinks.tsx
+++ b/packages/gamut-labs/src/experimental/GlobalFooter/FooterNavLinks/CompanyLinks.tsx
@@ -113,7 +113,9 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
             </Anchor>
           </FooterLinkItem>
         )}
-        <SocialMediaLinks />
+        <FooterLinkItem>
+          <SocialMediaLinks />
+        </FooterLinkItem>
       </FooterLinkItems>
     </Box>
   );

--- a/packages/gamut-labs/src/experimental/GlobalFooter/FooterNavLinks/SocialMediaLinks.tsx
+++ b/packages/gamut-labs/src/experimental/GlobalFooter/FooterNavLinks/SocialMediaLinks.tsx
@@ -37,12 +37,11 @@ export const SocialMediaLinks: React.FC = () => {
   return (
     <FooterLinkItems aria-label="Social Media">
       {media.map(({ label, url, icon: IconComponent }) => (
-        <Box as="li" display="inline-block">
+        <Box as="li" display="inline-block" key={label}>
           <Anchor
             aria-label={label}
             fontSize={20}
             href={url}
-            key={label}
             marginRight={8}
             rel="noopener noreferrer"
             target="_blank"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Fixes a misplaced `key` prop in `SocialMediaLinks` and correctly wraps its `ul` with an `li` inside the parent `ul`.

<!--- END-CHANGELOG-DESCRIPTION -->

Followup to https://github.com/Codecademy/client-modules/pull/1598 from https://app.circleci.com/pipelines/github/codecademy-engineering/Codecademy/81248/workflows/ee4c9bb0-bc7d-4731-aa5d-cb628eb927f2/jobs/1269958 CI failures (I'd made changes late in the PR that broke the monolith).