### PR TITLE
fix: Revert "fix: add docs back to header and footer"

### DIFF
--- a/packages/gamut-labs/src/lib/resourcesList/__tests__/index-test.tsx
+++ b/packages/gamut-labs/src/lib/resourcesList/__tests__/index-test.tsx
@@ -1,6 +1,6 @@
 import { footerResourcesList, headerResourcesList } from '../index';
 
-const resourcesCount = 5;
+const resourcesCount = 4;
 
 describe('Resources List', () => {
   it('returns all the footer items', () => {

--- a/packages/gamut-labs/src/lib/resourcesList/index.ts
+++ b/packages/gamut-labs/src/lib/resourcesList/index.ts
@@ -15,14 +15,6 @@ type FooterResourceList = {
 
 export const resourcesList: ResourcesList[] = [
   {
-    id: 'docs',
-    href: '/resources/docs',
-    footerTrackingTarget: 'docs',
-    headerTrackingTarget: 'topnav_resources_docs',
-    text: 'Docs',
-    type: 'link',
-  },
-  {
     id: 'cheatsheets',
     href: '/resources/cheatsheets/all',
     footerTrackingTarget: 'cheatsheets_home',


### PR DESCRIPTION
Reverts Codecademy/client-modules#2024

JK We're nixing Docs from the header and footer again. lolol
(Docs errors came back to bite in THE INCIDENT TAKE 2, so we're nixing Docs for the weekend until we can root cause it effectively next Tues)