### PR TITLE
fix: GridForm Sweet Container - add missing label

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSweetContainerInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSweetContainerInput/index.tsx
@@ -25,7 +25,8 @@ export const GridFormSweetContainerInput: React.FC<GridFormSweetContainerInputPr
       top="100vh"
       width="0"
     >
-      <Input name={name} ref={register()} type="checkbox" label={label} />
+      <label htmlFor={name}>{label}</label>
+      <Input name={name} ref={register()} type="checkbox" id={name} />
     </Box>
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSweetContainerInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSweetContainerInput/index.tsx
@@ -8,11 +8,13 @@ import { GridFormSweetContainerField } from '../../types';
 export type GridFormSweetContainerInputProps = {
   field: GridFormSweetContainerField;
   register: UseFormMethods['register'];
+  label: string;
 };
 
 export const GridFormSweetContainerInput: React.FC<GridFormSweetContainerInputProps> = ({
   register,
   field: { name },
+  label,
 }) => {
   return (
     <Box
@@ -23,7 +25,7 @@ export const GridFormSweetContainerInput: React.FC<GridFormSweetContainerInputPr
       top="100vh"
       width="0"
     >
-      <Input name={name} ref={register()} type="checkbox" />
+      <Input name={name} ref={register()} type="checkbox" label={label} />
     </Box>
   );
 };

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -102,7 +102,11 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
 
       case 'sweet-container':
         return (
-          <GridFormSweetContainerInput register={register} field={field} />
+          <GridFormSweetContainerInput
+            register={register}
+            field={field}
+            label={field.label}
+          />
         );
 
       default:

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -108,7 +108,7 @@ export type GridFormHiddenField = HiddenField & {
 };
 
 export type GridFormSweetContainerField = HiddenField & {
-  label: React.ReactNode;
+  label: string;
   type: 'sweet-container';
 };
 


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
The sweet container/honeypot was not applying the label, so accessibility was getting axed.  This fixes that.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: GROW-2381
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
