### PR TITLE
feat(tracking): add experiment category to tracking types

### DIFF
--- a/packages/tracking/src/events/types.ts
+++ b/packages/tracking/src/events/types.ts
@@ -42,6 +42,10 @@ export type EventDataTypes = {
   exercise: {
     force_pass: BaseEventAnyData;
   };
+  // events for tracking experiments in optimizely
+  experiment: {
+    contentful_experiment_assignment_event: BaseEventAnyData;
+  };
   payments: {
     cancel_survey: BaseEventAnyData;
   };


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Adds an `experiment` category and `contentful_experiment_assignment_event` to EventDataTypes. This will help us to send Segment tracking events for Optimizely experiments from portal-app to the monolith.

This PR is related to:
Add new Segment Tracker event to monolith: https://github.com/codecademy-engineering/Codecademy/pull/30278
Adding tracking event trigger on an decision event: https://github.com/codecademy-engineering/portal-app/pull/1787

We're trying to get a tracking event fired like this:
![Screen Shot 2022-04-06 at 12 06 41 PM](https://user-images.githubusercontent.com/29311886/162050123-5fc0fbe1-8301-4a8f-880e-871f1e47d9b1.png)

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to JIRA ticket: REACH-1765
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
