### PR TITLE
fix: disable react/jsx-one-expression-per-line rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -120,6 +120,7 @@ module.exports = {
     'prefer-template': 'off',
     'react/jsx-filename-extension': 'off',
     'react/jsx-no-bind': 'off',
+    'react/jsx-one-expression-per-line': 'off',
     'react/jsx-pascal-case': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/prefer-es6-class': 'off',

--- a/packages/gamut-labs/src/ErrorContents/__tests__/ErrorContents-test.tsx
+++ b/packages/gamut-labs/src/ErrorContents/__tests__/ErrorContents-test.tsx
@@ -1,0 +1,21 @@
+import { setupRtl } from '@codecademy/gamut-tests';
+
+import { ErrorContents } from '..';
+
+const renderView = setupRtl(ErrorContents);
+
+describe('ErrorContents', () => {
+  it('does not show support information when none is provided', () => {
+    const { view } = renderView();
+
+    expect(view.queryByRole('group')).toBeNull();
+  });
+
+  it('shows support information when provided', () => {
+    const { view } = renderView({
+      supportInformation: [['User ID', 'abc123']],
+    });
+
+    view.getByRole('group');
+  });
+});

--- a/packages/gamut-labs/src/ErrorContents/index.tsx
+++ b/packages/gamut-labs/src/ErrorContents/index.tsx
@@ -1,0 +1,44 @@
+import { Anchor, Box, Text } from '@codecademy/gamut';
+import React from 'react';
+
+export type ErrorContentsProps = {
+  /**
+   * Any debug info to display, such as ["User ID", <user-id>].
+   */
+  supportInformation?: [string, string][];
+};
+
+export const ErrorContents: React.FC<ErrorContentsProps> = ({
+  supportInformation,
+}) => (
+  <Box maxWidth="40rem" my={96} mx="auto" as="main">
+    <Text as="h1" fontSize={44}>
+      Something has gone wrong
+    </Text>
+    <Text as="p" my={16}>
+      We&apos;re sorry, and we are working our best to fix this. In the
+      meantime, have you tried the following?
+    </Text>
+    <Box as="ul">
+      <li>Refreshing this page.</li>
+      <li>Clearing your browser cache.</li>
+    </Box>
+    <Text as="p">
+      If that doesn&apos;t help, please let us know on our{' '}
+      <Anchor href="https://help.codecademy.com/hc/en-us">Help Center</Anchor>!
+    </Text>
+
+    {supportInformation && (
+      <Box as="details" fontSize={16} textColor="gray-700">
+        <Box as="summary" mt={48} mb={8}>
+          Support information
+        </Box>
+        {supportInformation.map(([key, value]) => (
+          <Text as="code" display="block" fontSize="small" key={key}>
+            {key}: {value}
+          </Text>
+        ))}
+      </Box>
+    )}
+  </Box>
+);

--- a/packages/gamut-labs/src/index.ts
+++ b/packages/gamut-labs/src/index.ts
@@ -5,6 +5,7 @@ export * from './CurriculumCard';
 export * from './Byline';
 export * from './EditorialImage';
 export * from './EditorialQuote';
+export * from './ErrorContents';
 export * from './Header/HeaderContainer';
 export * from './Header/HeaderTab';
 export * from './Loading';

--- a/packages/styleguide/stories/Molecules/ErrorContents.stories.mdx
+++ b/packages/styleguide/stories/Molecules/ErrorContents.stories.mdx
@@ -1,0 +1,39 @@
+import { ErrorContents } from '@codecademy/gamut-labs/src';
+import title from '@codecademy/macros/lib/title.macro';
+import { PropsTable } from '@codecademy/storybook-addon-variance';
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+<Meta
+  title={title}
+  component={ErrorContents}
+  parameters={{
+    subtitle: 'Generic "something has gone wrong" contents for an error page.',
+    source: 'gamut-labs',
+    status: 'updating',
+  }}
+/>
+
+<Canvas>
+  <Story name="ErrorContents">{(args) => <ErrorContents {...args} />}</Story>
+</Canvas>
+
+<PropsTable story="ErrorContents" />
+
+## Support Information
+
+Optional `supportInformation` debug values may be provided to help with customer support debugging.
+They will be shown in a details pane.
+
+<Canvas>
+  <Story name="SupportInformation">
+    {(args) => (
+      <ErrorContents
+        {...args}
+        supportInformation={[
+          ['User ID', 'abc123'],
+          ['Timestamp', '123456789'],
+        ]}
+      />
+    )}
+  </Story>
+</Canvas>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Disables an annoying rule that conflicts with Prettier.

<!--- END-CHANGELOG-DESCRIPTION -->