### PR TITLE
fix: revert "fix: clear errors on input change in GridForm"

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCheckboxInput/index.tsx
@@ -6,7 +6,6 @@ import { GridFormCheckboxField } from '../../types';
 
 export type GridFormCheckboxInputProps = {
   className?: string;
-  clearErrors: UseFormMethods['clearErrors'];
   field: GridFormCheckboxField;
   register: UseFormMethods['register'];
   showRequired?: boolean;
@@ -14,7 +13,6 @@ export type GridFormCheckboxInputProps = {
 
 export const GridFormCheckboxInput: React.FC<GridFormCheckboxInputProps> = ({
   className,
-  clearErrors,
   field,
   register,
   showRequired,
@@ -26,10 +24,7 @@ export const GridFormCheckboxInput: React.FC<GridFormCheckboxInputProps> = ({
       disabled={field.disabled}
       htmlFor={field.name}
       name={field.name}
-      onChange={(event) => {
-        clearErrors();
-        field.onUpdate?.(event.target.checked);
-      }}
+      onChange={(event) => field.onUpdate?.(event.target.checked)}
       label={field.description}
       multiline={field.multiline}
       ref={register(field.validation)}

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormCustomInput/index.tsx
@@ -5,7 +5,6 @@ import { GridFormCustomField, GridFormCustomGroupField } from '../../types';
 
 export type GridFormCustomInputProps = {
   className?: string;
-  clearErrors: UseFormMethods['clearErrors'];
   error?: string;
   field: GridFormCustomField | GridFormCustomGroupField;
   register: UseFormMethods['register'];
@@ -14,7 +13,6 @@ export type GridFormCustomInputProps = {
 
 export const GridFormCustomInput: React.FC<GridFormCustomInputProps> = ({
   className,
-  clearErrors,
   error,
   field,
   register,
@@ -24,7 +22,6 @@ export const GridFormCustomInput: React.FC<GridFormCustomInputProps> = ({
     <>
       {field.render({
         className,
-        clearErrors,
         error,
         field,
         register,

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormFileInput/index.tsx
@@ -6,7 +6,6 @@ import { GridFormFileField } from '../../types';
 
 export type GridFormFileInputProps = {
   className?: string;
-  clearErrors: UseFormMethods['clearErrors'];
   error?: boolean;
   showRequired?: boolean;
   field: Omit<GridFormFileField, 'label'>;
@@ -15,7 +14,6 @@ export type GridFormFileInputProps = {
 
 export const GridFormFileInput: React.FC<GridFormFileInputProps> = ({
   className,
-  clearErrors,
   error,
   field,
   register,
@@ -28,10 +26,7 @@ export const GridFormFileInput: React.FC<GridFormFileInputProps> = ({
       error={error}
       htmlFor={field.name}
       name={field.name}
-      onChange={(event) => {
-        clearErrors();
-        field.onUpdate?.(event.target.files!);
-      }}
+      onChange={(event) => field.onUpdate?.(event.target.files!)}
       ref={register(field.validation)}
       type="file"
       id={field.id}

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormRadioGroupInput/index.tsx
@@ -7,7 +7,6 @@ import { GridFormRadioGroupField } from '../../types';
 
 export type GridFormRadioGroupInputProps = {
   className?: string;
-  clearErrors: UseFormMethods['clearErrors'];
   field: GridFormRadioGroupField;
   register: UseFormMethods['register'];
   setValue: (name: string, value: string) => void;
@@ -16,7 +15,6 @@ export type GridFormRadioGroupInputProps = {
 
 export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = ({
   className,
-  clearErrors,
   field,
   register,
   setValue,
@@ -34,8 +32,6 @@ export const GridFormRadioGroupInput: React.FC<GridFormRadioGroupInputProps> = (
       aria-label={ariaLabel}
       aria-required={showRequired}
       onChange={(event) => {
-        clearErrors(field.name);
-
         const { value } = event.target;
         setValue(field.name, value);
         field.onUpdate?.(value);

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormSelectInput/index.tsx
@@ -6,7 +6,6 @@ import { GridFormSelectField } from '../../types';
 
 export type GridFormSelectInputProps = {
   className?: string;
-  clearErrors: UseFormMethods['clearErrors'];
   error?: boolean;
   showRequired?: boolean;
   field: Omit<GridFormSelectField, 'label'>;
@@ -15,7 +14,6 @@ export type GridFormSelectInputProps = {
 
 export const GridFormSelectInput: React.FC<GridFormSelectInputProps> = ({
   className,
-  clearErrors,
   error,
   field,
   register,
@@ -29,10 +27,7 @@ export const GridFormSelectInput: React.FC<GridFormSelectInputProps> = ({
       error={error}
       htmlFor={field.name}
       name={field.name}
-      onChange={(event) => {
-        clearErrors();
-        field.onUpdate?.(event.target.value);
-      }}
+      onChange={(event) => field.onUpdate?.(event.target.value)}
       ref={register(field.validation)}
       options={field.options}
       id={field.id}

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextArea/index.tsx
@@ -6,7 +6,6 @@ import { GridFormTextAreaField } from '../../types';
 
 export type GridFormTextAreaProps = {
   className?: string;
-  clearErrors: UseFormMethods['clearErrors'];
   error?: boolean;
   showRequired?: boolean;
   field: Omit<GridFormTextAreaField, 'label'>;
@@ -15,7 +14,6 @@ export type GridFormTextAreaProps = {
 
 export const GridFormTextArea: React.FC<GridFormTextAreaProps> = ({
   className,
-  clearErrors,
   error,
   field,
   register,
@@ -28,10 +26,7 @@ export const GridFormTextArea: React.FC<GridFormTextAreaProps> = ({
       error={error}
       htmlFor={field.name}
       name={field.name}
-      onChange={(event) => {
-        clearErrors(field.name);
-        field.onUpdate?.(event.target.value);
-      }}
+      onChange={(event) => field.onUpdate?.(event.target.value)}
       ref={register(field.validation)}
       id={field.id}
       aria-invalid={error}

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/__tests__/GridFormTextInput-test.tsx
@@ -1,47 +1,21 @@
-import { setupRtl } from '@codecademy/gamut-tests';
-import userEvent from '@testing-library/user-event';
-
-import { stubTextField } from '../../../__tests__/stubs';
 import { itHandlesAriaInvalid } from '../../__fixtures__/assertions';
-import { GridFormTextInput } from '..';
-
-const renderGridFormTextInput = setupRtl(GridFormTextInput, {
-  clearErrors: jest.fn(),
-  field: stubTextField,
-  register: jest.fn(),
-});
+import { renderGridFormTextInput } from '../../__fixtures__/renderers';
 
 describe('GridFormTextInput', () => {
   describe('when an id is passed as a prop', () => {
     it('renders an input with the same id', () => {
-      const { view } = renderGridFormTextInput({
-        field: {
-          ...stubTextField,
-          id: 'mycoolid',
-        },
-      });
+      const textInput = renderGridFormTextInput({ id: 'mycoolid' });
 
-      expect(view.getByRole('textbox')).toHaveProperty('id', 'mycoolid');
+      expect(textInput.find('input#mycoolid').length).toBe(1);
     });
   });
 
   describe('when no id is passed', () => {
     it('renders an input with the id equal to the field name', () => {
-      const { view } = renderGridFormTextInput({
-        field: {
-          ...stubTextField,
-          name: 'name',
-        },
-      });
+      const textInput = renderGridFormTextInput({ name: 'name' });
 
-      expect(view.getByRole('textbox')).toHaveProperty('id', 'name');
+      expect(textInput.find('input#name').length).toBe(1);
     });
-  });
-
-  it('clears errors when typed into', () => {
-    const { view } = renderGridFormTextInput();
-
-    userEvent.type(view.getByRole('textbox'), 'hi');
   });
 
   itHandlesAriaInvalid('GridFormTextInput', 'input');

--- a/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/GridFormTextInput/index.tsx
@@ -5,7 +5,6 @@ import { Input } from '../../../Form';
 import { GridFormTextField } from '../../types';
 
 export type GridFormTextInputProps = {
-  clearErrors: UseFormMethods['clearErrors'];
   className?: string;
   error?: boolean;
   showRequired?: boolean;
@@ -15,7 +14,6 @@ export type GridFormTextInputProps = {
 
 export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({
   className,
-  clearErrors,
   error,
   field,
   register,
@@ -27,10 +25,7 @@ export const GridFormTextInput: React.FC<GridFormTextInputProps> = ({
       disabled={field.disabled}
       error={error}
       htmlFor={field.name}
-      onChange={(event) => {
-        clearErrors(field.name);
-        field.onUpdate?.(event.target.value);
-      }}
+      onChange={(event) => field.onUpdate?.(event.target.value)}
       placeholder={field.placeholder}
       name={field.name}
       ref={register(field.validation)}

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__fixtures__/renderers.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__fixtures__/renderers.tsx
@@ -35,7 +35,6 @@ export const renderGridFormSelectInput = (
 ) => {
   return mountWithTheme(
     <GridFormSelectInput
-      clearErrors={jest.fn()}
       field={{ ...stubSelectField, ...extraProps }}
       register={jest.fn()}
       {...extraProps}
@@ -48,7 +47,6 @@ export const renderGridFormTextInput = (
 ) => {
   return mountWithTheme(
     <GridFormTextInput
-      clearErrors={jest.fn()}
       field={{ ...stubTextField, ...extraProps }}
       register={jest.fn()}
       {...extraProps}
@@ -61,7 +59,6 @@ export const renderGridFormTextArea = (
 ) => {
   return mountWithTheme(
     <GridFormTextArea
-      clearErrors={jest.fn()}
       field={{ ...stubTextareaField, ...extraProps }}
       register={jest.fn()}
       {...extraProps}
@@ -74,7 +71,6 @@ export const renderGridFormRadioGroupInput = (
 ) => {
   return mountWithTheme(
     <GridFormRadioGroupInput
-      clearErrors={jest.fn()}
       field={{ ...stubRadioGroupField, ...extraProps }}
       setValue={jest.fn()}
       register={jest.fn()}
@@ -88,7 +84,6 @@ export const renderGridFormFileInput = (
 ) => {
   return mountWithTheme(
     <GridFormFileInput
-      clearErrors={jest.fn()}
       field={{ ...stubFileField, ...extraProps }}
       register={jest.fn()}
       {...extraProps}
@@ -101,7 +96,6 @@ export const renderGridFormCheckboxInput = (
 ) => {
   return mountWithTheme(
     <GridFormCheckboxInput
-      clearErrors={jest.fn()}
       field={{ ...stubCheckboxField, ...extraProps }}
       register={jest.fn()}
       {...extraProps}

--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -15,7 +15,6 @@ import { GridFormInputGroup, GridFormInputGroupProps } from '..';
 
 const renderComponent = (overrides: Partial<GridFormInputGroupProps>) => {
   const props: GridFormInputGroupProps = {
-    clearErrors: jest.fn(),
     field: stubSelectField,
     setValue: jest.fn(),
     register: jest.fn(),

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -20,7 +20,6 @@ import { GridFormTextArea } from './GridFormTextArea';
 import { GridFormTextInput } from './GridFormTextInput';
 
 export type GridFormInputGroupProps = {
-  clearErrors: UseFormMethods['clearErrors'];
   error?: string;
   isFirstError?: boolean;
   field: GridFormField;
@@ -31,7 +30,6 @@ export type GridFormInputGroupProps = {
 };
 
 export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
-  clearErrors,
   error,
   isFirstError,
   field,
@@ -48,7 +46,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
       case 'checkbox':
         return (
           <GridFormCheckboxInput
-            clearErrors={clearErrors}
             field={field}
             register={register}
             showRequired={isRequired}
@@ -59,7 +56,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
       case 'custom-group':
         return (
           <GridFormCustomInput
-            clearErrors={clearErrors}
             field={field}
             register={register}
             setValue={setValue}
@@ -70,7 +66,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
       case 'radio-group':
         return (
           <GridFormRadioGroupInput
-            clearErrors={clearErrors}
             field={field}
             register={register}
             showRequired={isRequired}
@@ -81,7 +76,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
       case 'select':
         return (
           <GridFormSelectInput
-            clearErrors={clearErrors}
             error={!!errorMessage}
             field={field}
             register={register}
@@ -92,7 +86,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
       case 'file':
         return (
           <GridFormFileInput
-            clearErrors={clearErrors}
             error={!!errorMessage}
             field={field}
             register={register}
@@ -103,7 +96,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
       case 'textarea':
         return (
           <GridFormTextArea
-            clearErrors={clearErrors}
             error={!!errorMessage}
             field={field}
             register={register}
@@ -125,7 +117,6 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
       default:
         return (
           <GridFormTextInput
-            clearErrors={clearErrors}
             error={!!errorMessage}
             field={field}
             register={register}

--- a/packages/gamut/src/GridForm/__tests__/GridForm-test.tsx
+++ b/packages/gamut/src/GridForm/__tests__/GridForm-test.tsx
@@ -20,7 +20,7 @@ import {
 } from './stubs';
 
 describe('GridForm', () => {
-  it('submits the form when all inputs are filled out', async () => {
+  it('submits the form when all inputs are  completely filled out', async () => {
     const fields = [stubCheckboxField, stubSelectField, stubTextField];
     const api = createPromise<{}>();
     const onSubmit = async (values: {}) => api.resolve(values);

--- a/packages/gamut/src/GridForm/index.tsx
+++ b/packages/gamut/src/GridForm/index.tsx
@@ -82,7 +82,6 @@ export function GridForm<
   showRequired = false,
 }: GridFormProps<Values>) {
   const {
-    clearErrors,
     errors,
     handleSubmit,
     register,
@@ -120,7 +119,6 @@ export function GridForm<
 
           return (
             <GridFormInputGroup
-              clearErrors={clearErrors}
               error={errorMessage as string}
               isFirstError={isFirstError}
               field={field}

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -37,7 +37,6 @@ export type GridFormCheckboxField = BaseFormField<boolean> & {
 
 export type GridFormCustomFieldProps = {
   className?: string;
-  clearErrors: UseFormMethods['clearErrors'];
   error?: string;
   field: GridFormCustomField | GridFormCustomGroupField;
   register: UseFormMethods['register'];


### PR DESCRIPTION
Reverts Codecademy/client-modules#1815 -- this was breaking Login on the monolith PR envs + locally (never went to prod, thankfully). behavior still live on [penguin](https://penguin.codecademy.com/login)

haven't dug into exactly why but think it's safer to revert this for now so we can ship tomorrow