### PR TITLE
feat(GridFormRadioGroupInput): Can use a ReactNode for labels

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
@@ -22,6 +22,31 @@ describe('GridFormRadioGroupInput', () => {
     });
   });
 
+  it('accepts JSX for the group label', () => {
+    const radioButtons = renderGridFormRadioGroupInput({
+      label: (
+        <div>
+          <span>Test Label</span>
+        </div>
+      ),
+    });
+
+    console.log(radioButtons.debug());
+
+    expect(radioButtons.text()).toContain('Test Label');
+  });
+
+  describe('when label is passed as a ReactNode', () => {
+    it('renders an input with the same id', () => {
+      const radioButtons = renderGridFormRadioGroupInput({
+        id: 'mycoolid',
+        name: 'name',
+      });
+
+      expect(radioButtons.find('input#name-0-mycoolid').length).toBe(1);
+    });
+  });
+
   describe('Radio', () => {
     it('accepts JSX for the label', () => {
       const radioButtons = renderGridFormRadioGroupInput({

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
@@ -23,6 +23,18 @@ describe('GridFormRadioGroupInput', () => {
     });
   });
 
+  describe('Radio', () => {
+    it('accepts JSX for the label', () => {
+      const radioButtons = renderGridFormRadioGroupInput({
+        id: 'id',
+        options: [{ label: <img alt="" src="" />, value: '' }],
+        name: 'name',
+      });
+
+      expect(radioButtons.find('img').length).toBe(1);
+    });
+  });
+
   describe('aria-label', () => {
     it('aria-label is set to the label by default', () => {
       const radioButtons = renderGridFormRadioGroupInput({
@@ -54,29 +66,6 @@ describe('GridFormRadioGroupInput', () => {
       expect(radioButtons.find(RadioGroup).props()['aria-label']).toBe(
         'Overridden Test Label'
       );
-    });
-  });
-
-  describe('when label is passed as a ReactNode', () => {
-    it('renders an input with the same id', () => {
-      const radioButtons = renderGridFormRadioGroupInput({
-        id: 'mycoolid',
-        name: 'name',
-      });
-
-      expect(radioButtons.find('input#name-0-mycoolid').length).toBe(1);
-    });
-  });
-
-  describe('Radio', () => {
-    it('accepts JSX for the label', () => {
-      const radioButtons = renderGridFormRadioGroupInput({
-        id: 'id',
-        options: [{ label: <img alt="" src="" />, value: '' }],
-        name: 'name',
-      });
-
-      expect(radioButtons.find('img').length).toBe(1);
     });
   });
 });

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/__tests__/GridFormRadioGroupInput-test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { RadioGroup } from '../../../..';
 import { renderGridFormRadioGroupInput } from '../../__fixtures__/renderers';
 
 describe('GridFormRadioGroupInput', () => {
@@ -22,18 +23,38 @@ describe('GridFormRadioGroupInput', () => {
     });
   });
 
-  it('accepts JSX for the group label', () => {
-    const radioButtons = renderGridFormRadioGroupInput({
-      label: (
-        <div>
-          <span>Test Label</span>
-        </div>
-      ),
+  describe('aria-label', () => {
+    it('aria-label is set to the label by default', () => {
+      const radioButtons = renderGridFormRadioGroupInput({
+        label: 'Test Label',
+      });
+
+      expect(radioButtons.find(RadioGroup).props()['aria-label']).toBe(
+        'Test Label'
+      );
     });
 
-    console.log(radioButtons.debug());
+    it('aria-label is overridden by the ariaLabel prop', () => {
+      const radioButtons = renderGridFormRadioGroupInput({
+        label: 'Test Label',
+        ariaLabel: 'Overridden Test Label',
+      });
 
-    expect(radioButtons.text()).toContain('Test Label');
+      expect(radioButtons.find(RadioGroup).props()['aria-label']).toBe(
+        'Overridden Test Label'
+      );
+    });
+
+    it('aria-label is used when JSX is passed to the label', () => {
+      const radioButtons = renderGridFormRadioGroupInput({
+        label: <img alt="" src="" />,
+        ariaLabel: 'Overridden Test Label',
+      });
+
+      expect(radioButtons.find(RadioGroup).props()['aria-label']).toBe(
+        'Overridden Test Label'
+      );
+    });
   });
 
   describe('when label is passed as a ReactNode', () => {

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
@@ -1,3 +1,4 @@
+import { isString } from 'lodash';
 import React from 'react';
 import { UseFormMethods } from 'react-hook-form';
 
@@ -19,13 +20,16 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
   setValue,
   showRequired,
 }) => {
+  const ariaLabel: string | undefined =
+    field.ariaLabel ?? (isString(field.label) ? field.label : undefined);
+
   return (
     <RadioGroup
       className={className}
       htmlForPrefix={field.name}
       name={field.name}
       role="radiogroup"
-      aria-label={field.label}
+      aria-label={ariaLabel}
       aria-required={showRequired}
       onChange={(event) => {
         const { value } = event.target;

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -85,10 +85,11 @@ export type GridFormRadioOption = {
 };
 
 export type GridFormRadioGroupField = BaseFormField<string> & {
-  label: string;
+  label: ReactNode | string; // If this is a string, it will also be used as the aria-label.
   options: GridFormRadioOption[];
   validation?: ValidationRules;
   type: 'radio-group';
+  ariaLabel?: string;
 };
 
 export type GridFormSelectField = BaseFormField<string> & {


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Currently the label for the GridFormRadioGroupInput has to be a string. We want to let it also be a ReactNode for more flexible labels. However, the label does double duty an aria-label right now so we also need a way to provide the aria-label in this new world of ReactNode labels. 

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/PG0kVYDIuLk3hE566beZUV/Profiles-Concept-Refinement?node-id=998%3A2640
- [x] Related to JIRA ticket: https://codecademy.atlassian.net/browse/EGG-1404
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
