### PR TITLE
chore(styleguide): remove 'storybook' prefix from deploy URIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
           name: deploy
           command: |
             DEPLOY_MESSAGE="User: ${CIRCLE_USERNAME} Project: ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} Pull Request: ${CIRCLE_PULL_REQUEST}"
-            npx netlify-cli@2.37.0 deploy --message="${DEPLOY_MESSAGE}" --dir=dist --json > .deploy-output
+            npx netlify-cli@2.37.0 deploy --message="${DEPLOY_MESSAGE}" --dir=dist/storybook --json > .deploy-output
       - setup_remote_docker
       - run: docker pull cloudposse/github-commenter:0.5.0-58
       - run:


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Removes `storybook` from the beginning of styleguide deploy URIs by deploying what's inside that folder instead of its parent.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- ~[ ] Related to designs:~
- [x] Related to JIRA ticket: WEB-1630
- [x] I have run this code to verify it works
- ~[] This PR includes unit tests for the code change~

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
