### PR TITLE
fix(eslint-config): disable react/prop-types in TypeScript files

### DIFF
--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -14,6 +14,9 @@ const tsConfig = {
     // These off-by-default or configurable rules are good and we like having them on
     '@typescript-eslint/non-nullable-type-assertion-style': 'error',
     '@typescript-eslint/prefer-optional-chain': 'error',
+
+    // These are no longer necessary now that we have TypeScript
+    'react/prop-types': 'off',
   },
 };
 


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

TypeScript files don't need to check `react/prop-types`, so this disables that rule in them.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to JIRA ticket: WEB-1713
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
