### PR TITLE
feat(tracking): Adding misc field for click and visit events

### DIFF
--- a/packages/tracking/src/events/track.ts
+++ b/packages/tracking/src/events/track.ts
@@ -99,18 +99,3 @@ export const createTracker = ({ apiBaseUrl, verbose }: TrackerOptions) => {
     },
   };
 };
-
-/**
- * The `misc` field for click and visit tracking takes the form of an arbitrary
- * number of key=value pairs delimited by commas.
- *
- * This helper function will take a flat javascript object and spit out the string in the correct form.
- */
-export const exportMiscTrackingData = <
-  T extends Record<string, string | number | boolean>
->(
-  data: T
-): string =>
-  Object.entries(data)
-    .map(([key, value]) => `${key}=${value}`)
-    .join(',');

--- a/packages/tracking/src/events/types.ts
+++ b/packages/tracking/src/events/types.ts
@@ -136,7 +136,7 @@ export type UserSharedData = BaseEventData & {
   content_ids?: TrackingContentIds;
   /** the repo that this event is being fired from */
   source_codebase?: string;
-  /** Should be used for arbitrary comma delimited key=value pairs. (use `exportMiscTrackingData` to format the string) */
+  /** Should be used for arbitrary JSON that has been passed through JSON.stringify. */
   misc?: string;
 };
 


### PR DESCRIPTION
### Overview

We want more flexibility with out data types, and so we're adding a special `misc` field for the shared user data that we can store arbitrary JSON data that has been run through `JSON.stringify`. 

I worked with @vlagregor to verify this format works and is parsable from snowflake/looker.

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to JIRA ticket: https://codecademy.atlassian.net/browse/EGG-2458
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
