### PR TITLE
fix(AvatarChooser): Add alt text to Avatar image

### DIFF
--- a/packages/gamut-labs/src/AvatarChooser/__tests__/AvatarChooser-test.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/__tests__/AvatarChooser-test.tsx
@@ -26,6 +26,12 @@ describe('AvatarChooser', () => {
     expect(img.src).toMatch(testImageSource);
   });
 
+  it('Renders image alt text', () => {
+    const { view } = renderView();
+    const img = view.getByRole('img') as HTMLImageElement;
+    expect(img.alt).toBe('Avatar Photo');
+  });
+
   it('Renders error', () => {
     const error = 'This is a test error!';
     const { view } = renderView({ error });

--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -96,11 +96,7 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
       width="fit-content"
       maxWidth={pxRem(120)}
     >
-      <StyledAvatar
-        src={imageSrc}
-        disableDropshadow
-        aria-labelledby="Avatar Photo"
-      />
+      <StyledAvatar src={imageSrc} disableDropshadow alt="Avatar Photo" />
       <ChoosePhotoLabel ref={choosePhotoLabelRef} htmlFor="avatar-chooser">
         <ChoosePhotoSpan
           role="button"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Was incorrectly using `aria-labelledby` instead of `alt` for the `Avatar` component.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
