### PR TITLE
chore: use width 100 for iframe

### DIFF
--- a/packages/codebytes/src/codeByteEditor.tsx
+++ b/packages/codebytes/src/codeByteEditor.tsx
@@ -13,7 +13,7 @@ import { trackUserImpression } from './libs/eventTracking';
 import { CodeByteEditorProps } from './types';
 
 const editorStates = states({
-  isIFrame: { height: '100vh' },
+  isIFrame: { height: '100vh', width: '100%' },
 });
 
 const editorBaseStyles = system.css({


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

Small change to make the width 100% for the iframe version so it takes up the full width and length of the page. Prior to this, we were getting a fixed width. 

### PR Checklist

- [x] I have run this code to verify it works

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
