### PR TITLE
fix: used _, not xs, for lowest size in GlobalFooter

### DIFF
--- a/packages/gamut-labs/src/experimental/GlobalFooter/FooterNavLinks/index.tsx
+++ b/packages/gamut-labs/src/experimental/GlobalFooter/FooterNavLinks/index.tsx
@@ -20,10 +20,10 @@ export const FooterNavLinks: React.FC<FooterNavLinksProps> = ({
 }) => {
   return (
     <FooterNavLinksGrid>
-      <Column size={{ xs: 12, md: 6 }}>
+      <Column size={{ _: 12, md: 6 }}>
         <CompanyLinks onClick={onClick} userGeo={userGeo} />
       </Column>
-      <Column size={{ xs: 12, md: 6 }}>
+      <Column size={{ _: 12, md: 6 }}>
         <CatalogLinks onClick={onClick} />
       </Column>
     </FooterNavLinksGrid>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Fixes the smallest size resolution for the GlobalFooter being responsive.

<!--- END-CHANGELOG-DESCRIPTION -->

The bug only reproes on small mobile devices like Pixels. It doesn't repro if you just shrink the browser viewport, it actually has to emulate mobile device. 😫 

Shoutout to Amy from finance for forwarding a report to us! 🙌 

### PR Checklist

- [x] Related to designs:
- [x] Related to JIRA ticket: WEB-1411
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
