### PR TITLE
feat(Markdown): remove max-height of tables

### DIFF
--- a/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown-test.tsx
@@ -62,9 +62,6 @@ describe('<Markdown />', () => {
     `;
     const { wrapper } = renderWrapper({ text: table });
     expect(wrapper.find('div.tableWrapper table').length).toEqual(1);
-    expect(wrapper.find('div.tableWrapper').prop('style')).toEqual({
-      maxHeight: 180,
-    });
   });
 
   it('Skips rendering custom tables in markdown when skipProcessing.table is true', () => {

--- a/packages/gamut/src/Markdown/index.tsx
+++ b/packages/gamut/src/Markdown/index.tsx
@@ -16,7 +16,7 @@ import {
   MarkdownAnchor,
   MarkdownAnchorProps,
 } from './libs/overrides/MarkdownAnchor';
-import { Table, TableProps } from './libs/overrides/Table';
+import { Table } from './libs/overrides/Table';
 import { createPreprocessingInstructions } from './libs/preprocessing';
 import { defaultSanitizationConfig } from './libs/sanitizationConfig';
 import styles from './styles/index.module.scss';
@@ -103,9 +103,7 @@ export class Markdown extends PureComponent<MarkdownProps> {
         }),
       !skipDefaultOverrides.table &&
         createTagOverride('table', {
-          component: (props: TableProps) => (
-            <Table maxHeight={spacing === 'tight' ? 180 : 500} {...props} />
-          ),
+          component: Table,
           allowedAttributes: ['style'],
         }),
       ...overrides,

--- a/packages/gamut/src/Markdown/libs/overrides/Table/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/Table/index.tsx
@@ -2,13 +2,9 @@ import React, { HTMLAttributes } from 'react';
 
 import styles from './styles.module.scss';
 
-export interface TableProps extends HTMLAttributes<HTMLTableElement> {
-  maxHeight?: number | string;
-}
-
-export const Table: React.FC<TableProps> = ({ maxHeight, ...props }) => {
+export const Table: React.FC<HTMLAttributes<HTMLTableElement>> = (props) => {
   return (
-    <div className={styles.tableWrapper} style={{ maxHeight }}>
+    <div className={styles.tableWrapper}>
       <table {...props} />
     </div>
   );

--- a/packages/gamut/src/Markdown/libs/overrides/Table/styles.module.scss
+++ b/packages/gamut/src/Markdown/libs/overrides/Table/styles.module.scss
@@ -1,8 +1,9 @@
 @import "~@codecademy/gamut-styles/utils";
 
 .tableWrapper {
-  overflow: scroll;
   border: px-rem(1px) solid $color-gray-300;
+  max-height: 500px;
+  overflow: auto;
 
   table {
     font-family: $font-monospace;
@@ -31,11 +32,6 @@
       text-align: inherit;
       vertical-align: middle;
       color: $color-black;
-    }
-
-    th {
-      position: sticky;
-      top: 0;
     }
 
     tr:nth-child(even),


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Removes 'tight' max-height of 150px and sets the max-height to 500px by default for Markdown tables. Also adjusts overflow to be `auto`, not always `scroll`.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs: 
- [ ] Related to JIRA ticket: https://codecademy.atlassian.net/browse/LX-5045
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

before:
![Screen Shot 2021-08-04 at 11 08 13 AM](https://user-images.githubusercontent.com/30914906/128205780-2c7cfb84-f845-4235-a3d1-8e1f30d98af6.png)

after:
![Screen Shot 2021-08-04 at 11 07 59 AM](https://user-images.githubusercontent.com/30914906/128205770-bd864b0a-d87b-4590-91ac-41817b666646.png)

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
