### PR TITLE
chore: bump component-test-setup to v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "babel-jest": "26.6.3",
     "babel-plugin-macros": "3.0.1",
     "babel-preset-codecademy": "2.3.0",
-    "component-test-setup": "^0.2.5",
+    "component-test-setup": "^0.3.1",
     "core-js": "3.7.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.5",

--- a/packages/gamut-kit/package.json
+++ b/packages/gamut-kit/package.json
@@ -16,7 +16,7 @@
     "@codecademy/gamut-system": "^0.7.1",
     "@codecademy/gamut-tests": "^2.3.24",
     "@codecademy/variance": "^0.11.1",
-    "component-test-setup": "^0.2.5"
+    "component-test-setup": "^0.3.1"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/gamut-styles/package.json
+++ b/packages/gamut-styles/package.json
@@ -30,7 +30,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@types/react-helmet": "^6.1.0",
-    "component-test-setup": "^0.2.5"
+    "component-test-setup": "^0.3.1"
   },
   "license": "MIT",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6027,10 +6027,10 @@ component-emitter@^1.2.1:
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-component-test-setup@*, component-test-setup@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.npmjs.org/component-test-setup/-/component-test-setup-0.2.5.tgz#9c0a024304b44061ac1439438806beb31ff5dab5"
-  integrity sha512-1cSXa9b7r/OnzOgiGEax0AR2gKex6DCgFKbDHpL19wn8ku2TyjJusRsJGzmLubPFQRNLqeMgfA8Y9ZZQq3nxtQ==
+component-test-setup@*, component-test-setup@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/component-test-setup/-/component-test-setup-0.3.1.tgz#b8bacdb0eaac1e1e5974ae29dbe57f2f063144db"
+  integrity sha512-+gSBZBBuT7O7rQiMzizrHqTF1ttW87hWdJwo1fVibHZGC3rKCCBETE+pIfzlPj8yrxe83UC7UVMP+Wz8Iiee6Q==
 
 compute-scroll-into-view@^1.0.17:
   version "1.0.17"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Bumps `component-test-setup` to its latest version, which includes couple of bugfixes.

<!--- END-CHANGELOG-DESCRIPTION -->
