### PR TITLE
fix: add unique ID per Pattern usage

### DIFF
--- a/packages/gamut/src/Pattern/defs.tsx
+++ b/packages/gamut/src/Pattern/defs.tsx
@@ -41,7 +41,7 @@ export const defs = (name: PatternName, id: string) => {
           height="8"
           patternUnits="userSpaceOnUse"
         >
-          <g clipPath="url(#clipDiagonalStripesRegular)">
+          <g clipPath={`url(#clipDiagonalStripesRegular-${id})`}>
             <rect width="8" height="8" fill="white" />
             <rect y="7" width="1" height="1" fill="currentColor" />
             <rect x="1" y="6" width="1" height="1" fill="currentColor" />
@@ -68,7 +68,7 @@ export const defs = (name: PatternName, id: string) => {
           height="4"
           patternUnits="userSpaceOnUse"
         >
-          <g clipPath="url(#clipDiagonalStripesDense)">
+          <g clipPath={`url(#clipDiagonalStripesDense-${id})`}>
             <rect width="4" height="4" fill="white" />
             <rect y="3" width="1" height="1" fill="currentColor" />
             <rect x="1" y="2" width="1" height="1" fill="currentColor" />

--- a/packages/gamut/src/Pattern/defs.tsx
+++ b/packages/gamut/src/Pattern/defs.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { PatternName } from './index';
 
-export const defs = (name: PatternName) => {
+export const defs = (name: PatternName, id: string) => {
   return (
     <defs>
       {name === 'diagonalStripesLoose' && (
         <pattern
-          id="diagonalStripesLoose"
+          id={`$diagonalStripesLoose-${id}`}
           x="0"
           y="0"
           width="16"
@@ -34,7 +34,7 @@ export const defs = (name: PatternName) => {
       )}
       {name === 'diagonalStripesRegular' && (
         <pattern
-          id="diagonalStripesRegular"
+          id={`$diagonalStripesRegular-${id}`}
           x="0"
           y="0"
           width="8"
@@ -61,7 +61,7 @@ export const defs = (name: PatternName) => {
       )}
       {name === 'diagonalStripesDense' && (
         <pattern
-          id="diagonalStripesDense"
+          id={`$diagonalStripesDense-${id}`}
           x="0"
           y="0"
           width="4"
@@ -84,7 +84,7 @@ export const defs = (name: PatternName) => {
       )}
       {name === 'checkerLoose' && (
         <pattern
-          id="checkerLoose"
+          id={`$checkerLoose-${id}`}
           x="0"
           y="0"
           width="16"
@@ -97,7 +97,7 @@ export const defs = (name: PatternName) => {
       )}
       {name === 'checkerRegular' && (
         <pattern
-          id="checkerRegular"
+          id={`$checkerRegular-${id}`}
           x="0"
           y="0"
           width="8"
@@ -110,7 +110,7 @@ export const defs = (name: PatternName) => {
       )}
       {name === 'checkerDense' && (
         <pattern
-          id="checkerDense"
+          id={`$checkerDense-${id}`}
           x="0"
           y="0"
           width="4"
@@ -123,7 +123,7 @@ export const defs = (name: PatternName) => {
       )}
       {name === 'dotLoose' && (
         <pattern
-          id="dotLoose"
+          id={`$dotLoose-${id}`}
           x="0"
           y="0"
           width="16"

--- a/packages/gamut/src/Pattern/index.tsx
+++ b/packages/gamut/src/Pattern/index.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled';
-import React, { ComponentProps } from 'react';
+import { uniqueId } from 'lodash';
+import React, { ComponentProps, useState } from 'react';
 
 import { Box } from '../Box';
 import { defs } from './defs';
@@ -17,18 +17,15 @@ export interface PatternProps extends ComponentProps<typeof Box> {
   name: PatternName;
 }
 
-const Svg = styled.svg`
-  width: 100%;
-  height: 100%;
-`;
-
 export const Pattern: React.FC<PatternProps> = ({ name, ...props }) => {
+  const [id] = useState(() => uniqueId(name));
+
   return (
     <Box {...props}>
-      <Svg aria-hidden>
-        {defs(name)}
+      <Box aria-hidden as="svg" height="100%" width="100%">
+        {defs(name, id)}
         <rect x="0" y="0" width="100%" height="100%" fill={`url(#${name})`} />
-      </Svg>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Uses Lodash's `uniqueId` once per component usage to make pattern IDs unique.

<!--- END-CHANGELOG-DESCRIPTION -->

This fixes a potential accessibility issue where multiple patterns on a page have the same `id` attribute.

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: GROW-2394
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
