### PR TITLE
chore: bump component-test-setup to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "babel-jest": "26.6.3",
     "babel-plugin-macros": "3.0.1",
     "babel-preset-codecademy": "2.3.0",
-    "component-test-setup": "^0.2.4",
+    "component-test-setup": "^0.2.5",
     "core-js": "3.7.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.5",

--- a/packages/gamut-kit/package.json
+++ b/packages/gamut-kit/package.json
@@ -16,7 +16,7 @@
     "@codecademy/gamut-system": "^0.7.0",
     "@codecademy/gamut-tests": "^2.3.20",
     "@codecademy/variance": "^0.10.1",
-    "component-test-setup": "^0.2.4"
+    "component-test-setup": "^0.2.5"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/gamut-styles/package.json
+++ b/packages/gamut-styles/package.json
@@ -30,7 +30,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@types/react-helmet": "^6.1.0",
-    "component-test-setup": "^0.2.4"
+    "component-test-setup": "^0.2.5"
   },
   "license": "MIT",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5941,10 +5941,10 @@ component-emitter@^1.2.1:
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-component-test-setup@*, component-test-setup@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.npmjs.org/component-test-setup/-/component-test-setup-0.2.4.tgz#a887541f9bea022bbca778fdd132293c425d0b04"
-  integrity sha512-+mLZBqg0SntjEhBXSIL7VB4JFzIjp7/MgYqWWa58ws2TDPUYmf8M/jDMJB9+zPwayw32QoMT6lH8/KyPYvIVug==
+component-test-setup@*, component-test-setup@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.npmjs.org/component-test-setup/-/component-test-setup-0.2.5.tgz#9c0a024304b44061ac1439438806beb31ff5dab5"
+  integrity sha512-1cSXa9b7r/OnzOgiGEax0AR2gKex6DCgFKbDHpL19wn8ku2TyjJusRsJGzmLubPFQRNLqeMgfA8Y9ZZQq3nxtQ==
 
 compute-scroll-into-view@^1.0.17:
   version "1.0.17"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Bumps `component-test-setup` to 0.2.5 in all packages.

<!--- END-CHANGELOG-DESCRIPTION -->

Brings in https://github.com/Codecademy/component-test-setup/pull/15 so I can use it in the monolith.

### PR Checklist

- ~[ ] Related to designs:~
- ~[ ] Related to JIRA ticket: ABC-123~
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
