### PR TITLE
fix: add docs back to header and footer

### DIFF
--- a/packages/gamut-labs/src/lib/resourcesList/__tests__/index-test.tsx
+++ b/packages/gamut-labs/src/lib/resourcesList/__tests__/index-test.tsx
@@ -1,6 +1,6 @@
 import { footerResourcesList, headerResourcesList } from '../index';
 
-const resourcesCount = 4;
+const resourcesCount = 5;
 
 describe('Resources List', () => {
   it('returns all the footer items', () => {

--- a/packages/gamut-labs/src/lib/resourcesList/index.ts
+++ b/packages/gamut-labs/src/lib/resourcesList/index.ts
@@ -15,6 +15,14 @@ type FooterResourceList = {
 
 export const resourcesList: ResourcesList[] = [
   {
+    id: 'docs',
+    href: '/resources/docs',
+    footerTrackingTarget: 'docs',
+    headerTrackingTarget: 'topnav_resources_docs',
+    text: 'Docs',
+    type: 'link',
+  },
+  {
     id: 'cheatsheets',
     href: '/resources/cheatsheets/all',
     footerTrackingTarget: 'cheatsheets_home',


### PR DESCRIPTION
Reverts Codecademy/client-modules#2022