### PR TITLE
feat: disabled consistent-return ESLint rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -92,6 +92,7 @@ module.exports = {
     'arrow-body-style': 'off',
     camelcase: 'off',
     'class-methods-use-this': 'off',
+    'consistent-return': 'off',
     'default-case': 'off',
     'func-names': 'off',
     'global-require': 'off',


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Disables the `consistent-return` rule in our ESLint configuration because it's annoying with exhaustive switch statements.

<!--- END-CHANGELOG-DESCRIPTION -->

TypeScript already validates strict function return types for us with `strictNullChecks`.
