### PR TITLE
chore(tracking): Update segment destination mappings

### DIFF
--- a/packages/tracking/src/integrations/__tests__/mapDestinations-test.ts
+++ b/packages/tracking/src/integrations/__tests__/mapDestinations-test.ts
@@ -97,15 +97,12 @@ describe('mapDestinations', () => {
       expect(identifyPreferences).toEqual(expect.objectContaining(output));
     };
 
-    it('does not include FullStory when there is no user', () => {
+    it('does not include FullStory when consent does not include C0003', () => {
       testCase({}, { FullStory: false });
     });
 
-    it('includes FullStory when there is a user', () => {
-      testCase(
-        { user: { email: 'test@test.com', id: 'bcd234' } },
-        { FullStory: true }
-      );
+    it('includes FullStory when consent includes C0002', () => {
+      testCase({ consentDecision: [Consent.Performance] }, { FullStory: true });
     });
 
     it('does not include Hindsight when consent does not include C0004', () => {

--- a/packages/tracking/src/integrations/mapDestinations.ts
+++ b/packages/tracking/src/integrations/mapDestinations.ts
@@ -9,7 +9,13 @@ export type DestinationMapOptions = {
 
 // The Functional category may need to be added here in the future.
 const targetingCategories = ['Advertising', 'Attribution', 'Email Marketing'];
-const performanceCategories = ['Analytics', 'Customer Success'];
+const performanceCategories = [
+  'Analytics',
+  'Customer Success',
+  'Surveys',
+  'Heatmaps & Recording',
+];
+const functionalCategories = ['SMS & Push Notifications'];
 
 /**
  * @see https://www.notion.so/codecademy/GDPR-Compliance-141ebcc7ffa542daa0da56e35f482b41
@@ -19,14 +25,9 @@ export const mapDestinations = ({
   destinations,
   user,
 }: DestinationMapOptions) => {
-  // See GROW-1111, GROW-1137 for FullStory context
-  // The intention is to enable fullstory for logged-in users. See GROW-2292
-  const enableFullStory = !!user;
-
   const destinationPreferences: Record<string, boolean> = Object.assign(
     {
       'Segment.io': consentDecision.includes(Consent.Functional),
-      FullStory: enableFullStory,
     },
     ...destinations.map((dest) => {
       if (targetingCategories.includes(dest.category)) {
@@ -39,15 +40,20 @@ export const mapDestinations = ({
           [dest.id]: consentDecision.includes(Consent.Performance),
         };
       }
+      if (functionalCategories.includes(dest.category)) {
+        return {
+          [dest.id]: consentDecision.includes(Consent.Functional),
+        };
+      }
       return {
         [dest.id]: true,
       };
     })
   );
 
-  const identifyPreferences = {
+  const identifyPreferences: Record<string, boolean> = {
     All: false,
-    FullStory: enableFullStory,
+    FullStory: consentDecision.includes(Consent.Performance),
     Hindsight: consentDecision.includes(Consent.Targeting),
     UserLeap: consentDecision.includes(Consent.Performance),
   };


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Add more Segment categories to our OneTrust consent mapping
<!--- END-CHANGELOG-DESCRIPTION -->

### Note

We are also removing the hardcoded logic for FullStory.  It was broken, as FullStory was enabled in the list of destinations, and was thus always overriding this.  Seeing as we didn't go over our recording budget, we decided to just continue to open this up to all people.

### PS

There is a known but in the Pricing page (Next.js Portal App) which is causing the Segment Scripts to not be initialized.  we will be tackling that in a separate branch next sprint.