### PR TITLE
fix(LayoutMenu): add aria-expanded

### DIFF
--- a/packages/gamut-labs/src/LayoutMenu/AccordionMenu.tsx
+++ b/packages/gamut-labs/src/LayoutMenu/AccordionMenu.tsx
@@ -66,6 +66,7 @@ export const AccordionMenu: React.FC<AccordionMenuProps> = ({
             onSectionToggle(section.slug);
             setExpanded((prev) => !prev);
           }}
+          aria-expanded={expanded}
         >
           <Text variant="title-xs">{section.title}</Text>
           <ExpandChevron ml={12} size={14} expanded={expanded} />


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Adds `aria-expanded` to the `Anchor` we are now using instead of the `AccordionButton` within the `LayoutMenu` to fix an accessibility bug.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-1192](https://codecademy.atlassian.net/browse/REACH-1192)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
