### PR TITLE
fix: add role to ToolTip for axe

### DIFF
--- a/packages/gamut/src/ToolTip/__tests__/ToolTip-test.tsx
+++ b/packages/gamut/src/ToolTip/__tests__/ToolTip-test.tsx
@@ -10,7 +10,7 @@ describe('ToolTip', () => {
   it('does not give its container a tabIndex when it is not focusable', () => {
     const { view } = renderView({ children, id: 'test-id' });
 
-    const container = view.getByLabelText(children);
+    const container = view.getByTestId('tooltip-target-container');
 
     expect(container).not.toHaveAttribute('tabIndex');
   });
@@ -19,7 +19,7 @@ describe('ToolTip', () => {
     const children = 'Hello';
     const { view } = renderView({ children, focusable: true, id: 'test-id' });
 
-    const container = view.getByLabelText(children);
+    const container = view.getByTestId('tooltip-target-container');
 
     expect(container).toHaveAttribute('tabIndex', '0');
   });

--- a/packages/gamut/src/ToolTip/__tests__/ToolTip-test.tsx
+++ b/packages/gamut/src/ToolTip/__tests__/ToolTip-test.tsx
@@ -10,7 +10,7 @@ describe('ToolTip', () => {
   it('does not give its container a tabIndex when it is not focusable', () => {
     const { view } = renderView({ children, id: 'test-id' });
 
-    const container = view.getByTestId('tooltip-target-container');
+    const container = view.getByLabelText(children);
 
     expect(container).not.toHaveAttribute('tabIndex');
   });
@@ -19,7 +19,7 @@ describe('ToolTip', () => {
     const children = 'Hello';
     const { view } = renderView({ children, focusable: true, id: 'test-id' });
 
-    const container = view.getByTestId('tooltip-target-container');
+    const container = view.getByLabelText(children);
 
     expect(container).toHaveAttribute('tabIndex', '0');
   });

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -217,7 +217,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
   return (
     <TooltipWrapper className={containerClassName}>
       <TargetContainer
-        aria-labelledby={id}
+        aria-describedby={id}
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
             (event.target as HTMLElement).blur();

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -218,8 +218,8 @@ export const ToolTip: React.FC<ToolTipProps> = ({
     <TooltipWrapper className={containerClassName}>
       <TargetContainer
         data-testid="tooltip-target-container"
-        aria-describedby={id}
-        aria-label="info"
+        aria-labelledby={id}
+        role="complementary"
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
             (event.target as HTMLElement).blur();

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -219,6 +219,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
       <TargetContainer
         data-testid="tooltip-target-container"
         aria-describedby={id}
+        aria-label="info"
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
             (event.target as HTMLElement).blur();

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -217,6 +217,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
   return (
     <TooltipWrapper className={containerClassName}>
       <TargetContainer
+        data-testid="tooltip-target-container"
         aria-describedby={id}
         onKeyDown={(event) => {
           if (event.key === 'Escape') {

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -217,7 +217,6 @@ export const ToolTip: React.FC<ToolTipProps> = ({
   return (
     <TooltipWrapper className={containerClassName}>
       <TargetContainer
-        data-testid="tooltip-target-container"
         aria-labelledby={id}
         role="button"
         onKeyDown={(event) => {

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -219,7 +219,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
       <TargetContainer
         data-testid="tooltip-target-container"
         aria-labelledby={id}
-        role="complementary"
+        role="button"
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
             (event.target as HTMLElement).blur();


### PR DESCRIPTION
### Overview
<!--- CHANGELOG-DESCRIPTION -->
change ToolTip aria-labelledby to aria-describedby to pass cypress-axe tests in portal-app
<!--- END-CHANGELOG-DESCRIPTION -->
related PR in portal-app: https://github.com/codecademy-engineering/portal-app/pull/440

this was the axe error: 
```
Description:  Ensures ARIA attributes are allowed for an element's role
Elements must only use allowed ARIA attributes
https://dequeuniversity.com/rules/axe/4.2/aria-allowed-attr?application=axeAPI
"Fix all of the following:
  ARIA attribute cannot be used: aria-labelledby"
```


### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: EGG-1345
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
