### PR TITLE
fix: fixes a monaco editor display bug for lines below 14-17

### DIFF
--- a/packages/codebytes/src/codeByteEditor.tsx
+++ b/packages/codebytes/src/codeByteEditor.tsx
@@ -56,7 +56,7 @@ export const CodeByteEditor: React.FC<CodeByteEditorProps> = ({
   }, [trackingData]);
 
   return (
-    <EditorContainer bg="black" maxWidth="43rem" {...rest}>
+    <EditorContainer bg="black" maxWidth="43rem" {...rest} overflow="hidden">
       <Box borderBottom={1} borderColor="gray-900" py={4} pl={8}>
         <IconButton
           icon={FaviconIcon}

--- a/packages/codebytes/src/drawers.tsx
+++ b/packages/codebytes/src/drawers.tsx
@@ -17,8 +17,6 @@ const RightDrawerIcon = LeftDrawerIcon.withComponent(ArrowChevronRightIcon);
 
 const Drawer = styled(FlexBox)<{ open?: boolean; hideOnClose?: boolean }>`
   position: relative;
-  // A hidden overflowing element causes accessibility errors
-  // The background of the overflowing element causes triggers color contrast errors
   ${({ open, hideOnClose }) => `
     flex-basis: ${open ? '100%' : '0%'};
     visibility: ${!open && hideOnClose ? 'hidden' : 'visible'};

--- a/packages/codebytes/src/drawers.tsx
+++ b/packages/codebytes/src/drawers.tsx
@@ -19,9 +19,6 @@ const Drawer = styled(FlexBox)<{ open?: boolean; hideOnClose?: boolean }>`
   position: relative;
   // A hidden overflowing element causes accessibility errors
   // The background of the overflowing element causes triggers color contrast errors
-  & .lines-content {
-    height: 100% !important;
-  }
   ${({ open, hideOnClose }) => `
     flex-basis: ${open ? '100%' : '0%'};
     visibility: ${!open && hideOnClose ? 'hidden' : 'visible'};


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
There was some css added to monaco-editor that allowed cypress tests to pass without axe issues.  But this caused a bug with lines below the set height to not be shown in the editor.   Here, I've removed that css, and I've made a PR to monolith that skips that axe check until we are able to add it back in DISC-529.  Root cause: https://github.com/dequelabs/axe-core/issues/2806

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to JIRA ticket: DISC-521
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
