### PR TITLE
fix(FormGroupLabel): 

### DIFF
--- a/packages/gamut/src/Form/FormGroupLabel.tsx
+++ b/packages/gamut/src/Form/FormGroupLabel.tsx
@@ -39,7 +39,7 @@ const labelStates = states({
   tooltipPadding: { mr: 16 },
 });
 
-interface LabelVariants
+export interface LabelVariants
   extends StyleProps<typeof labelSizeVariants>,
     StyleProps<typeof labelStates> {}
 

--- a/packages/gamut/src/Form/FormGroupLabel.tsx
+++ b/packages/gamut/src/Form/FormGroupLabel.tsx
@@ -6,6 +6,7 @@ import React, { HTMLAttributes } from 'react';
 
 import { FlexBox } from '..';
 import { ToolTip, ToolTipProps } from '../ToolTip';
+import { FormGroupProps } from '.';
 import { formBaseStyles, formFieldTextDisabledStyles } from './styles';
 
 const StyledToolTipContainer = styled.span`
@@ -39,7 +40,7 @@ const labelStates = states({
   tooltipPadding: { mr: 16 },
 });
 
-export interface LabelVariants
+interface LabelVariants
   extends StyleProps<typeof labelSizeVariants>,
     StyleProps<typeof labelStates> {}
 
@@ -55,16 +56,7 @@ export type FormGroupLabelProps = HTMLAttributes<HTMLDivElement> &
     size?: 'small' | 'large';
   };
 
-const Label = styled
-  .label(labelSizeVariants, labelStates)
-  .withComponent((props: FormGroupLabelProps) => {
-    if (props.htmlFor) {
-      // We know this is wrong because props.htmlFor exists...
-      // eslint-disable-next-line jsx-a11y/label-has-associated-control
-      return <label {...props} />;
-    }
-    return <div {...props} />;
-  });
+const Label = styled.label<FormGroupLabelProps>(labelSizeVariants, labelStates);
 
 export const FormGroupLabel: React.FC<FormGroupLabelProps> = ({
   children,
@@ -85,6 +77,7 @@ export const FormGroupLabel: React.FC<FormGroupLabelProps> = ({
         tooltipPadding={Boolean(tooltip)}
         className={className}
         size={size}
+        as={htmlFor ? 'label' : 'div'}
       >
         {children}
         {showRequired ? ' *' : ''}


### PR DESCRIPTION
### Overview

Passing props through .withComponent is causing some console error (cos tooltipPadding is passing through to the DOM div/label element). This fixes that.

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
