### PR TITLE
fix: changing logic of Business Account Management profile item to use `isBusinessAdmin`

### DIFF
--- a/packages/gamut-labs/src/GlobalHeader/GlobalHeaderItems.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/GlobalHeaderItems.tsx
@@ -277,7 +277,7 @@ export const proProfile = (
   isMobile?: boolean
 ): AppHeaderProfileDropdownItem => {
   const topSection = [profileMyProfile, profileAccount, profileMyHome];
-  if (!isMobile && (user.isAccountManager || user.isAdmin)) {
+  if (!isMobile && (user.isAccountManager || user.isBusinessAdmin)) {
     topSection.push(profileBusinessAccount);
   }
   if (user.showReferrals) {


### PR DESCRIPTION
### Overview
As part of a wider security initiative we are restricting Business access to a new `business_admin` role. This PR is using this role for controlling visibility of the `Business Account Management` dropdown menu item.

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [EN-1224](https://codecademy.atlassian.net/browse/EN-1224)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
