### PR TITLE
feat(PageHero): add ability to use as subheader

### DIFF
--- a/packages/gamut-labs/src/LandingPage/PageHero.tsx
+++ b/packages/gamut-labs/src/LandingPage/PageHero.tsx
@@ -37,6 +37,7 @@ export type PageHeroProps = BaseProps & {
   media?: MediaProps;
   textLength: 'short' | 'long';
   showImageOnMobile?: boolean;
+  isSubheader?: boolean;
 };
 
 const getColumnLayout = (
@@ -76,6 +77,7 @@ export const PageHero: React.FC<PageHeroProps> = ({
   media,
   textLength,
   showImageOnMobile,
+  isSubheader,
   testId,
   onAnchorClick,
 }) => {
@@ -84,7 +86,7 @@ export const PageHero: React.FC<PageHeroProps> = ({
   return (
     <LayoutGrid data-testid={testId} rowGap={16} columnGap={{ _: 8, sm: 32 }}>
       <Column size={{ sm: left }} alignContent="flex-start">
-        {title && <Title isPageHeading>{title}</Title>}
+        {title && <Title isPageHeading={!isSubheader}>{title}</Title>}
         {desc && <Description text={desc} onAnchorClick={onAnchorClick} />}
         {cta && (
           <CTA href={cta.href} onCtaButtonClick={cta.onClick}>

--- a/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
+++ b/packages/styleguide/stories/Brand/Organisms/PageHero.stories.mdx
@@ -87,3 +87,20 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
     {(args) => <PageHero {...args} showImageOnMobile />}
   </Story>
 </Canvas>
+
+## Subheader
+
+<Canvas>
+  <Story name="Subheader">
+    {(args) => (
+      <PageHero
+        {...args}
+        title="Short Headline"
+        desc="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Amet dolor in porta adipiscing euismod id sodales velit. Consequat, nibh quam suscipit pharetra, lacus nam. Elit ullamcorper magna ultricies cursus tempus amet. Urna, sagittis lobortis sit quis nibh facilisis euismod dolor. Dolor iaculis congue sit pharetra. A lorem sed dapibus est vel eros mauris malesuada tortor."
+        isSubheader
+        textLength="short"
+        buttonType="regular"
+      />
+    )}
+  </Story>
+</Canvas>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Changes the default title being the page header to an optional prop `isSubheader`.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/J5yB1jyELiNt3Vb47T9GcE/Job-Readiness?node-id=58%3A615
- [x] Related to JIRA ticket: [REACH-1326]
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
