### PR TITLE
fix: Google and App store 

### DIFF
--- a/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CompanyLinks.tsx
+++ b/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CompanyLinks.tsx
@@ -181,6 +181,7 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
             href="https://itunes.apple.com/us/app/codecademy-go/id1376029326"
             onClick={(event) => onClick({ event, target: 'apple_store' })}
             target="_blank"
+            rel="noopener"
           >
             <img
               alt="Download on the App Store"
@@ -195,6 +196,7 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
             href="https://play.google.com/store/apps/details?id=com.ryzac.codecademygo"
             onClick={(event) => onClick({ event, target: 'google_play' })}
             target="_blank"
+            rel="noopener"
           >
             <img
               alt="Get it on Google Play"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Paired with Josh to run a performance audit on portal app. One of the findings was missing in the lighthouse report was, missing `rel="noopener"`/`rel="noreferrer"` in the footer links for Google and App store links.

<img width="815" alt="Screen Shot 2021-06-07 at 2 38 03 PM" src="https://user-images.githubusercontent.com/47792836/121071458-f8080480-c79d-11eb-815b-8560b548ca04.png">

This PR aims to add `rel="noopener"` to the affected components.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs:
- [x] Related to JIRA ticket: [WEB-1450](https://codecademy.atlassian.net/browse/WEB-1450)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->

