### PR TITLE
fix: switch tracking 'verbose' type back to boolean

### DIFF
--- a/packages/tracking/src/events/track.ts
+++ b/packages/tracking/src/events/track.ts
@@ -8,7 +8,7 @@ import type {
 
 export type TrackerOptions = {
   apiBaseUrl: string;
-  verbose?: string;
+  verbose?: boolean;
 };
 
 export const createTracker = ({ apiBaseUrl, verbose }: TrackerOptions) => {


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

I'd switched `verbose` to an optional _string_ instead of _boolean_. Sigh.

<!--- END-CHANGELOG-DESCRIPTION -->
