### PR TITLE
fix(GlobalHeader): Limit buttons on mobile header < XS to 1 and use small size GM-345

### DIFF
--- a/packages/gamut-labs/src/AppHeader/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/index.tsx
@@ -39,7 +39,8 @@ export const AppHeaderFillButton = styled(FillButton)(focusStyles);
 export const mapItemToElement = (
   action: AppHeaderClickHandler,
   item: AppHeaderItem,
-  redirectParam?: string
+  redirectParam?: string,
+  mobile = false
 ): ReactNode => {
   switch (item.type) {
     case 'logo':
@@ -54,6 +55,7 @@ export const mapItemToElement = (
     case 'text-button':
       return (
         <AppHeaderTextButton
+          size={mobile ? 'small' : 'normal'}
           onClick={(event: React.MouseEvent) => action(event, item)}
           data-testid={item.dataTestId}
           href={
@@ -68,6 +70,7 @@ export const mapItemToElement = (
     case 'fill-button':
       return (
         <AppHeaderFillButton
+          size={mobile ? 'small' : 'normal'}
           data-testid={item.dataTestId}
           href={
             item.redirect

--- a/packages/gamut-labs/src/AppHeaderMobile/index.tsx
+++ b/packages/gamut-labs/src/AppHeaderMobile/index.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   ContentContainer,
   FlexBox,
+  GridBox,
   Overlay,
 } from '@codecademy/gamut';
 import { CloseIcon, MenuIcon } from '@codecademy/gamut-icons';
@@ -66,16 +67,29 @@ export const AppHeaderMobile: React.FC<AppHeaderMobileProps> = ({
     setMobileMenuOpen(true);
   };
 
-  const mapItemsToElement = <T extends AppHeaderItem[]>(items: T) => {
-    return items.map((item, index) => (
-      <Box
-        key={item.id}
-        ml={index === 0 ? 0 : 4}
-        mr={index === items.length - 1 ? 0 : 4}
-      >
-        {mapItemToElement(action, item, redirectParam)}
-      </Box>
-    ));
+  const mapItemsToElement = <T extends AppHeaderItem[]>(
+    items: T,
+    hideExtraItems?: boolean
+  ) => {
+    const shouldHideItems = hideExtraItems === true && items.length > 1;
+    return items.map((item, index) => {
+      const isFirstItem = index === 0;
+      const isLastItem = index + 1 === items.length;
+      const isHidable = !isLastItem && shouldHideItems;
+      return (
+        <Box
+          key={item.id}
+          ml={isFirstItem ? 0 : 4}
+          mr={isLastItem ? 0 : 4}
+          display={{
+            _: isHidable ? 'none' : 'block',
+            xs: 'block',
+          }}
+        >
+          {mapItemToElement(action, item, redirectParam, true)}
+        </Box>
+      );
+    });
   };
 
   return (
@@ -86,8 +100,7 @@ export const AppHeaderMobile: React.FC<AppHeaderMobileProps> = ({
             {mapItemsToElement(items.left)}
           </AppBarSection>
           <AppBarSection position="right">
-            {mapItemsToElement(items.right)}
-
+            {mapItemsToElement(items.right, true)}
             <FlexBox ml={24}>
               <IconButton
                 type="button"

--- a/packages/gamut-labs/src/AppHeaderMobile/index.tsx
+++ b/packages/gamut-labs/src/AppHeaderMobile/index.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   ContentContainer,
   FlexBox,
-  GridBox,
   Overlay,
 } from '@codecademy/gamut';
 import { CloseIcon, MenuIcon } from '@codecademy/gamut-icons';


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
* Adds logic for small button usage on the mobile menu
* Ensures that only 1 button is visible when under our smallest breakpoint to prevent blowout.
<!--- END-CHANGELOG-DESCRIPTION -->

<img width="393" alt="Screen Shot 2021-09-03 at 6 43 48 PM" src="https://user-images.githubusercontent.com/52927224/132071825-78177420-4121-4812-8718-b82b43c103b5.png">
<img width="409" alt="Screen Shot 2021-09-03 at 9 30 28 PM" src="https://user-images.githubusercontent.com/52927224/132078104-0b396ce3-5000-4999-b78d-09acfe3c53b4.png">


### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: https://codecademy.atlassian.net/browse/GM-345
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
