### PR TITLE
feat(modes): Add `createModes` for inline color mode customization 

### DIFF
--- a/packages/gamut-styles/src/variance/props.ts
+++ b/packages/gamut-styles/src/variance/props.ts
@@ -19,6 +19,7 @@ export const border = variance.create(PROPERTIES.border);
 
 export const css = variance.createCss(PROPERTIES.all);
 export const variant = variance.createVariant(PROPERTIES.all);
+export const modes = variance.createModes(PROPERTIES.all);
 
 /** Sub Groups */
 

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -2,9 +2,11 @@ import {
   fontSmoothPixel,
   lineHeight,
   pxRem,
+  system,
   timing,
   variant,
 } from '@codecademy/gamut-styles';
+import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
 
@@ -34,12 +36,17 @@ const TargetContainer = styled.div`
   padding: 0;
 `;
 
-type ToolTipContainerProps = {
+type ToolTipContainerProps = StyleProps<typeof modes> & {
   alignment: ToolTipAlignment;
-  mode: VisualTheme;
 };
 
+const modes = system.modes({
+  light: { '> div, &:before': { textColor: 'black', bg: 'background' } },
+  dark: { '> div, &:before': { textColor: 'beige', bg: 'black' } },
+});
+
 const ToolTipContainer = styled.div<ToolTipContainerProps>`
+  ${modes}
   ${fontSmoothPixel}
   display: flex;
   opacity: 0;
@@ -49,8 +56,6 @@ const ToolTipContainer = styled.div<ToolTipContainerProps>`
   width: 16rem;
   visibility: hidden;
 
-  // Both before and after psuedo-elements are used because ::after's background should go over the container's
-  // and ::before's box-shadow should be behind the container itself
   &::after,
   &::before {
     content: '';
@@ -59,16 +64,6 @@ const ToolTipContainer = styled.div<ToolTipContainerProps>`
     position: absolute;
     transform: rotate(45deg);
     width: ${arrowHeight};
-  }
-
-  &::before {
-    ${variant({
-      prop: 'mode',
-      variants: {
-        dark: { backgroundColor: 'black' },
-        light: { backgroundColor: 'white' },
-      },
-    })}
   }
 
   ${TargetContainer}:hover + &,
@@ -143,19 +138,11 @@ const ToolTipContainer = styled.div<ToolTipContainerProps>`
     `}
 `;
 
-const ToolTipBody = styled.div<{ mode: VisualTheme }>`
+const ToolTipBody = styled.div`
   display: inline-block;
   font-size: ${pxRem(14)};
   line-height: ${lineHeight.base};
   padding: 0.6rem 0.75rem;
-
-  ${variant({
-    prop: 'mode',
-    variants: {
-      dark: { backgroundColor: 'black', textColor: 'white' },
-      light: { backgroundColor: 'white', textColor: 'black' },
-    },
-  })}
 `;
 
 export type ToolTipProps = {
@@ -197,7 +184,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
   containerClassName,
   focusable,
   id,
-  mode = 'light',
+  mode,
   target,
 }) => {
   return (
@@ -219,7 +206,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
         mode={mode}
         aria-live="polite"
       >
-        <ToolTipBody mode={mode}>{children}</ToolTipBody>
+        <ToolTipBody>{children}</ToolTipBody>
       </ToolTipContainer>
     </TooltipWrapper>
   );

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -56,6 +56,11 @@ const ToolTipContainer = styled.div<ToolTipContainerProps>`
   width: 16rem;
   visibility: hidden;
 
+  /**
+   Both before and after psuedo-elements are used because ::after's background should go over the container's
+   and ::before's box-shadow should be behind the container itself
+  */
+
   &::after,
   &::before {
     content: '';

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -4,7 +4,6 @@ import {
   pxRem,
   system,
   timing,
-  variant,
 } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';

--- a/packages/variance/integration/__fixtures__/theme.ts
+++ b/packages/variance/integration/__fixtures__/theme.ts
@@ -19,4 +19,7 @@ export const { theme } = createTheme({
     48: '3rem',
     64: '4rem',
   },
-} as const).build();
+} as const)
+  .addColors({ black: '#000000', white: '#ffffff' })
+  .addColorModes('light', { light: { text: 'black' }, dark: { text: 'white' } })
+  .build();

--- a/packages/variance/integration/__tests__/variance-test.ts
+++ b/packages/variance/integration/__tests__/variance-test.ts
@@ -539,3 +539,30 @@ describe('variants', () => {
     });
   });
 });
+
+describe('modes', () => {
+  const modes = variance.createModes({
+    color: { property: 'color', scale: 'colors' },
+  });
+  const testMode = modes({
+    light: { color: 'black' },
+    dark: { color: 'white' },
+  });
+
+  it.each([
+    ['active mode', { theme }, { color: theme.colors.black }],
+    [
+      'active mode',
+      {
+        theme: {
+          ...theme,
+          colorModes: { ...theme.colorModes, active: 'dark' },
+        },
+      },
+      { color: theme.colors.white },
+    ],
+    ['with prop', { mode: 'dark', theme }, { color: theme.colors.white }],
+  ])('renders styles for %s', (name, props: any, result: object) => {
+    expect(testMode(props)).toEqual(result);
+  });
+});

--- a/packages/variance/src/core.ts
+++ b/packages/variance/src/core.ts
@@ -222,7 +222,6 @@ export const variance = {
     const css: CSS<P> = this.createCss(config);
     return (modes) => {
       type Modes = keyof typeof modes;
-      console.log(modes);
       const modeFns = {} as Record<Modes, (props: ThemeProps) => CSSObject>;
 
       Object.keys(modes).forEach((key) => {

--- a/packages/variance/src/core.ts
+++ b/packages/variance/src/core.ts
@@ -5,6 +5,7 @@ import {
   AbstractPropTransformer,
   Compose,
   CSS,
+  Modes,
   Parser,
   Prop,
   PropTransformer,
@@ -211,6 +212,31 @@ export const variance = {
           baseFn(props),
           variantFns?.[selected as Keys]?.(props)
         );
+      };
+    };
+  },
+  createModes<
+    Config extends Record<string, Prop>,
+    P extends Parser<TransformerMap<Config>>
+  >(config: Config): Modes<P> {
+    const css: CSS<P> = this.createCss(config);
+    return (modes) => {
+      type Modes = keyof typeof modes;
+      console.log(modes);
+      const modeFns = {} as Record<Modes, (props: ThemeProps) => CSSObject>;
+
+      Object.keys(modes).forEach((key) => {
+        const modeKeys = key as Modes;
+        const cssProps = modes[modeKeys];
+        modeFns[modeKeys] = css(cssProps as any);
+      });
+
+      return (props) => {
+        const { theme, mode = get(theme, 'colorModes.active') } = props;
+        const styles = {};
+        if (!mode) return styles;
+
+        return merge(styles, modeFns?.[mode as Modes]?.(props));
       };
     };
   },

--- a/packages/variance/src/types/config.ts
+++ b/packages/variance/src/types/config.ts
@@ -102,8 +102,8 @@ export interface Variant<P extends AbstractParser> {
 
 export interface Modes<P extends AbstractParser> {
   <
-    X extends keyof Theme,
-    Modes extends 'colorModes' extends X
+    ThemeKeys extends keyof Theme,
+    Modes extends 'colorModes' extends ThemeKeys
       ? 'modes' extends keyof Theme['colorModes']
         ? keyof Theme['colorModes']['modes']
         : never
@@ -111,7 +111,7 @@ export interface Modes<P extends AbstractParser> {
     Base extends AbstractProps
   >(
     options: Record<Modes, SelectorProps<Base, SystemProps<P>>>
-  ): (props: Record<'mode', Modes> & ThemeProps) => CSSObject;
+  ): (props: VariantProps<'mode', Modes> & ThemeProps) => CSSObject;
 }
 
 export interface CSS<P extends AbstractParser> {

--- a/packages/variance/src/types/config.ts
+++ b/packages/variance/src/types/config.ts
@@ -100,6 +100,20 @@ export interface Variant<P extends AbstractParser> {
   }): (props: VariantProps<PropKey, Keys | false> & ThemeProps) => CSSObject;
 }
 
+export interface Modes<P extends AbstractParser> {
+  <
+    X extends keyof Theme,
+    Modes extends 'colorModes' extends X
+      ? 'modes' extends keyof Theme['colorModes']
+        ? keyof Theme['colorModes']['modes']
+        : never
+      : never,
+    Base extends AbstractProps
+  >(
+    options: Record<Modes, SelectorProps<Base, SystemProps<P>>>
+  ): (props: Record<'mode', Modes> & ThemeProps) => CSSObject;
+}
+
 export interface CSS<P extends AbstractParser> {
   <Props extends AbstractProps>(config: SelectorProps<Props, SystemProps<P>>): (
     props: ThemeProps


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
#### Changes
Adds a `createModes` method in variance to handle custom styles that are not named in the core color mode config.  This has the same API as the original `variant()` API in gamut system but is tied to `mode` specifically.  Further it has custom behavior in that it reads the mutable value of `colorModes.active` from theme as the default mode if no `mode` prop is passed.

The main use case currently is to act as a bridge till the color echosystem is mature enough to handle this complexity gracefully. 


```tsx
const Tooltip = styled.div(modes({ light: { textColor: 'beige' , bg: 'black' }, dark: { textColor: 'black', bg: 'white' }))
```

In context
```tsx
<ColorMode mode="dark">
   <ToolTip /> // dark
   <ToolTip mode="light" /> // light
</ColorMode>
```
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
