### PR TITLE
fix(Flyout): Move Close Icon Placement

### DIFF
--- a/packages/gamut-labs/src/Flyout/index.tsx
+++ b/packages/gamut-labs/src/Flyout/index.tsx
@@ -1,5 +1,5 @@
 import { BodyPortal, FocusTrap, IconButton } from '@codecademy/gamut';
-import { MiniDeleteIcon } from '@codecademy/gamut-icons';
+import { CloseIcon } from '@codecademy/gamut-icons';
 import { system, variant } from '@codecademy/gamut-styles';
 import { StyleProps, variance } from '@codecademy/variance';
 import styled from '@emotion/styled';
@@ -133,10 +133,11 @@ export const Flyout: React.FC<FlyoutProps> = ({
                 {...styleProps}
               >
                 <IconButton
-                  icon={MiniDeleteIcon}
+                  icon={CloseIcon}
                   onClick={toggleExpanded}
                   position="absolute"
-                  right="0"
+                  top="0.5rem"
+                  right="0.5rem"
                 />
                 {children}
               </DrawerBase>

--- a/packages/gamut-labs/src/Flyout/index.tsx
+++ b/packages/gamut-labs/src/Flyout/index.tsx
@@ -1,5 +1,5 @@
 import { BodyPortal, FocusTrap, IconButton } from '@codecademy/gamut';
-import { CloseIcon } from '@codecademy/gamut-icons';
+import { MiniDeleteIcon } from '@codecademy/gamut-icons';
 import { system, variant } from '@codecademy/gamut-styles';
 import { StyleProps, variance } from '@codecademy/variance';
 import styled from '@emotion/styled';
@@ -133,7 +133,7 @@ export const Flyout: React.FC<FlyoutProps> = ({
                 {...styleProps}
               >
                 <IconButton
-                  icon={CloseIcon}
+                  icon={MiniDeleteIcon}
                   onClick={toggleExpanded}
                   position="absolute"
                   top="0.5rem"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Moves the close icon in `Flyout` in by 8px on the top and right to align with Codecademy logo in `LayoutMenu` and fix issue where the x-button sometimes overlaps with the scroll bar
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
