### PR TITLE
fix(codebytes): semantic text color

### DIFF
--- a/packages/codebytes/src/editor.tsx
+++ b/packages/codebytes/src/editor.tsx
@@ -26,7 +26,7 @@ const Output = styled.pre<{ hasError: boolean }>`
   font-size: 0.875rem;
   overflow: auto;
   ${({ hasError, theme }) => `
-  color: ${hasError ? theme.colors.orange : theme.colors.white};
+  color: ${hasError ? theme.colors.orange : theme.colors.text};
   background-color: ${theme.colors['navy-900']};
 `}
 `;


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

Really small pull request to use the semantic color text for white text. Using `theme.colors.white` was breaking in portal-app, weirdly, but cass mentioned we're trying to move to more semantic names anyways.  

### PR Checklist
- [x] I have run this code to verify it works
<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
