### PR TITLE
feat(FloatingCard): Adds shadow offset direction and pattern

### DIFF
--- a/packages/gamut/src/FloatingCard/FloatingCard.tsx
+++ b/packages/gamut/src/FloatingCard/FloatingCard.tsx
@@ -84,16 +84,27 @@ const CardBody = styled('div', styledOptions)<
 export type FloatingCardProps = {
   className?: string;
   pattern?: React.ComponentType<PatternProps>;
+  shadow?: 'bottom-left' | 'bottom-right';
 } & ComponentProps<typeof CardBody>;
 
 export const FloatingCard = forwardRef<HTMLDivElement, FloatingCardProps>(
-  ({ children, className, pattern = CheckerDense, ...rest }, ref) => (
+  (
+    {
+      children,
+      className,
+      pattern: Pattern = CheckerDense,
+      shadow = 'bottom-left',
+      ...rest
+    },
+    ref
+  ) => (
     <CardWrapper>
-      <CheckerDense
+      <Pattern
         dimensions={1}
         position="absolute"
-        top=".5rem"
-        left="-0.5rem"
+        top="0.5rem"
+        left={shadow === 'bottom-left' ? '-0.5rem' : undefined}
+        right={shadow === 'bottom-right' ? '-0.5rem' : undefined}
       />
       <CardBody className={className} {...rest} ref={ref}>
         {children}

--- a/packages/styleguide/stories/Atoms/FloatingCard.stories.mdx
+++ b/packages/styleguide/stories/Atoms/FloatingCard.stories.mdx
@@ -15,7 +15,6 @@ import { PropsTable } from '~styleguide/blocks';
   }}
   args={{
     children: "Yakety Yak don't don't talk back!",
-    pattern: 'checkerDense',
   }}
 />
 
@@ -48,6 +47,39 @@ FloatingCards can optionally display a beak. This is used to indicate a point of
 </Story>
 
 <br />
+
+## Shadow Direction
+
+There are 2 types of shadow directions. By default, FloatingCards is set with a shadow offset to the bottom-left.
+
+<Canvas>
+  <Story name="FloatingCard Shadow">
+    {(args) => (
+      <GridBox gridAutoFlow="column" columnGap={24} py={16}>
+        {['bottom-left', 'bottom-right'].map((shadow) => (
+          <FloatingCard shadow={shadow}>{shadow}</FloatingCard>
+        ))}
+      </GridBox>
+    )}
+  </Story>
+</Canvas>
+
+## Shadow Pattern
+
+When changing the pattern of the FloatingCard shadow, provide the `pattern` prop with the imported pattern from `@codecademy/gamut-patterns`.
+
+```tsx
+import { FloatingCard } from '@codecademy/gamut';
+import { DotDense } from '@codecademy/gamut-patterns';
+
+export const MyComponent: React.FC = () => {
+  return (
+    <FloatingCard shadow="bottom-right" pattern={DotDense}>
+      We all float down here.
+    </FloatingCard>
+  );
+};
+```
 
 ## Code Playground
 


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
This FloatingCard feature adds a shadow prop to optionally change the direction of the shadow when needed. By default, the shadow is set to the bottom-left (as it were before) and now the pattern of the shadow can also be changed to a pattern that exists in the gamut-pattern kit.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-1123](https://codecademy.atlassian.net/browse/REACH-1123)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
