### PR TITLE
feat(GlobalFooter): Update href of 'Beta Content' link to point at hub page

### DIFF
--- a/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CatalogLinks.tsx
+++ b/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CatalogLinks.tsx
@@ -122,7 +122,7 @@ export const CatalogLinks: React.FC<CatalogLinksProps> = ({ onClick }) => {
         </CatalogFooterLinkItem>
         <CatalogFooterLinkItem>
           <Anchor
-            href="/learn/beta-content"
+            href="/catalog/subject/beta"
             onClick={(event) => onClick({ event, target: 'betaContent' })}
             variant="interface"
           >


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Change the href of the "Beta Content" link in the `GlobalFooter` to point at `/catalog/subject/beta` instead of `/learn/beta-content`
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [X] Related to JIRA ticket: [LX-5099](https://codecademy.atlassian.net/browse/LX-5099)
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
