### PR TITLE
fix: Set `Card` non variant text color to ensure no inheritance GM-347

### DIFF
--- a/packages/gamut/src/Card/index.tsx
+++ b/packages/gamut/src/Card/index.tsx
@@ -10,20 +10,20 @@ const DynamicCardWrapper = styled(Box)<CardWrapperProps>(
     prop: 'shadow',
     base: {
       position: 'relative',
-      boxShadow: `0px 0px 0 ${theme.colors.secondary}`,
+      boxShadow: `0px 0px 0 currentColor`,
       transition: 'box-shadow 200ms ease, transform 200ms ease',
     },
     variants: {
       small: {
         '&:hover': {
           transform: 'translate(2px, -2px)',
-          boxShadow: `-4px 4px 0 ${theme.colors.secondary}`,
+          boxShadow: `-4px 4px 0 currentColor`,
         },
       },
       medium: {
         '&:hover': {
           transform: 'translate(4px, -4px)',
-          boxShadow: `-8px 8px 0 ${theme.colors.secondary}`,
+          boxShadow: `-8px 8px 0 currentColor`,
         },
       },
     },
@@ -80,6 +80,7 @@ export const Card: React.FC<CardProps> = ({ variant, ...rest }) => {
         border={1}
         borderColor="secondary-hover"
         bg="background"
+        color="text"
         p={16}
         {...rest}
       />


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
* Cards without a variant  didn't set text color (`Background` does this automatically, but is not used for these).  This appropriately sets them.
<!--- END-CHANGELOG-DESCRIPTION -->

<img width="1551" alt="Screen Shot 2021-09-04 at 4 16 32 PM" src="https://user-images.githubusercontent.com/52927224/132107061-5001dea8-0b15-4f21-9e4c-536fc51e413d.png">


### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: https://codecademy.atlassian.net/browse/GM-347
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
