### PR TITLE
fix: use a sticky Box for GlobalPage's header

### DIFF
--- a/packages/gamut-labs/src/GlobalPage/index.tsx
+++ b/packages/gamut-labs/src/GlobalPage/index.tsx
@@ -1,5 +1,6 @@
 import {
   AppWrapper,
+  Box,
   PageWrapper,
   SkipToContent,
   SkipToContentTarget,
@@ -47,7 +48,9 @@ export const GlobalPage: React.FC<GlobalPageProps> = ({
   return (
     <PageWrapper bg={backgroundColor}>
       <SkipToContent contentId={skipToContentId || defaultSkipToContentId} />
-      <GlobalHeader {...header} />
+      <Box as="header" position="sticky" top={0} zIndex={2}>
+        <GlobalHeader {...header} />
+      </Box>
       {!skipToContentId && <SkipToContentTarget id={defaultSkipToContentId} />}
       <AppWrapper as={contentAs}>{children}</AppWrapper>
       <GlobalFooter {...footer} />


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

I think this will fix it to be nice and sticky in portal-app? It'll at least add a missing `header` role.

<!--- END-CHANGELOG-DESCRIPTION -->

Required for https://github.com/codecademy-engineering/portal-app/pull/31 to pass, I think.

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: WEB-1436
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
