### PR TITLE
fix: add shouldForwardProp to DropdownButton

### DIFF
--- a/packages/gamut-labs/src/DropdownButton/index.tsx
+++ b/packages/gamut-labs/src/DropdownButton/index.tsx
@@ -1,13 +1,15 @@
 import { Box, FillButton, StrokeButton } from '@codecademy/gamut';
 import { ArrowChevronDownFilledIcon } from '@codecademy/gamut-icons';
-import { pxRem } from '@codecademy/gamut-styles';
+import { pxRem, shouldForwardProp } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
 import React, { useRef, useState } from 'react';
 
 import { Popover } from '../Popover';
 import { DropdownItem, DropdownList } from './DropdownList';
 
-const DownArrow = styled(ArrowChevronDownFilledIcon)<{ isOpen?: boolean }>`
+const DownArrow = styled(ArrowChevronDownFilledIcon, { shouldForwardProp })<{
+  isOpen?: boolean;
+}>`
   margin-left: ${pxRem(8)};
   transition: transform 0.35s ease-out;
   ${({ isOpen }) => isOpen && 'transform: rotate(-180deg)'};


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Adds a `shouldForwardProp` to `DropdownButton` so React doesn't forward `isOpen`.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- ~[ ] Related to designs:~
- ~[ ] Related to JIRA ticket: ABC-123~
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
