### PR TITLE
fix(a11y): fixes screen reader readout for progress components

### DIFF
--- a/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
+++ b/packages/gamut/src/ProgressBar/__tests__/ProgressBar-test.tsx
@@ -34,14 +34,17 @@ describe('ProgressBar', () => {
 
   it('does not include percentage visually when size is small', () => {
     const { wrapper } = renderWrapper({ size: 'small' });
-
-    expect(wrapper.text()).toEqual('');
+    // Enzyme doesn't differentiate between visible and invisible
+    // test so this tests that only the screen reader text renders
+    expect(wrapper.text()).toEqual('Progress: 50%');
   });
 
   it('includes percentage visually when size is large', () => {
     const { wrapper } = renderWrapper({ size: 'large' });
-
-    expect(wrapper.text()).toEqual('50%');
+    // Enzyme doesn't differentiate between visible and invisible
+    // test so this test accounts for both the visible '50%' and
+    // the 'Progress: 50%' that is only visible to screenreaders
+    expect(wrapper.text()).toEqual('Progress: 50%50%');
   });
 
   it('uses an svg when given a pattern', () => {

--- a/packages/gamut/src/ProgressBar/index.tsx
+++ b/packages/gamut/src/ProgressBar/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import React from 'react';
 
 import { Pattern, PatternName } from '../Pattern';
+import { Text } from '../Typography';
 
 export type ProgressBarProps = {
   className?: string;
@@ -170,14 +171,13 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
 }) => {
   return (
     <ProgressBarWrapper
-      aria-label={`Progress: ${percent}%`}
       aria-live="polite"
-      role="figure"
       border={bordered ? 'bordered' : 'basic'}
       size={size}
       variant={variant}
       backgroundOverride={pattern ? 'pattern' : 'none'}
     >
+      <Text as="label" screenreader>{`Progress: ${percent}%`}</Text>
       {pattern && (
         <Pattern width="100%" position="absolute" zIndex={0} name={pattern} />
       )}
@@ -189,7 +189,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
         }}
       >
         {['large', 'xl'].includes(size) && (
-          <DisplayedPercent>{percent}%</DisplayedPercent>
+          <DisplayedPercent aria-hidden>{percent}%</DisplayedPercent>
         )}
       </Bar>
     </ProgressBarWrapper>

--- a/packages/gamut/src/RadialProgress/index.tsx
+++ b/packages/gamut/src/RadialProgress/index.tsx
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import React, { SVGProps } from 'react';
 
+import { Text } from '../Typography';
 import styles from './styles.module.scss';
 
 export interface RadialProgressProps extends SVGProps<SVGSVGElement> {
@@ -42,19 +43,15 @@ export const RadialProgress: React.FC<RadialProgressProps> = ({
   } else {
     finalValue = startingValue = convertPercentToOffset(value);
   }
+  const labelPercent = Array.isArray(value) ? value[1] : value;
 
   return (
-    <div
+    <figure
       className={cx(styles.radialProgress, className)}
       style={{ height: size, width: size }}
     >
-      <svg
-        aria-label={`${value}% progress`}
-        viewBox="0 0 100 100"
-        height={size}
-        width={size}
-        {...props}
-      >
+      <Text as="figcaption" screenreader>{`${labelPercent}% progress`}</Text>
+      <svg viewBox="0 0 100 100" height={size} width={size} {...props}>
         <circle
           cx="50"
           cy="50"
@@ -91,6 +88,6 @@ export const RadialProgress: React.FC<RadialProgressProps> = ({
         </circle>
       </svg>
       {children && <div className={styles.children}>{children}</div>}
-    </div>
+    </figure>
   );
 };

--- a/packages/gamut/src/Typography/variants.ts
+++ b/packages/gamut/src/Typography/variants.ts
@@ -75,6 +75,8 @@ export const typographyElementVariants = {
     display: 'inline-block',
   },
   div: {},
+  figcaption: {},
+  label: {},
 } as const;
 
 export const typographyUtilities = {


### PR DESCRIPTION
### Overview
<!--- CHANGELOG-DESCRIPTION -->
Fixes a few screen reader bugs in the ProgressBar and RadialProgress
- Progress Bar now reads on a screen reader as `Progress: xx%` with no other noise 
- RadialProgress now reads on a screen reader as `xx% progress` with no other noise 
<!--- END-CHANGELOG-DESCRIPTION -->

### Fixes
- The Progress Bar w/percentage readout was reading both the wrapper label (`Progress: xx%`) and then the internal span (`xx%`).  - Fixed by setting aria-hidden on visual percentage readout to true
- Progress Bar component was reading as `empty figure` - fixed by using an internal label element and removing 'aria-label' from the wrapping div
- Radial Progress label was reading as `[x%, xx%] progress` when an array was used
- Radial Progress component was also reading as `empty group`, changed to figure element, with a screen reader only figcaption. 
### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: TR2-601, TR2-599
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
