### PR TITLE
fix(tracking): super-bind the sendBeacon to navigator

### DIFF
--- a/packages/tracking/src/events/track.ts
+++ b/packages/tracking/src/events/track.ts
@@ -24,9 +24,12 @@ export const createTracker = ({ apiBaseUrl, verbose }: TrackerOptions) => {
     }
 
     // Firefox allows users to disable navigator.sendBeacon, and very old Safari versions don't have it.
-    // [WEB-1700]: Additionally, Chrome 79-80 gives "Illegal invocation" with ?., so through 2022 we should support them.
-    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-    if (navigator.sendBeacon && navigator.sendBeacon(uri, form)) {
+    const sendBeacon =
+      // [WEB-1700]: Additionally, Chrome 79-80 gives "Illegal invocation" with ?., so through 2022 we should support them.
+      // It seems similar to this: https://github.com/vercel/next.js/issues/23856
+      // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+      navigator.sendBeacon && navigator.sendBeacon.bind(navigator);
+    if (sendBeacon?.(uri, form)) {
       return;
     }
 


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Another attempt to fix our `navigator.sendBeacon` `IllegalInvocation` woes.

<!--- END-CHANGELOG-DESCRIPTION -->

Uses the same solution from https://github.com/vercel/next.js/issues/23856 to bind `sendBeacon` to `navigator` explicitly so that Chrome <=80 stops throwing scope issues.

### PR Checklist

- [x] Related to JIRA ticket: WEB-1700
- [ ] I have run this code to verify it works
- ~[ ] This PR includes unit tests for the code change~

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
