### PR TITLE
feat(GridFormInputGroup): Adding ability to hide errors for custom grid form inputs

### DIFF
--- a/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/__tests__/GridFormInputGroup-test.tsx
@@ -61,6 +61,22 @@ describe('GridFormInputGroup', () => {
     expect(wrapped.text()).toEqual(text);
   });
 
+  it('hides the error for a custom input if hideError is passed.', () => {
+    const error = 'Oh no!';
+    const { wrapped } = renderComponent({
+      field: {
+        render: () => 'Hello, world!',
+        name: 'stub-custom',
+        size: 6,
+        type: 'custom',
+        hideError: true,
+      },
+      error,
+    });
+
+    expect(wrapped.text()).not.toContain(error);
+  });
+
   it('renders a radio group when the field type is radio-group', () => {
     const { wrapped } = renderComponent({
       field: { ...stubRadioGroupField, id: 'mycoolid' },

--- a/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
+++ b/packages/gamut/src/GridForm/GridFormInputGroup/index.tsx
@@ -154,12 +154,14 @@ export const GridFormInputGroup: React.FC<GridFormInputGroupProps> = ({
     </FormGroupLabel>
   );
 
+  const hideError = 'hideError' in field && field.hideError;
+
   return (
     <Column size={field?.size} rowspan={field?.rowspan ?? 1}>
       <FormGroup mb={0}>
         {field.hideLabel ? <HiddenText>{label}</HiddenText> : label}
         {getInput()}
-        {errorMessage && (
+        {!hideError && errorMessage && (
           <FormError
             role={isFirstError ? 'alert' : 'status'}
             aria-live={isFirstError ? 'assertive' : 'off'}

--- a/packages/gamut/src/GridForm/types.ts
+++ b/packages/gamut/src/GridForm/types.ts
@@ -49,6 +49,7 @@ export type GridFormCustomField = BaseFormField<any> & {
   render: (props: GridFormCustomFieldProps) => React.ReactNode;
   validation?: ValidationRules;
   type: 'custom';
+  hideError?: boolean; // Custom fields can choose to implement their own error displays.
 };
 
 export type GridFormCustomGroupField = BaseFormField<any> & {


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Custom grid form elements potentially need to have more fine-tune control over how to display errors. They are passed the `errorMessage` when rendered, but currently the error is rendered as a sibling to the component directly below it without any styling adjustments. 

There were 2 options here:
1. Add more styling options/variants for the errors displayed for a custom input.
2. Add the ability to hide the default error and delegate displaying the error to the custom element.

I've chosen to go with option 2 here, as the error really needs to be aware of the contents of what is rendered in the custom element to look correct in my use-case (a centered error below the AvatarChooser). 

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [] Related to designs:
- [x] Related to JIRA ticket: https://codecademy.atlassian.net/browse/EGG-1447
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
