### PR TITLE
fix(Checkbox): safari and ff labelling

### DIFF
--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -121,7 +121,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               <Polyline checked={checked} points="4 11 8 15 16 6" />
             </CheckboxVector>
           </CheckboxElement>
-          <CheckboxText multiline={multiline} disabled={disabled}>
+          <CheckboxText
+            id={id || htmlFor}
+            multiline={multiline}
+            disabled={disabled}
+          >
             {label}
           </CheckboxText>
         </CheckboxLabel>

--- a/packages/styleguide/stories/Atoms/FormInputs/Checkbox.stories.mdx
+++ b/packages/styleguide/stories/Atoms/FormInputs/Checkbox.stories.mdx
@@ -138,8 +138,27 @@ If you need to checkboxes to fit into a smaller space, you can use our `tight` s
 
 <Canvas>
   <Story name="Tight Spacing">
-    <Checkbox checked readOnly spacing="tight" label="a small space" />
-    <Checkbox spacing="tight" label="with three checkboxes" />
-    <Checkbox checked readOnly spacing="tight" label="neat huh?" />
+    <Checkbox
+      checked
+      readOnly
+      spacing="tight"
+      label="a small space"
+      htmlFor="spacing-1"
+      name="spacing-1"
+    />
+    <Checkbox
+      spacing="tight"
+      label="with three checkboxes"
+      htmlFor="spacing-2"
+      name="spacing-2"
+    />
+    <Checkbox
+      checked
+      readOnly
+      spacing="tight"
+      label="neat huh?"
+      htmlFor="spacing-3"
+      name="spacing-3"
+    />
   </Story>
 </Canvas>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Fixes an issue where Checkboxes weren't being properly labelled on Safari + Firefox. Please check out the [Checkbox](https://612ff33f7b1bb40b3b04f8fb--gamut-preview.netlify.app/storybook/) story and the [Portal App PR](https://github.com/codecademy-engineering/portal-app/pull/542) to test the behavior. 

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: gm-241
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
