### PR TITLE
fix: Hiding checkbox svg from accessibility api

### DIFF
--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -113,6 +113,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               height="22px"
               viewBox="0 0 20 20"
               color={checked ? 'currentColor' : 'transparent'}
+              aria-hidden
             >
               <path
                 d="M3,1 L17,1 L17,1 C18.1045695,1 19,1.8954305 19,3 L19,17 L19,17 C19,18.1045695 18.1045695,19 17,19 L3,19 L3,19 C1.8954305,19 1,18.1045695 1,17 L1,3 L1,3 C1,1.8954305 1.8954305,1 3,1 Z"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
On Firefox and Safari the screen reader is picking up the SVG as an unlabeled image. 

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [EN-1113](https://codecademy.atlassian.net/browse/EN-1113)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
