### PR TITLE
fix(PageSection): Adding margin-top to footer of PageSection

### DIFF
--- a/packages/gamut-labs/src/PageSection/index.tsx
+++ b/packages/gamut-labs/src/PageSection/index.tsx
@@ -67,7 +67,7 @@ export const PageSection: React.FC<PageSectionProps> = ({
   const maybeRenderSectionFooter = () => {
     if (!footerButton) return null;
     return (
-      <FlexBox justifyContent="flex-end">
+      <FlexBox justifyContent="flex-end" marginTop={16}>
         {renderSectionButton(footerButton)}
       </FlexBox>
     );


### PR DESCRIPTION
### Overview

This just adds a `marginTop={16}` to the footer of the `PageSection` component so it's not right up against the content of the section.

This is to support the following design for the Profiles page, but should be applicable to every usecase:
![image](https://user-images.githubusercontent.com/4298857/116298060-dbb18a80-a750-11eb-8183-27d0b152a78c.png)


### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
