### PR TITLE
fix(GlobalHeader): corrected 360px for notifications

### DIFF
--- a/packages/gamut-labs/src/Notifications/NotificationsContents.tsx
+++ b/packages/gamut-labs/src/Notifications/NotificationsContents.tsx
@@ -37,7 +37,6 @@ export const NotificationsContents: React.FC<NotificationsContentsProps> = (
       pb={24}
       pt={32}
       role="dialog"
-      width={360}
     >
       <FlexBox
         alignItems="center"

--- a/packages/gamut-labs/src/Notifications/NotificationsPopover.tsx
+++ b/packages/gamut-labs/src/Notifications/NotificationsPopover.tsx
@@ -19,7 +19,7 @@ export const NotificationsPopover: React.FC<NotificationsRendererProps> = ({
       onRequestClose={onClose}
       targetRef={bellRef}
     >
-      <FlexBox bg="white" textAlign="left">
+      <FlexBox bg="white" textAlign="left" width={360}>
         <NotificationsContents {...props} />
       </FlexBox>
     </Popover>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Corrects 360px width for header notifications to only apply in the desktop popover.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- ~[ ] Related to designs:~
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
