### PR TITLE
fix(Drawer): add 100% height to inner Box

### DIFF
--- a/packages/gamut-labs/src/Drawer/index.tsx
+++ b/packages/gamut-labs/src/Drawer/index.tsx
@@ -36,7 +36,7 @@ export const Drawer: React.FC<DrawerProps> = ({
           transition={{ duration: timingValues.slow / 1000 }}
           {...props}
         >
-          <Box left="0" position="absolute" width={fullWidth}>
+          <Box height="100%" left="0" position="absolute" width={fullWidth}>
             {children}
           </Box>
         </DrawerBase>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Adds 100% height to the intermediate `Box` within `Drawer`.

<!--- END-CHANGELOG-DESCRIPTION -->

I'd missed this in https://github.com/Codecademy/client-modules/pull/2083, it needs to be there so tall content can have a vertical scrollbar.

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: GM-378 WEB-1417
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
