### PR TITLE
feat(tracking): add UserSharedData to user impressions

### DIFF
--- a/packages/tracking/src/events/types.ts
+++ b/packages/tracking/src/events/types.ts
@@ -224,15 +224,13 @@ export type UserVisitData = UserSharedData & {
   is_ugc?: boolean;
 };
 
-export type UserImpressionData = {
+export type UserImpressionData = Pick<
+  UserSharedData,
+  'context' | 'source_codebase'
+> & {
   page_name: string;
-  slug?: string;
   target: string;
-  context?: string;
-  path_slug?: string;
-  track_slug?: string;
-  module_slug?: string;
-  source_codebase?: string;
+  slug?: string;
   is_ugc?: boolean;
 };
 


### PR DESCRIPTION
### Overview

While working on implementing some new tracking, Kevin R and I realized that user impression events don't take the field `content_ids`, even though it exists as a field data science can query and the monolith will send it along: see [here](https://github.com/codecademy-engineering/Codecademy/blob/4d6e02aa7e4742fce1124206d7cdb1fdc228a94b/lib/segment_tracker/user_impression_event.rb). I believe that user impression events should share the same base UserSharedData fields.

Also, the other fields like `module_slug`, `track_slug`, and `path_slug` and not sent to Segment, so I have removed them.

See here: https://docs.google.com/spreadsheets/d/1qx-TDOIL-t_XQp7XKA-wUmEWEARhPyuFZ4Vn5fKV6qs/edit#gid=1929949552 for a document data science sent over with the available fields for them to query.

<!--- CHANGELOG-DESCRIPTION -->
Add UserSharedData to user impressions events
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
