### PR TITLE
fix: bump tracking package babel-preset-codecademy to latest

### DIFF
--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@babel/cli": "^7.13.10",
     "@types/jest": "^26.0.15",
-    "babel-preset-codecademy": "^2.3.0",
+    "babel-preset-codecademy": "^4.0.1",
     "jest-fetch-mock": "^3.0.3",
     "ts-jest": "^26.4.1",
     "typescript": "*"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

`@codecademy/tracking` was compiling with the 2.X line. We're up to 4.X.

<!--- END-CHANGELOG-DESCRIPTION -->

The current version of the package emits `import` statements for Babel runtime helpers that include the root path the build task is running from, including `/circleci/` and such. Oy vey.

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: WEB-1449
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
