### PR TITLE
fix: allow no user for tracking integrations

### DIFF
--- a/packages/tracking/src/integrations/index.ts
+++ b/packages/tracking/src/integrations/index.ts
@@ -20,7 +20,7 @@ export type TrackingIntegrationsSettings = {
   /**
    * User details to identify in Segment.
    */
-  user: UserIntegrationSummary;
+  user?: UserIntegrationSummary;
 
   /**
    * Segment write key.


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Anonymous users aren't identified in tracking and it shouldn't require a `user` for them.

<!--- END-CHANGELOG-DESCRIPTION -->

The internal type `AnalyticsLoadOptions` has `user` as optional already -- just the externally facing `TrackingIntegrationsSettings` didn't.

### PR Checklist

- ~[ ] Related to designs:~
- [ ] Related to JIRA ticket: WEB-1433
- [x] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
