### PR TITLE
fix: Cards now correctly set color mode for their contents GM-308

### DIFF
--- a/packages/gamut-styles/src/ColorMode.tsx
+++ b/packages/gamut-styles/src/ColorMode.tsx
@@ -10,6 +10,8 @@ import { mapValues, pick } from 'lodash';
 import React, { ComponentProps, forwardRef, useMemo } from 'react';
 
 import {
+  background,
+  border,
   color,
   css,
   flex,
@@ -29,7 +31,6 @@ export type ColorAlias = keyof ColorModeShape;
 export type ColorModeProps = {
   mode: ColorModes;
   bg?: Colors;
-  className?: string;
 };
 
 export const providerProps = variance.compose(
@@ -38,7 +39,9 @@ export const providerProps = variance.compose(
   grid,
   flex,
   positioning,
-  space
+  space,
+  border,
+  background
 );
 
 export const modeColorProps = ({

--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -45,10 +45,7 @@ export const CardWrapper = styled(Background)<
 );
 
 export const Card: React.FC<CardProps> = ({ variant = 'white', ...rest }) => {
-  return <CardWrapper bg={variant} {...rest} outline={variant === 'navy'} />;
-};
-
-CardWrapper.defaultProps = {
-  p: 16,
-  variant: 'white',
+  return (
+    <CardWrapper bg={variant} outline={variant === 'navy'} p={16} {...rest} />
+  );
 };

--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -7,6 +7,8 @@ const shadowVariants = variant({
   prop: 'shadow',
   base: {
     position: 'relative',
+    border: 1,
+    borderColor: 'navy',
     boxShadow: `0px 0px 0 ${theme.colors.navy}`,
     transition: 'box-shadow 200ms ease, transform 200ms ease',
   },
@@ -46,6 +48,6 @@ export const CardWrapper = styled(Background)<
 
 export const Card: React.FC<CardProps> = ({ variant = 'white', ...rest }) => {
   return (
-    <CardWrapper bg={variant} outline={variant === 'navy'} p={16} {...rest} />
+    <CardWrapper bg={variant} p={16} outline={variant === 'navy'} {...rest} />
   );
 };

--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -33,14 +33,11 @@ export interface CardProps
   variant?: 'navy' | 'white' | 'hyper' | 'yellow';
 }
 
-interface CardWrapperProps
-  extends StyleProps<typeof shadowVariants>,
-    StyleProps<typeof system['background']> {
+interface CardWrapperProps extends StyleProps<typeof shadowVariants> {
   outline?: boolean;
 }
 
 const CardWrapper = styled(Background)<CardWrapperProps>(
-  system.css({ border: 1, borderRadius: '2px' }),
   shadowVariants,
   system.states({
     outline: {
@@ -48,12 +45,9 @@ const CardWrapper = styled(Background)<CardWrapperProps>(
         outline: '1px solid currentColor',
       },
     },
-  }),
-  system.background
+  })
 );
 
-export const Card: React.FC<CardProps> = ({ variant = 'white', ...rest }) => {
-  return (
-    <CardWrapper bg={variant} p={16} outline={variant === 'navy'} {...rest} />
-  );
-};
+export const Card: React.FC<CardProps> = ({ variant = 'white', ...rest }) => (
+  <CardWrapper bg={variant} p={16} outline={variant === 'navy'} {...rest} />
+);

--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -32,9 +32,7 @@ export interface CardProps extends StyleProps<typeof shadowVariants> {
   variant?: 'yellow' | 'navy' | 'white' | 'hyper';
 }
 
-export const CardWrapper = styled(Background)<
-  CardProps & { outline?: boolean }
->(
+const CardWrapper = styled(Background)<CardProps & { outline?: boolean }>(
   system.css({ border: 1, borderRadius: '2px' }),
   shadowVariants,
   system.states({

--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -1,7 +1,7 @@
 import { Background, system, theme, variant } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
 const shadowVariants = variant({
   prop: 'shadow',
@@ -28,11 +28,16 @@ const shadowVariants = variant({
   },
 });
 
-export interface CardProps extends StyleProps<typeof shadowVariants> {
-  variant?: 'yellow' | 'navy' | 'white' | 'hyper';
+export interface CardProps
+  extends Omit<ComponentProps<typeof CardWrapper>, 'outline' | 'bg'> {
+  variant?: 'navy' | 'white' | 'hyper' | 'yellow';
 }
 
-const CardWrapper = styled(Background)<CardProps & { outline?: boolean }>(
+interface CardWrapperProps extends StyleProps<typeof shadowVariants> {
+  outline?: boolean;
+}
+
+const CardWrapper = styled(Background)<CardWrapperProps>(
   system.css({ border: 1, borderRadius: '2px' }),
   shadowVariants,
   system.states({

--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -33,7 +33,9 @@ export interface CardProps
   variant?: 'navy' | 'white' | 'hyper' | 'yellow';
 }
 
-interface CardWrapperProps extends StyleProps<typeof shadowVariants> {
+interface CardWrapperProps
+  extends StyleProps<typeof shadowVariants>,
+    StyleProps<typeof system['background']> {
   outline?: boolean;
 }
 
@@ -46,7 +48,8 @@ const CardWrapper = styled(Background)<CardWrapperProps>(
         outline: '1px solid currentColor',
       },
     },
-  })
+  }),
+  system.background
 );
 
 export const Card: React.FC<CardProps> = ({ variant = 'white', ...rest }) => {

--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -1,36 +1,7 @@
-import { theme, variant } from '@codecademy/gamut-styles';
+import { Background, system, theme, variant } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
-
-import { Box } from '../Box';
-
-const cardVariants = variant({
-  base: {
-    border: 1,
-    borderRadius: '2px',
-  },
-  variants: {
-    yellow: {
-      bg: 'yellow',
-      textColor: 'navy',
-    },
-    navy: {
-      bg: 'navy',
-      textColor: 'white',
-      '&:hover': {
-        outline: '1px solid currentColor',
-      },
-    },
-    white: {
-      bg: 'white',
-      textColor: 'navy',
-    },
-    hyper: {
-      bg: 'hyper',
-      textColor: 'white',
-    },
-  },
-});
+import React from 'react';
 
 const shadowVariants = variant({
   prop: 'shadow',
@@ -55,12 +26,29 @@ const shadowVariants = variant({
   },
 });
 
-export type CardProps = StyleProps<typeof cardVariants> &
-  StyleProps<typeof shadowVariants>;
+export interface CardProps extends StyleProps<typeof shadowVariants> {
+  variant?: 'yellow' | 'navy' | 'white' | 'hyper';
+}
 
-export const Card = styled(Box)<CardProps>(cardVariants, shadowVariants);
+export const CardWrapper = styled(Background)<
+  CardProps & { outline?: boolean }
+>(
+  system.css({ border: 1, borderRadius: '2px' }),
+  shadowVariants,
+  system.states({
+    outline: {
+      '&:hover': {
+        outline: '1px solid currentColor',
+      },
+    },
+  })
+);
 
-Card.defaultProps = {
+export const Card: React.FC<CardProps> = ({ variant = 'white', ...rest }) => {
+  return <CardWrapper bg={variant} {...rest} outline={variant === 'navy'} />;
+};
+
+CardWrapper.defaultProps = {
   p: 16,
   variant: 'white',
 };


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
* Switch Cards to use `Background` to ensure components within cards behave correctly.
* Changes hover behavior to only use borderColor and without an outline for future proofing.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs:
- [x] Related to JIRA ticket: https://codecademy.atlassian.net/browse/GM-308
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
