### PR TITLE
fix: remove get options from client modules

### DIFF
--- a/packages/codebytes/src/__tests__/codebyte-test.tsx
+++ b/packages/codebytes/src/__tests__/codebyte-test.tsx
@@ -2,14 +2,12 @@ import './mocks';
 
 import { setupRtl } from '@codecademy/gamut-tests';
 import userEvent from '@testing-library/user-event';
-import { encode } from 'js-base64';
 import React from 'react';
 
 import { CodeByteEditor } from '..';
 import { helloWorld, validLanguages } from '../consts';
 import { trackClick } from '../helpers';
 import { trackUserImpression } from '../libs/eventTracking';
-import { CodeByteEditorProps } from '../types';
 
 const mockEditorTestId = 'mock-editor-test-id';
 
@@ -37,31 +35,6 @@ jest.mock('../MonacoEditor', () => ({
 }));
 
 const renderWrapper = setupRtl(CodeByteEditor, {});
-
-type RenderWrapperWithProps = CodeByteEditorProps & { mode?: string };
-
-const renderWrapperWith = ({ mode, ...rest }: RenderWrapperWithProps) => {
-  const url = new URL(window.location.href);
-
-  const { text, language } = rest;
-  if (text) {
-    url.searchParams.set('text', encode(text));
-  }
-  if (language) {
-    url.searchParams.set('lang', language);
-  }
-  url.searchParams.set('client-name', 'forum');
-  url.searchParams.set(
-    'page',
-    'https://discuss.codecademy.com/some-interesting/post'
-  );
-  if (mode) {
-    url.searchParams.set('mode', mode);
-  }
-  window.history.replaceState({}, '', url.toString());
-
-  return renderWrapper(rest);
-};
 
 describe('CodeBytes', () => {
   const initialUrl = window.location.href;

--- a/packages/codebytes/src/__tests__/codebyte-test.tsx
+++ b/packages/codebytes/src/__tests__/codebyte-test.tsx
@@ -127,7 +127,7 @@ describe('CodeBytes', () => {
       expect(trackClick).toHaveBeenCalledWith('lang_select', undefined);
     });
 
-    it('triggers trackClick for the first edit in view mode', () => {
+    it('triggers trackClick for the first edit', () => {
       const testString = 'original-value';
       const { view } = renderWrapper({
         text: testString,

--- a/packages/codebytes/src/__tests__/codebyte-test.tsx
+++ b/packages/codebytes/src/__tests__/codebyte-test.tsx
@@ -167,24 +167,15 @@ describe('CodeBytes', () => {
       expect(trackClick).toHaveBeenCalledWith('edit', undefined);
     });
 
-    it('triggers trackUserImpression for view mode', () => {
-      renderWrapperWith({
+    it('triggers trackUserImpression', () => {
+      renderWrapper({
         text: 'some-value',
         language: 'javascript',
-      });
-
-      expect(trackUserImpression).toHaveBeenCalledWith({
-        page_name: 'forum',
-        context: 'https://discuss.codecademy.com/some-interesting/post',
-        target: 'codebyte',
-      });
-    });
-
-    it('triggers trackUserImpression for compose mode', () => {
-      renderWrapperWith({
-        text: 'some-value',
-        language: 'javascript',
-        mode: 'compose',
+        trackingData: {
+          page_name: 'forum_compose',
+          context: 'https://discuss.codecademy.com/some-interesting/post',
+        },
+        renderMode: 'compose',
       });
 
       expect(trackUserImpression).toHaveBeenCalledWith({

--- a/packages/codebytes/src/__tests__/codebyte-test.tsx
+++ b/packages/codebytes/src/__tests__/codebyte-test.tsx
@@ -132,6 +132,7 @@ describe('CodeBytes', () => {
       const { view } = renderWrapper({
         text: testString,
         language: 'javascript',
+        trackFirstEdit: true,
       });
 
       const editor = view.getByTestId(mockEditorTestId);
@@ -148,7 +149,6 @@ describe('CodeBytes', () => {
           page_name: 'forum_compose',
           context: 'https://discuss.codecademy.com/some-interesting/post',
         },
-        renderMode: 'compose',
       });
 
       expect(trackUserImpression).toHaveBeenCalledWith({

--- a/packages/codebytes/src/__tests__/helpers-test.tsx
+++ b/packages/codebytes/src/__tests__/helpers-test.tsx
@@ -1,6 +1,4 @@
-import { encode } from 'js-base64';
-
-import { CodebytesParams, getOptions, trackClick } from '../helpers';
+import { trackClick } from '../helpers';
 import { trackUserClick } from '../libs/eventTracking';
 
 jest.mock('../libs/eventTracking');
@@ -8,46 +6,6 @@ jest.mock('../libs/eventTracking');
 const initialUrl = window.location.href;
 const resetCodebytesParams = () =>
   window.history.replaceState(null, '', initialUrl);
-type SetCodebytesParamsProps = Record<CodebytesParams, string>;
-const setCodebytesParams = (params: SetCodebytesParamsProps) => {
-  if (params.text) {
-    params.text = encode(params.text);
-  }
-
-  const url = new URL(window.location.href);
-  Object.entries(params).forEach(([key, value]) => {
-    url.searchParams.set(key, value);
-  });
-
-  window.history.replaceState({}, '', url.toString());
-};
-
-describe('getOptions', () => {
-  afterEach(() => {
-    resetCodebytesParams();
-  });
-
-  it('parses props out of the window locations', () => {
-    const text = `
-    const msg = 'Sup?';
-    console.log(msg);
-    `.trim();
-    setCodebytesParams({
-      lang: 'javascript',
-      text,
-      'copy-mode': '',
-      'client-name': 'forum',
-      page: 'https://discuss.codecademy.com/some-interesting/post',
-      mode: 'compose',
-    });
-
-    expect(getOptions()).toEqual({
-      clientName: 'forum',
-      parentPage: 'https://discuss.codecademy.com/some-interesting/post',
-      renderMode: 'compose',
-    });
-  });
-});
 
 describe('trackClick', () => {
   afterEach(() => {
@@ -55,20 +13,15 @@ describe('trackClick', () => {
     (trackUserClick as any).mockReset();
   });
 
-  it('proxies to trackUserClick setting the page_name, context, and target', () => {
+  it('tracks user click when tracking data is provided', () => {
     const target = 'foobar';
-    setCodebytesParams({
-      lang: 'javascript',
-      text: `
-      const msg = 'Sup?';
-      console.log(msg);
-      `.trim(),
-      'copy-mode': '',
-      'client-name': 'forum',
-      page: 'https://discuss.codecademy.com/some-interesting/post',
-      mode: '',
-    });
-    trackClick(target);
+    const trackingData = {
+      page_name: 'forum',
+      context: 'https://discuss.codecademy.com/some-interesting/post',
+      target,
+    };
+
+    trackClick(target, trackingData);
     expect(trackUserClick).toHaveBeenCalledWith({
       page_name: 'forum',
       context: 'https://discuss.codecademy.com/some-interesting/post',
@@ -76,45 +29,10 @@ describe('trackClick', () => {
     });
   });
 
-  it('defaults the client name to "Unknown"', () => {
+  it('tracks user click when tracking data is not provided', () => {
     const target = 'foobar';
-    setCodebytesParams({
-      lang: 'javascript',
-      text: `
-      const msg = 'Sup?';
-      console.log(msg);
-      `.trim(),
-      'copy-mode': '',
-      'client-name': '',
-      page: 'https://discuss.codecademy.com/some-interesting/post',
-      mode: '',
-    });
     trackClick(target);
     expect(trackUserClick).toHaveBeenCalledWith({
-      page_name: 'Unknown',
-      context: 'https://discuss.codecademy.com/some-interesting/post',
-      target,
-    });
-  });
-
-  it('embeds the render mode into the page_name', () => {
-    const mode = 'compose';
-    const target = 'foobar';
-    setCodebytesParams({
-      lang: 'javascript',
-      text: `
-      const msg = 'Sup?';
-      console.log(msg);
-      `.trim(),
-      'copy-mode': '',
-      'client-name': 'forum',
-      page: 'https://discuss.codecademy.com/some-interesting/post',
-      mode,
-    });
-    trackClick(target);
-    expect(trackUserClick).toHaveBeenCalledWith({
-      page_name: `forum_${mode}`,
-      context: 'https://discuss.codecademy.com/some-interesting/post',
       target,
     });
   });

--- a/packages/codebytes/src/codeByteEditor.tsx
+++ b/packages/codebytes/src/codeByteEditor.tsx
@@ -4,6 +4,7 @@ import { Background, states, system } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
 import React, { useEffect, useState } from 'react';
+import { renderIntoDocument } from 'react-dom/test-utils';
 
 import { helloWorld, LanguageOption } from './consts';
 import { Editor } from './editor';
@@ -44,6 +45,7 @@ export const CodeByteEditor: React.FC<CodeByteEditorProps> = ({
   onLanguageChange,
   onCopy,
   trackingData,
+  renderMode,
 }) => {
   const getInitialText = () => {
     if (initialText !== undefined) return initialText;
@@ -57,17 +59,12 @@ export const CodeByteEditor: React.FC<CodeByteEditorProps> = ({
   const [hasBeenEdited, setHasBeenEdited] = useState(false);
 
   useEffect(() => {
-    const options = getOptions();
-    const page_name = options.renderMode
-      ? `${options.clientName}_${options.renderMode}`
-      : options.clientName;
-
     trackUserImpression({
-      page_name,
-      context: options.parentPage,
+      page_name: trackingData?.page_name ?? 'Unknown',
+      context: trackingData?.context ?? document.referrer,
       target: 'codebyte',
     });
-  }, []);
+  }, [trackingData]);
 
   return (
     <EditorContainer bg="black" as="main" isIFrame={isIFrame}>
@@ -90,7 +87,6 @@ export const CodeByteEditor: React.FC<CodeByteEditorProps> = ({
           onChange={(newText: string) => {
             setText(newText);
             onEdit?.(newText, language);
-            const { renderMode } = getOptions();
             if (!renderMode && hasBeenEdited === false) {
               setHasBeenEdited(true);
               trackClick('edit', trackingData);

--- a/packages/codebytes/src/codeByteEditor.tsx
+++ b/packages/codebytes/src/codeByteEditor.tsx
@@ -33,7 +33,7 @@ export const CodeByteEditor: React.FC<CodeByteEditorProps> = ({
   onLanguageChange,
   onCopy,
   trackingData,
-  renderMode,
+  trackFirstEdit = false,
   ...rest
 }) => {
   const getInitialText = () => {
@@ -76,7 +76,7 @@ export const CodeByteEditor: React.FC<CodeByteEditorProps> = ({
           onChange={(newText: string) => {
             setText(newText);
             onEdit?.(newText, language);
-            if (!renderMode && hasBeenEdited === false) {
+            if (trackFirstEdit && hasBeenEdited === false) {
               setHasBeenEdited(true);
               trackClick('edit', trackingData);
             }

--- a/packages/codebytes/src/codeByteEditor.tsx
+++ b/packages/codebytes/src/codeByteEditor.tsx
@@ -4,11 +4,10 @@ import { Background, system } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
 import React, { useEffect, useState } from 'react';
-import { renderIntoDocument } from 'react-dom/test-utils';
 
 import { helloWorld, LanguageOption } from './consts';
 import { Editor } from './editor';
-import { getOptions, trackClick } from './helpers';
+import { trackClick } from './helpers';
 import { LanguageSelection } from './languageSelection';
 import { trackUserImpression } from './libs/eventTracking';
 import { CodeByteEditorProps } from './types';

--- a/packages/codebytes/src/helpers/index.ts
+++ b/packages/codebytes/src/helpers/index.ts
@@ -2,33 +2,6 @@ import { UserClickData } from '@codecademy/tracking';
 
 import { trackUserClick } from '../libs/eventTracking';
 
-export type CodebyteOptions = {
-  clientName: string;
-  parentPage: string;
-  renderMode: string;
-};
-
-export enum CodebytesParams {
-  Language = 'lang',
-  Text = 'text',
-  CopyMode = 'copy-mode',
-  ClientName = 'client-name',
-  Page = 'page',
-  Mode = 'mode',
-}
-
-export const getOptions = (): CodebyteOptions => {
-  const currentUri = new URL(window.location.href);
-
-  return {
-    clientName:
-      currentUri.searchParams.get(CodebytesParams.ClientName) || 'Unknown',
-    parentPage:
-      currentUri.searchParams.get(CodebytesParams.Page) || document.referrer,
-    renderMode: currentUri.searchParams.get(CodebytesParams.Mode) || '',
-  };
-};
-
 export const trackClick = (
   target: string,
   trackingData?: Omit<UserClickData, 'target'>
@@ -39,14 +12,8 @@ export const trackClick = (
       target,
     });
   }
-  const options = getOptions();
-  const page_name = options.renderMode
-    ? `${options.clientName}_${options.renderMode}`
-    : options.clientName;
 
   trackUserClick({
-    page_name,
-    context: options.parentPage,
     target,
   });
 };

--- a/packages/codebytes/src/helpers/index.ts
+++ b/packages/codebytes/src/helpers/index.ts
@@ -5,15 +5,4 @@ import { trackUserClick } from '../libs/eventTracking';
 export const trackClick = (
   target: string,
   trackingData?: Omit<UserClickData, 'target'>
-) => {
-  if (trackingData) {
-    return trackUserClick({
-      ...trackingData,
-      target,
-    });
-  }
-
-  trackUserClick({
-    target,
-  });
-};
+) => trackUserClick({ ...trackingData, target });

--- a/packages/codebytes/src/index.ts
+++ b/packages/codebytes/src/index.ts
@@ -1,2 +1,3 @@
 export * from './codeByteEditor';
 export * from './consts';
+export * from './types';

--- a/packages/codebytes/src/types.ts
+++ b/packages/codebytes/src/types.ts
@@ -16,5 +16,5 @@ export interface CodeByteEditorProps
   onEdit?: CodebytesChangeHandler;
   onLanguageChange?: CodebytesChangeHandler;
   trackingData?: Omit<UserClickData, 'target'>;
-  renderMode?: string;
+  trackFirstEdit?: boolean;
 }

--- a/packages/codebytes/src/types.ts
+++ b/packages/codebytes/src/types.ts
@@ -15,4 +15,5 @@ export interface CodeByteEditorProps {
   onEdit?: CodebytesChangeHandler;
   onLanguageChange?: CodebytesChangeHandler;
   trackingData?: Omit<UserClickData, 'target'>;
+  renderMode?: string;
 }


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

This pull request largely removes `getOptions` from the codebytes package, since it's quite specific to the way we render codebytes on forums, passing in data for tracking from params. 

It also updates trackUserImpression on mount, trackUserImpression-related tests, and adds a simple test to use trackingData if trackingData is passed in! 

Much of the getOptions logic will now move to portal-app. 

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
