### PR TITLE
feat(LayoutMenu): add breakpoint prop for configurable layout switching

### DIFF
--- a/packages/gamut-labs/src/LayoutMenu/LayoutMenu.tsx
+++ b/packages/gamut-labs/src/LayoutMenu/LayoutMenu.tsx
@@ -21,6 +21,10 @@ export type LayoutMenuProps = {
    * Text shown in mobile button that opens flyout on click
    */
   mobileButtonText: string;
+  /**
+   * Breakpoint above which the menu button displays as a full sidebar
+   */
+  breakpoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 };
 
 export const LayoutMenu: React.FC<LayoutMenuProps> = ({
@@ -28,6 +32,7 @@ export const LayoutMenu: React.FC<LayoutMenuProps> = ({
   onSectionToggle,
   selectedItem,
   mobileButtonText,
+  breakpoint = 'lg',
   children,
 }) => {
   const closeFlyoutRef = useRef(() => {});
@@ -52,7 +57,7 @@ export const LayoutMenu: React.FC<LayoutMenuProps> = ({
 
   return (
     <nav>
-      <Box display={{ _: 'block', lg: 'none' }}>
+      <Box display={{ _: 'block', [breakpoint]: 'none' }}>
         <Flyout
           renderButton={renderButton}
           closeFlyoutRef={closeFlyoutRef}
@@ -66,7 +71,7 @@ export const LayoutMenu: React.FC<LayoutMenuProps> = ({
           </Box>
         </Flyout>
       </Box>
-      <Box display={{ _: 'none', lg: 'block' }}>
+      <Box display={{ _: 'none', [breakpoint]: 'block' }}>
         {accordionMenuSections}
         {children}
       </Box>


### PR DESCRIPTION
### Overview

The cc docs designs have the LayoutMenu breakpoint at `md` instead of `lg` screen sizes, so I figured it would be nice to have this be configurable

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/nkBzG9nJW36t8kDOBcvnyU/Codecademy-Docs---MVP?node-id=672%3A1468
- [x] Related to JIRA ticket: [REACH-817](https://codecademy.atlassian.net/browse/REACH-817)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
