### PR TITLE
fix: use old style existence check for navigator.sendBeacon

### DIFF
--- a/packages/tracking/src/events/track.ts
+++ b/packages/tracking/src/events/track.ts
@@ -24,7 +24,9 @@ export const createTracker = ({ apiBaseUrl, verbose }: TrackerOptions) => {
     }
 
     // Firefox allows users to disable navigator.sendBeacon, and very old Safari versions don't have it.
-    if (navigator.sendBeacon?.(uri, form)) {
+    // [WEB-1700]: Additionally, Chrome 79-80 gives "Illegal invocation" with ?., so through 2022 we should support them.
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+    if (navigator.sendBeacon && navigator.sendBeacon(uri, form)) {
       return;
     }
 


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Uses `&&` instead of `?.` to check whether `navigator.sendBeacon` exists.

<!--- END-CHANGELOG-DESCRIPTION -->

We investigated using the steps in [Frontend Error Reporting](https://www.notion.so/codecademy/Frontend-Error-Reporting-cfc3a3426b9544849dbcec36480e6f8d):
1. The stack trace itself (copied to the Jira ticket) points at a call like `r && r.call(`
2. `r` is assigned to `navigator.sendBeacon`
3. The only place we use `sendBeacon` anywhere is in `track.ts`, whose contents do match up with the minified source

Seems to be from `navigator.sendBeacon?.(...)` being called. We couldn't repro it on the latest Chrome, but Dataog showed that it only happens in Chrome 79 and 80. I couldn't repro that in Browserstack either. I suppose we should support them for a few seasons more.

### PR Checklist

- [x] Related to JIRA ticket: WEB-1700
- [x] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

Co-authored-by: Charlie Bliss <cbliss@codecademy.com>
Co-authored-by: Katie Zutter <katelyn@codeacademy.com>
Co-authored-by: Melanie Mohn <mmohn@codecademy.com>
Co-authored-by: Sanam Aghdaey <sanam@codecademy.com>
Co-authored-by: Sylvana Santos <sylvana@codecademy.com>
