### PR TITLE
chore: bumped babel-preset-codecademy to 5.0.1

### DIFF
--- a/packages/babel-preset-codecademy/package.json
+++ b/packages/babel-preset-codecademy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-codecademy",
-  "version": "4.0.2",
+  "version": "5.0.1",
   "description": "A collection of babel plugins and presets used at codecademy.com",
   "main": "index.js",
   "keywords": [

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.13.10",
     "@types/fetch-mock": "^7.3.3",
     "@types/jest": "^26.0.15",
-    "babel-preset-codecademy": "^4.0.2",
+    "babel-preset-codecademy": "^5.0.1",
     "fetch-mock": "^9.11.0",
     "jest-fetch-mock": "^3.0.3",
     "ts-jest": "^26.4.1",


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Version bump only.

<!--- END-CHANGELOG-DESCRIPTION -->

I'm seeing publish failures on main: https://app.circleci.com/pipelines/github/Codecademy/client-modules/23/workflows/0ec1625e-3c11-498a-9003-602e29ecea3a/jobs/133

```
lerna ERR! Error: Command failed: git tag babel-preset-codecademy@5.0.0 -m babel-preset-codecademy@5.0.0
lerna ERR! fatal: tag 'babel-preset-codecademy@5.0.0' already exists
lerna ERR! 
lerna ERR!     at makeError (/home/circleci/repo/node_modules/execa/index.js:174:9)
lerna ERR!     at /home/circleci/repo/node_modules/execa/index.js:278:16
lerna ERR!     at runMicrotasks (<anonymous>)
lerna ERR!     at processTicksAndRejections (internal/process/task_queues.js:95:5)
lerna ERR!     at async Promise.all (index 0)
```

so pushing the tag to 5.0.1 🤷 