### PR TITLE
fix(GlobalFooter): Update full catalog link

### DIFF
--- a/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CatalogLinks.tsx
+++ b/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CatalogLinks.tsx
@@ -113,7 +113,7 @@ export const CatalogLinks: React.FC<CatalogLinksProps> = ({ onClick }) => {
         <CatalogFooterLinkItem aria-hidden>—</CatalogFooterLinkItem>
         <CatalogFooterLinkItem>
           <Anchor
-            href="/catalog/subject/all"
+            href="/catalog/all"
             onClick={(event) => onClick({ event, target: 'fullCatalog' })}
             variant="interface"
           >


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Update full catalog link in the footer from `/catalog/subject/all` to `/catalog/all`. The former redirects to the latter, but we should just be using the latter.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
