### PR TITLE
feat(Spinner): Adding dataTestId to Spinner

### DIFF
--- a/packages/gamut/src/Spinner/index.tsx
+++ b/packages/gamut/src/Spinner/index.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, SVGProps } from 'react';
 
 export type SpinnerProps = SVGProps<SVGSVGElement> & {
   size?: number | string;
+  dataTestId?: string;
 };
 
 const defaultProps: SpinnerProps = {
@@ -10,10 +11,17 @@ const defaultProps: SpinnerProps = {
 
 export const Spinner: FunctionComponent<SpinnerProps> = ({
   size,
+  dataTestId = 'spinner',
   ...props
 }) => {
   return (
-    <svg viewBox="0 0 1000 1000" height={size} width={size} {...props}>
+    <svg
+      viewBox="0 0 1000 1000"
+      height={size}
+      width={size}
+      data-testid={dataTestId}
+      {...props}
+    >
       <circle fill="currentColor" cx="937.5" cy="500" r="62.5" />
       <path
         fill="currentColor"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

It's useful to be able to test whether or not a Spinner is on the page to assert if we are correctly in a loading state.

I've included the ability to pass a specific data-testid value to the spinner in case we have integration tests that have multiple spinners on the page.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
