### PR TITLE
fix(ToolTip): fix ternary for focusable

### DIFF
--- a/packages/gamut/src/Form/FormGroupLabel.tsx
+++ b/packages/gamut/src/Form/FormGroupLabel.tsx
@@ -82,7 +82,6 @@ export const FormGroupLabel: React.FC<FormGroupLabelProps> = ({
           <StyledToolTip
             alignment="bottom-right"
             target={<MiniInfoOutlineIcon size="0.8rem" aria-hidden="false" />}
-            focusable
             {...tooltip}
           />
         </StyledToolTipContainer>

--- a/packages/gamut/src/Form/FormGroupLabel.tsx
+++ b/packages/gamut/src/Form/FormGroupLabel.tsx
@@ -82,6 +82,7 @@ export const FormGroupLabel: React.FC<FormGroupLabelProps> = ({
           <StyledToolTip
             alignment="bottom-right"
             target={<MiniInfoOutlineIcon size="0.8rem" aria-hidden="false" />}
+            focusable
             {...tooltip}
           />
         </StyledToolTipContainer>

--- a/packages/gamut/src/ToolTip/__tests__/ToolTip-test.tsx
+++ b/packages/gamut/src/ToolTip/__tests__/ToolTip-test.tsx
@@ -23,4 +23,20 @@ describe('ToolTip', () => {
 
     expect(container).toHaveAttribute('tabIndex', '0');
   });
+
+  it('does not give its container a role=button when it is not focusable', () => {
+    const { view } = renderView({ children, id: 'test-id' });
+
+    const container = view.getByLabelText(children);
+
+    expect(container).not.toHaveAttribute('role');
+  });
+
+  it('does give its container a role=button when it is focusable', () => {
+    const { view } = renderView({ children, focusable: true, id: 'test-id' });
+
+    const container = view.getByRole('button');
+
+    expect(container).toBeDefined();
+  });
 });

--- a/packages/gamut/src/ToolTip/index.tsx
+++ b/packages/gamut/src/ToolTip/index.tsx
@@ -218,7 +218,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
     <TooltipWrapper className={containerClassName}>
       <TargetContainer
         aria-labelledby={id}
-        role={focusable ? undefined : 'button'}
+        role={focusable ? 'button' : undefined}
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
             (event.target as HTMLElement).blur();


### PR DESCRIPTION
### Overview
Makes `role=button` conditional (in the right way) based on the focusable prop.

draft monolith PR here : https://github.com/codecademy-engineering/Codecademy/pull/26542

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: gm-327
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
