### PR TITLE
feat(Avatar)!: convert avatar sizes to using numbers over string enum

### DIFF
--- a/packages/gamut-labs/src/Avatar/__tests__/avatar-test.tsx
+++ b/packages/gamut-labs/src/Avatar/__tests__/avatar-test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import { Avatar, avatarSizes } from '..';
+import { Avatar } from '..';
 
 describe('Avatar', () => {
   it('when an "alt" prop is passed, an "alt" attribute is added to the <img/>', () => {
@@ -21,20 +21,12 @@ describe('Avatar', () => {
   });
 
   it('when a "size" prop is passed, the <img/> height and width attributes are set accordingly', () => {
-    const wrapper = mount(<Avatar src="" alt="" size="small" />);
-    expect(
-      wrapper.find(
-        `img[height="${avatarSizes.small}"][width="${avatarSizes.small}"]`
-      )
-    ).toHaveLength(1);
+    const wrapper = mount(<Avatar src="" alt="" size={32} />);
+    expect(wrapper.find(`img[height="32px"][width="32px"]`)).toHaveLength(1);
   });
 
   it('when a "size" prop is not passed, the <img/> height and width attributes are set to the default value', () => {
     const wrapper = mount(<Avatar src="" alt="" />);
-    expect(
-      wrapper.find(
-        `img[height="${avatarSizes.medium}"][width="${avatarSizes.medium}"]`
-      )
-    ).toHaveLength(1);
+    expect(wrapper.find(`img[height="118px"][width="118px"]`)).toHaveLength(1);
   });
 });

--- a/packages/gamut-labs/src/Avatar/__tests__/avatar-test.tsx
+++ b/packages/gamut-labs/src/Avatar/__tests__/avatar-test.tsx
@@ -22,11 +22,11 @@ describe('Avatar', () => {
 
   it('when a "size" prop is passed, the <img/> height and width attributes are set accordingly', () => {
     const wrapper = mount(<Avatar src="" alt="" size={32} />);
-    expect(wrapper.find(`img[height="32px"][width="32px"]`)).toHaveLength(1);
+    expect(wrapper.find('Image').props()).toMatchObject({ dimensions: 32 });
   });
 
   it('when a "size" prop is not passed, the <img/> height and width attributes are set to the default value', () => {
     const wrapper = mount(<Avatar src="" alt="" />);
-    expect(wrapper.find(`img[height="118px"][width="118px"]`)).toHaveLength(1);
+    expect(wrapper.find('Image').props()).toMatchObject({ dimensions: 118 });
   });
 });

--- a/packages/gamut-labs/src/Avatar/__tests__/avatar-test.tsx
+++ b/packages/gamut-labs/src/Avatar/__tests__/avatar-test.tsx
@@ -22,11 +22,11 @@ describe('Avatar', () => {
 
   it('when a "size" prop is passed, the <img/> height and width attributes are set accordingly', () => {
     const wrapper = mount(<Avatar src="" alt="" size={32} />);
-    expect(wrapper.find('Image').props()).toMatchObject({ dimensions: 32 });
+    expect(wrapper.find('Image').prop('dimensions')).toBe(32);
   });
 
   it('when a "size" prop is not passed, the <img/> height and width attributes are set to the default value', () => {
     const wrapper = mount(<Avatar src="" alt="" />);
-    expect(wrapper.find('Image').props()).toMatchObject({ dimensions: 118 });
+    expect(wrapper.find('Image').prop('dimensions')).toBe(118);
   });
 });

--- a/packages/gamut-labs/src/Avatar/index.tsx
+++ b/packages/gamut-labs/src/Avatar/index.tsx
@@ -62,9 +62,9 @@ export type AvatarBaseProps = {
   disableDropshadow?: boolean;
 
   /**
-   * Size of the Avatar; small = 32x32, medium = 118x118
+   * Size of the Avatar.
    */
-  size?: 'small' | 'medium';
+  size?: 32 | 64 | 118;
 
   /**
    * Overrides styles on the Avatar container.
@@ -81,11 +81,6 @@ export type AvatarBaseProps = {
 
 export type AvatarProps = AvatarBaseProps & AvatarImageProps;
 
-export const avatarSizes = {
-  small: '32px',
-  medium: '118px',
-};
-
 export const Avatar: React.FC<AvatarProps> = ({
   mode,
   disableDropshadow,
@@ -99,10 +94,6 @@ export const Avatar: React.FC<AvatarProps> = ({
     disableDropshadow={disableDropshadow}
     data-testid="avatar-container"
   >
-    <Image
-      width={avatarSizes[size]}
-      height={avatarSizes[size]}
-      {...avatarImageProps}
-    />
+    <Image width={`${size}px`} height={`${size}px`} {...avatarImageProps} />
   </AvatarContainer>
 );

--- a/packages/gamut-labs/src/Avatar/index.tsx
+++ b/packages/gamut-labs/src/Avatar/index.tsx
@@ -64,7 +64,7 @@ export type AvatarBaseProps = {
   /**
    * Size of the Avatar.
    */
-  size?: 32 | 64 | 118;
+  size?: 32 | 48 | 64 | 118;
 
   /**
    * Overrides styles on the Avatar container.

--- a/packages/gamut-labs/src/Avatar/index.tsx
+++ b/packages/gamut-labs/src/Avatar/index.tsx
@@ -1,10 +1,11 @@
 import { VisualTheme } from '@codecademy/gamut';
-import { theme } from '@codecademy/gamut-styles';
+import { styledOptions, system, theme } from '@codecademy/gamut-styles';
+import { ResponsiveProp } from '@codecademy/variance';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
 
-const Image = styled.img();
+const Image = styled('img', styledOptions<'img'>())(system.layout);
 
 const AvatarContainer = styled.div<{
   mode?: VisualTheme;
@@ -64,7 +65,7 @@ export type AvatarBaseProps = {
   /**
    * Size of the Avatar.
    */
-  size?: 32 | 48 | 64 | 118;
+  size?: ResponsiveProp<32 | 48 | 64 | 118>;
 
   /**
    * Overrides styles on the Avatar container.
@@ -84,7 +85,7 @@ export type AvatarProps = AvatarBaseProps & AvatarImageProps;
 export const Avatar: React.FC<AvatarProps> = ({
   mode,
   disableDropshadow,
-  size = 'medium',
+  size = 118,
   className,
   ...avatarImageProps
 }) => (
@@ -94,6 +95,6 @@ export const Avatar: React.FC<AvatarProps> = ({
     disableDropshadow={disableDropshadow}
     data-testid="avatar-container"
   >
-    <Image width={`${size}px`} height={`${size}px`} {...avatarImageProps} />
+    <Image dimensions={size} {...avatarImageProps} />
   </AvatarContainer>
 );


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Changed the <Avatar /> component to using numbers directly over the string enum to give greater flexibility with size extensions
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [X] Related to designs: https://www.figma.com/file/SwfwQZmV4jtK68QaCa89h3/CC-Docs-v2---User-Recognition?node-id=452%3A61680
- [X] Related to JIRA ticket: REACH-1264
- [ ] I have run this code to verify it works
- [X] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
