### PR TITLE
fix(styleguide): Set Figma blocks aspect ratio to 16:9 GM-336

### DIFF
--- a/packages/styleguide/.storybook/components/Docs/DocsPage.tsx
+++ b/packages/styleguide/.storybook/components/Docs/DocsPage.tsx
@@ -118,7 +118,7 @@ export const DocsPage: React.FC = ({ children }) => {
         )}
         {design?.url && (
           <GridBox mb={32}>
-            <Figma height="30%" collapsable url={design?.url} />
+            <Figma height={9 / 16} collapsable url={design?.url} />
           </GridBox>
         )}
         {children}

--- a/packages/styleguide/.storybook/components/Docs/DocsPage.tsx
+++ b/packages/styleguide/.storybook/components/Docs/DocsPage.tsx
@@ -118,7 +118,7 @@ export const DocsPage: React.FC = ({ children }) => {
         )}
         {design?.url && (
           <GridBox mb={32}>
-            <Figma height={`${9 / 16}%`} collapsable url={design?.url} />
+            <Figma height="56.25%" collapsable url={design?.url} />
           </GridBox>
         )}
         {children}

--- a/packages/styleguide/.storybook/components/Docs/DocsPage.tsx
+++ b/packages/styleguide/.storybook/components/Docs/DocsPage.tsx
@@ -118,7 +118,7 @@ export const DocsPage: React.FC = ({ children }) => {
         )}
         {design?.url && (
           <GridBox mb={32}>
-            <Figma height={9 / 16} collapsable url={design?.url} />
+            <Figma height={`${9 / 16}%`} collapsable url={design?.url} />
           </GridBox>
         )}
         {children}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
* These were too short and looked weird.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs:
- [x] Related to JIRA ticket: https://codecademy.atlassian.net/browse/GM-336
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
