### PR TITLE
feat: update landing page `CTA` to show fill button or cta button

### DIFF
--- a/packages/gamut-labs/src/LandingPage/CTA.tsx
+++ b/packages/gamut-labs/src/LandingPage/CTA.tsx
@@ -10,18 +10,11 @@ export type CTAProps = DarkModeProps & {
 };
 
 export const CTA: React.FC<CTAProps> = ({
-  href,
-  mode,
-  onCtaButtonClick,
-  buttonType,
-  children,
+  buttonType = 'cta',
+  ...buttonProps
 }) =>
   buttonType === 'regular' ? (
-    <FillButton href={href} onClick={onCtaButtonClick} mode={mode}>
-      {children}
-    </FillButton>
+    <FillButton {...buttonProps} />
   ) : (
-    <CTAButton href={href} onClick={onCtaButtonClick} mode={mode}>
-      {children}
-    </CTAButton>
+    <CTAButton {...buttonProps} />
   );

--- a/packages/gamut-labs/src/LandingPage/CTA.tsx
+++ b/packages/gamut-labs/src/LandingPage/CTA.tsx
@@ -6,14 +6,14 @@ import { DarkModeProps } from './types';
 export type CTAProps = DarkModeProps & {
   href: string;
   onCtaButtonClick?: React.MouseEventHandler;
-  buttonType?: 'cta' | 'regular';
+  buttonType?: 'cta' | 'fill';
 };
 
 export const CTA: React.FC<CTAProps> = ({
   buttonType = 'cta',
   ...buttonProps
 }) =>
-  buttonType === 'regular' ? (
+  buttonType === 'fill' ? (
     <FillButton {...buttonProps} />
   ) : (
     <CTAButton {...buttonProps} />

--- a/packages/gamut-labs/src/LandingPage/CTA.tsx
+++ b/packages/gamut-labs/src/LandingPage/CTA.tsx
@@ -1,24 +1,27 @@
-import { Box, CTAButton } from '@codecademy/gamut';
+import { CTAButton, FillButton } from '@codecademy/gamut';
 import React from 'react';
 
 import { DarkModeProps } from './types';
 
 export type CTAProps = DarkModeProps & {
   href: string;
-  className?: string;
   onCtaButtonClick?: React.MouseEventHandler;
+  buttonType?: 'cta' | 'regular';
 };
 
 export const CTA: React.FC<CTAProps> = ({
   href,
   mode,
-  className,
   onCtaButtonClick,
+  buttonType,
   children,
-}) => (
-  <Box mt={32} className={className}>
+}) =>
+  buttonType === 'regular' ? (
+    <FillButton href={href} onClick={onCtaButtonClick} mode={mode}>
+      {children}
+    </FillButton>
+  ) : (
     <CTAButton href={href} onClick={onCtaButtonClick} mode={mode}>
       {children}
     </CTAButton>
-  </Box>
-);
+  );

--- a/packages/gamut-labs/src/LandingPage/PageFeatures.tsx
+++ b/packages/gamut-labs/src/LandingPage/PageFeatures.tsx
@@ -107,9 +107,11 @@ export const PageFeatures: React.FC<PageFeaturesProps> = ({
       {title && <Title isPageHeading={false}>{title}</Title>}
       {desc && <Description text={desc} onAnchorClick={onAnchorClick} />}
       {cta && (
-        <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
-          {cta.text}
-        </CTA>
+        <Box mt={32}>
+          <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
+            {cta.text}
+          </CTA>
+        </Box>
       )}
     </div>
     <Box mt={16}>

--- a/packages/gamut-labs/src/LandingPage/PageFeatures.tsx
+++ b/packages/gamut-labs/src/LandingPage/PageFeatures.tsx
@@ -108,7 +108,11 @@ export const PageFeatures: React.FC<PageFeaturesProps> = ({
       {desc && <Description text={desc} onAnchorClick={onAnchorClick} />}
       {cta && (
         <Box mt={32}>
-          <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
+          <CTA
+            href={cta.href}
+            onCtaButtonClick={cta.onClick}
+            buttonType={cta.buttonType}
+          >
             {cta.text}
           </CTA>
         </Box>

--- a/packages/gamut-labs/src/LandingPage/PageHero.tsx
+++ b/packages/gamut-labs/src/LandingPage/PageHero.tsx
@@ -3,6 +3,7 @@ import {
   Column,
   ColumnProps,
   LayoutGrid,
+  Text,
   VideoProps,
 } from '@codecademy/gamut';
 import styled from '@emotion/styled';

--- a/packages/gamut-labs/src/LandingPage/PageHero.tsx
+++ b/packages/gamut-labs/src/LandingPage/PageHero.tsx
@@ -82,7 +82,11 @@ export const PageHero: React.FC<PageHeroProps> = ({
         {desc && <Description text={desc} onAnchorClick={onAnchorClick} />}
         {cta && (
           <Box mt={32}>
-            <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
+            <CTA
+              href={cta.href}
+              onCtaButtonClick={cta.onClick}
+              buttonType={cta.buttonType}
+            >
               {cta.text}
             </CTA>
           </Box>

--- a/packages/gamut-labs/src/LandingPage/PageHero.tsx
+++ b/packages/gamut-labs/src/LandingPage/PageHero.tsx
@@ -1,4 +1,10 @@
-import { Column, ColumnProps, LayoutGrid, VideoProps } from '@codecademy/gamut';
+import {
+  Box,
+  Column,
+  ColumnProps,
+  LayoutGrid,
+  VideoProps,
+} from '@codecademy/gamut';
 import styled from '@emotion/styled';
 import React from 'react';
 
@@ -75,9 +81,11 @@ export const PageHero: React.FC<PageHeroProps> = ({
         {title && <Title isPageHeading>{title}</Title>}
         {desc && <Description text={desc} onAnchorClick={onAnchorClick} />}
         {cta && (
-          <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
-            {cta.text}
-          </CTA>
+          <Box mt={32}>
+            <CTA href={cta.href} onCtaButtonClick={cta.onClick}>
+              {cta.text}
+            </CTA>
+          </Box>
         )}
       </LeftColumn>
       {media && <PageHeroMedia media={media} size={right} />}

--- a/packages/gamut-labs/src/LandingPage/PagePrefooter.tsx
+++ b/packages/gamut-labs/src/LandingPage/PagePrefooter.tsx
@@ -1,29 +1,10 @@
-import { Container } from '@codecademy/gamut';
-import { mediaQueries } from '@codecademy/gamut-styles';
-import styled from '@emotion/styled';
+import { Box, FlexBox } from '@codecademy/gamut';
 import React from 'react';
 
 import { CTA } from './CTA';
 import { Description } from './Description';
 import { Title } from './Title';
 import { BaseProps, DarkModeProps } from './types';
-
-const FlexContainer = styled(Container)`
-  ${mediaQueries.sm} {
-    flex-direction: row;
-    align-items: center;
-  }
-`;
-
-const FlexContent = styled.div`
-  flex: 1;
-`;
-
-const StyledCTA = styled(CTA)`
-  ${mediaQueries.sm} {
-    margin: 0 0 0 2rem;
-  }
-`;
 
 export const PagePrefooter: React.FC<BaseProps & DarkModeProps> = ({
   title,
@@ -39,15 +20,27 @@ export const PagePrefooter: React.FC<BaseProps & DarkModeProps> = ({
   );
 
   return cta ? (
-    <FlexContainer data-testid={testId} nowrap column justify="spaceBetween">
-      <FlexContent>
+    <FlexBox
+      data-testid={testId}
+      flexDirection={{ _: 'column', sm: 'row' }}
+      justifyContent="space-between"
+      alignItems={{ sm: 'center' }}
+    >
+      <Box flex={1}>
         {SectionTitle}
         {Desc}
-      </FlexContent>
-      <StyledCTA href={cta.href} onCtaButtonClick={cta.onClick} mode={mode}>
-        {cta.text}
-      </StyledCTA>
-    </FlexContainer>
+      </Box>
+      <Box mt={{ _: 32, sm: 0 }} ml={{ sm: 32 }}>
+        <CTA
+          href={cta.href}
+          onCtaButtonClick={cta.onClick}
+          mode={mode}
+          buttonType={cta.buttonType}
+        >
+          {cta.text}
+        </CTA>
+      </Box>
+    </FlexBox>
   ) : (
     <div data-testid={testId}>
       {SectionTitle}

--- a/packages/gamut-labs/src/LandingPage/PageVideoGallery.tsx
+++ b/packages/gamut-labs/src/LandingPage/PageVideoGallery.tsx
@@ -1,4 +1,4 @@
-import { Video } from '@codecademy/gamut';
+import { Box, Video } from '@codecademy/gamut';
 import { mediaQueries } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
 import React from 'react';
@@ -63,11 +63,7 @@ export const PageVideoGallery: React.FC<PageVideoGalleryProps> = ({
   testId,
 }) => (
   <div>
-    {title && (
-      <Title mode={mode} isPageHeading>
-        {title}
-      </Title>
-    )}
+    {title && <Title mode={mode}>{title}</Title>}
     {desc && (
       <StyledDesc text={desc} onAnchorClick={onAnchorClick} mode={mode} />
     )}
@@ -82,9 +78,16 @@ export const PageVideoGallery: React.FC<PageVideoGalleryProps> = ({
       ))}
     </Grid>
     {cta && (
-      <CTA href={cta.href} onCtaButtonClick={cta.onClick} mode={mode}>
-        {cta.text}
-      </CTA>
+      <Box mt={32}>
+        <CTA
+          href={cta.href}
+          onCtaButtonClick={cta.onClick}
+          mode={mode}
+          buttonType={cta.buttonType}
+        >
+          {cta.text}
+        </CTA>
+      </Box>
     )}
   </div>
 );

--- a/packages/gamut-labs/src/LandingPage/types.tsx
+++ b/packages/gamut-labs/src/LandingPage/types.tsx
@@ -17,7 +17,7 @@ export type BaseProps = {
    *
    * onClick: callback when the button is clicked
    *
-   * buttonType: whether to show a CTA button or a regular fill button
+   * buttonType: whether to show a CTA button or a regular fill button, defaults to CTA button
    */
   cta?: {
     text: string;

--- a/packages/gamut-labs/src/LandingPage/types.tsx
+++ b/packages/gamut-labs/src/LandingPage/types.tsx
@@ -23,7 +23,7 @@ export type BaseProps = {
     text: string;
     href: string;
     onClick?: React.MouseEventHandler;
-    buttonType?: 'cta' | 'regular';
+    buttonType?: 'cta' | 'fill';
   };
 
   testId?: string;

--- a/packages/gamut-labs/src/LandingPage/types.tsx
+++ b/packages/gamut-labs/src/LandingPage/types.tsx
@@ -16,12 +16,16 @@ export type BaseProps = {
    * href: url to navigate to when clicking the button
    *
    * onClick: callback when the button is clicked
+   *
+   * buttonType: whether to show a CTA button or a regular fill button
    */
   cta?: {
     text: string;
     href: string;
     onClick?: React.MouseEventHandler;
+    buttonType?: 'cta' | 'regular';
   };
+
   testId?: string;
 };
 

--- a/packages/styleguide/stories/Brand/Organisms/PageFeatures.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageFeatures.stories.mdx
@@ -160,6 +160,8 @@ Omit the `desc` prop to not show a description. You can also omit the `desc` pro
 
 ## Regular Button
 
+Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
+
 <Canvas>
   <Story
     name="Regular Button"

--- a/packages/styleguide/stories/Brand/Organisms/PageFeatures.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageFeatures.stories.mdx
@@ -160,7 +160,7 @@ Omit the `desc` prop to not show a description. You can also omit the `desc` pro
 
 ## Regular Button
 
-Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
+Pass `buttonType` as `fill` to show a `FillButton` instead of the larger `CTAButton`. Text should always be Call to Action text regardless of button type.
 
 <Canvas>
   <Story
@@ -173,7 +173,7 @@ Pass `buttonType` as `regular` to show a regular `FillButton` instead of the lar
       <PageFeatures
         {...args}
         features={args.features.slice(0, 3)}
-        cta={{ ...args.cta, buttonType: 'regular' }}
+        cta={{ ...args.cta, buttonType: 'fill' }}
       />
     )}
   </Story>

--- a/packages/styleguide/stories/Brand/Organisms/PageFeatures.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageFeatures.stories.mdx
@@ -55,6 +55,8 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
   }}
 />
 
+<br />
+
 ## Featured Info
 
 Display text-only featurettes with no media associated.
@@ -90,7 +92,30 @@ Small icons can be used instead of full size images by setting the `featuresMedi
 Promote a single stat by setting the `featuresMedia` prop to `stat` and providing `statText`.
 
 <Canvas>
-  <Story name="Featured Stats" args={{ featuresMedia: 'stat' }}>
+  <Story
+    name="Featured Stats"
+    args={{
+      featuresMedia: 'stat',
+      features: [
+        {
+          statText: '45 mil.',
+          title: 'Software Engineer',
+        },
+        {
+          statText: '170',
+          title: 'Data Scientist',
+        },
+        {
+          statText: '200+',
+          title: 'Product Manager',
+        },
+        {
+          statText: '100%',
+          title: 'Product Designer',
+        },
+      ],
+    }}
+  >
     {(args) => <PageFeatures {...args} />}
   </Story>
 </Canvas>
@@ -102,5 +127,52 @@ If you specify a `maxCols` the features at desktop will wrap at that number of c
 <Canvas>
   <Story name="Features Grid" args={{ maxCols: 3, featuresMedia: 'icon' }}>
     {(args) => <PageFeatures {...args} />}
+  </Story>
+</Canvas>
+
+## Without Description
+
+Omit the `desc` prop to not show a description. You can also omit the `desc` prop on each object in the features array to not show a featured item description.
+
+<Canvas>
+  <Story
+    name="Without Description"
+    args={{
+      featuresMedia: 'icon',
+      desc: undefined,
+      features: [
+        {
+          imgSrc: 'https://content.codecademy.com/courses/free/boba.svg',
+          imgAlt: 'Codey boba tea',
+          title: 'Software Engineer',
+        },
+        {
+          imgSrc: 'https://content.codecademy.com/courses/free/boba.svg',
+          imgAlt: 'Codey boba tea',
+          title: 'Data Scientist',
+        },
+      ],
+    }}
+  >
+    {(args) => <PageFeatures {...args} />}
+  </Story>
+</Canvas>
+
+## Regular Button
+
+<Canvas>
+  <Story
+    name="Regular Button"
+    args={{
+      featuresMedia: 'image',
+    }}
+  >
+    {(args) => (
+      <PageFeatures
+        {...args}
+        features={args.features.slice(0, 3)}
+        cta={{ ...args.cta, buttonType: 'regular' }}
+      />
+    )}
   </Story>
 </Canvas>

--- a/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
@@ -37,18 +37,26 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
   }}
 />
 
-## With CTA
-
 <Canvas>
-  <Story name="With CTA">{(args) => <PageHero {...args} />}</Story>
+  <Story name="Page Hero">{(args) => <PageHero {...args} />}</Story>
 </Canvas>
 
-<PropsTable story="With CTA" />
+<PropsTable story="Page Hero" />
 
-## Without CTA
+## Regular Button
 
 <Canvas>
-  <Story name="Without CTA">
+  <Story name="Regular Button">
+    {(args) => (
+      <PageHero {...args} cta={{ ...args.cta, buttonType: 'regular' }} />
+    )}
+  </Story>
+</Canvas>
+
+## Without Button
+
+<Canvas>
+  <Story name="Without Button">
     {(args) => <PageHero {...args} cta={undefined} />}
   </Story>
 </Canvas>

--- a/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
@@ -67,13 +67,11 @@ Change the `media` prop to `type: video` and pass required video props to show a
 
 ## Regular Button
 
-Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
+Pass `buttonType` as `fill` to show a `FillButton` instead of the larger `CTAButton`. Text should always be Call to Action text regardless of button type.
 
 <Canvas>
   <Story name="Regular Button">
-    {(args) => (
-      <PageHero {...args} cta={{ ...args.cta, buttonType: 'regular' }} />
-    )}
+    {(args) => <PageHero {...args} cta={{ ...args.cta, buttonType: 'fill' }} />}
   </Story>
 </Canvas>
 

--- a/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
@@ -43,28 +43,12 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 <PropsTable story="Page Hero" />
 
-## Regular Button
+## Video
+
+Change the `media` prop to `type: video` and pass required video props to show a video in the hero.
 
 <Canvas>
-  <Story name="Regular Button">
-    {(args) => (
-      <PageHero {...args} cta={{ ...args.cta, buttonType: 'regular' }} />
-    )}
-  </Story>
-</Canvas>
-
-## Without Button
-
-<Canvas>
-  <Story name="Without Button">
-    {(args) => <PageHero {...args} cta={undefined} />}
-  </Story>
-</Canvas>
-
-## With Video
-
-<Canvas>
-  <Story name="With Video">
+  <Story name="Video">
     {(args) => (
       <PageHero
         {...args}
@@ -78,5 +62,37 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
         title="What's it like to be a Software Engineer"
       />
     )}
+  </Story>
+</Canvas>
+
+## Regular Button
+
+Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
+
+<Canvas>
+  <Story name="Regular Button">
+    {(args) => (
+      <PageHero {...args} cta={{ ...args.cta, buttonType: 'regular' }} />
+    )}
+  </Story>
+</Canvas>
+
+## Without Button
+
+Omit the `cta` prop to not show a button.
+
+<Canvas>
+  <Story name="Without Button">
+    {(args) => <PageHero {...args} cta={undefined} />}
+  </Story>
+</Canvas>
+
+## Without Description
+
+Omit the `desc` prop to not show a description.
+
+<Canvas>
+  <Story name="Without Description">
+    {(args) => <PageHero {...args} desc={undefined} />}
   </Story>
 </Canvas>

--- a/packages/styleguide/stories/Brand/Organisms/PagePrefooter.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PagePrefooter.stories.mdx
@@ -42,10 +42,7 @@ Pass `buttonType` as `regular` to show a regular `FillButton` instead of the lar
 <Canvas>
   <Story name="Regular Button">
     {(args) => (
-      <PagePrefooter
-        {...args}
-        cta={{ text: 'Click Me', href: '#', buttonType: 'regular' }}
-      />
+      <PagePrefooter {...args} cta={{ ...args.cta, buttonType: 'regular' }} />
     )}
   </Story>
 </Canvas>

--- a/packages/styleguide/stories/Brand/Organisms/PagePrefooter.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PagePrefooter.stories.mdx
@@ -37,12 +37,12 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 ## Regular Button
 
-Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
+Pass `buttonType` as `fill` to show a `FillButton` instead of the larger `CTAButton`. Text should always be Call to Action text regardless of button type.
 
 <Canvas>
   <Story name="Regular Button">
     {(args) => (
-      <PagePrefooter {...args} cta={{ ...args.cta, buttonType: 'regular' }} />
+      <PagePrefooter {...args} cta={{ ...args.cta, buttonType: 'fill' }} />
     )}
   </Story>
 </Canvas>

--- a/packages/styleguide/stories/Brand/Organisms/PagePrefooter.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PagePrefooter.stories.mdx
@@ -1,3 +1,4 @@
+import { Box } from '@codecademy/gamut/src';
 import { PagePrefooter } from '@codecademy/gamut-labs/src';
 import title from '@codecademy/macros/lib/title.macro';
 import { PropsTable } from '@codecademy/storybook-addon-variance';
@@ -28,18 +29,57 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
   }}
 />
 
-## With CTA
-
 <Canvas>
-  <Story name="With CTA">{(args) => <PagePrefooter {...args} />}</Story>
+  <Story name="Prefooter">{(args) => <PagePrefooter {...args} />}</Story>
 </Canvas>
 
-<PropsTable story="With CTA" />
+<PropsTable story="Prefooter" />
 
-## Without CTA
+## Regular Button
+
+Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
 
 <Canvas>
-  <Story name="Without CTA">
+  <Story name="Regular Button">
+    {(args) => (
+      <PagePrefooter
+        {...args}
+        cta={{ text: 'Click Me', href: '#', buttonType: 'regular' }}
+      />
+    )}
+  </Story>
+</Canvas>
+
+## Dark Mode
+
+Pass the `mode` prop as `'dark'` to use dark mode, which swaps the text color to beige and button to yellow.
+
+<Canvas>
+  <Story name="Dark Mode">
+    {(args) => (
+      <Box bg="navy" p={16}>
+        <PagePrefooter {...args} mode="dark" />
+      </Box>
+    )}
+  </Story>
+</Canvas>
+
+## Without Button
+
+Omit the `cta` prop to not show a button.
+
+<Canvas>
+  <Story name="Without Button">
     {(args) => <PagePrefooter {...args} cta={undefined} />}
+  </Story>
+</Canvas>
+
+## Without Description
+
+Omit the `desc` prop to not show a description.
+
+<Canvas>
+  <Story name="Without Description">
+    {(args) => <PagePrefooter {...args} desc={undefined} />}
   </Story>
 </Canvas>

--- a/packages/styleguide/stories/Brand/Organisms/PageVideoGallery.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageVideoGallery.stories.mdx
@@ -42,15 +42,26 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
   }}
 />
 
-## With title, desc, and CTA
-
 <Canvas>
-  <Story name="With Title, Desc, CTA">
-    {(args) => <PageVideoGallery {...args} />}
-  </Story>
+  <Story name="Video Gallery">{(args) => <PageVideoGallery {...args} />}</Story>
 </Canvas>
 
-<PropsTable story="With Title, Desc, CTA" />
+<PropsTable story="Video Gallery" />
+
+## Regular Button
+
+Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
+
+<Canvas>
+  <Story name="Regular Button">
+    {(args) => (
+      <PageVideoGallery
+        {...args}
+        cta={{ ...args.cta, buttonType: 'regular' }}
+      />
+    )}
+  </Story>
+</Canvas>
 
 ## Gallery only
 

--- a/packages/styleguide/stories/Brand/Organisms/PageVideoGallery.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageVideoGallery.stories.mdx
@@ -50,15 +50,12 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 ## Regular Button
 
-Pass `buttonType` as `regular` to show a regular `FillButton` instead of the larger `CTAButton`.
+Pass `buttonType` as `fill` to show a `FillButton` instead of the larger `CTAButton`. Text should always be Call to Action text regardless of button type.
 
 <Canvas>
   <Story name="Regular Button">
     {(args) => (
-      <PageVideoGallery
-        {...args}
-        cta={{ ...args.cta, buttonType: 'regular' }}
-      />
+      <PageVideoGallery {...args} cta={{ ...args.cta, buttonType: 'fill' }} />
     )}
   </Story>
 </Canvas>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Updates `CTA` to take a `buttonType` prop to determine whether to show a `CTAButton` (default) or a regular `FillButton`. Also refactors `PagePrefooter` to use newer gamut components.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/J5yB1jyELiNt3Vb47T9GcE/Job-Readiness?node-id=2%3A43
- [x] Related to JIRA ticket: [REACH-1327]
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
